### PR TITLE
fix(multi_object_tracker): merge footprints using convex hull

### DIFF
--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/object_model/shapes_transform.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/object_model/shapes_transform.hpp
@@ -39,9 +39,9 @@ geometry_msgs::msg::Polygon transformFootprint(
   const geometry_msgs::msg::Polygon & footprint, const geometry_msgs::msg::Pose & src_pose,
   const geometry_msgs::msg::Pose & dst_pose);
 
-// Compute the polygon union of two footprints already expressed in the same local frame.
-// Returns the exterior ring of the union polygon, or the convex hull of all vertices when
-// the inputs are disjoint.
+// Merge two footprints already expressed in the same local frame by taking the convex hull of
+// all their vertices. Returns the exterior ring of the hull, which covers both footprints whether
+// they overlap or are disjoint.
 geometry_msgs::msg::Polygon unionFootprints(
   const geometry_msgs::msg::Polygon & a, const geometry_msgs::msg::Polygon & b);
 

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/shape_model/pedestrian_shape_model.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/shape_model/pedestrian_shape_model.hpp
@@ -19,6 +19,8 @@
 #include "autoware/multi_object_tracker/tracker/shape_model/shape_model_base.hpp"
 #include "autoware/multi_object_tracker/types.hpp"
 
+#include <rclcpp/rclcpp.hpp>
+
 #include <autoware_perception_msgs/msg/shape.hpp>
 
 namespace autoware::multi_object_tracker
@@ -29,11 +31,18 @@ namespace autoware::multi_object_tracker
 // Internally always stores BOUNDING_BOX {length, width, height} in tracker heading frame.
 // Output type is always BOUNDING_BOX with explicit length and width.
 //
+// The measurement footprint keeps its measured orientation: it is stored anchored at the object
+// position but aligned to the global axes (never rotated to the tracker heading), which also keeps
+// the float32 footprint coordinates small. At export it is re-expressed in the output object's
+// frame (message position and orientation), so it is shifted to the exported pose while its global
+// orientation is preserved.
+//
 // Data flow:
 //   init()    — force all input types to internal BOUNDING_BOX; apply model-derived sanity bounds
 //   update()  — 3-branch update by input type (BBOX / CYLINDER / POLYGON);
-//               gains differ by type and trust_extension
-//   exportTo() — assemble output as a BOUNDING_BOX filling length and width
+//               gains differ by type and trust_extension; a non-empty footprint is stored
+//   exportTo() — assemble output as a BOUNDING_BOX filling length and width; emit the stored
+//                footprint (re-expressed in the output frame) while it is still fresh
 class PedestrianShapeModel : public ShapeModelBase
 {
 public:
@@ -43,14 +52,27 @@ public:
   void init(const types::DynamicObject & object);
 
   // Update shape from new measurement.
-  bool update(const types::DynamicObject & object, bool trust_extension, double tracker_yaw);
+  // trust_extension: whether the channel provides reliable size measurements.
+  // tracker_yaw: current tracker heading; required for POLYGON branch.
+  // time: measurement time; stamps the stored footprint so it can expire at export.
+  // A non-empty measurement footprint is stored in the global frame (measured orientation kept).
+  // Returns false if update was rejected (implausible dimensions).
+  bool update(
+    const types::DynamicObject & object, bool trust_extension, double tracker_yaw,
+    const rclcpp::Time & time);
 
   // Write shape into output object.
+  // Output type is always BOUNDING_BOX {length, width, height}. A stored footprint is re-expressed
+  // in the output object's local frame and emitted only while it is still fresh (see
+  // FOOTPRINT_TIMEOUT_S); otherwise it is cleared.
   void exportTo(types::DynamicObject & output) const;
 
 private:
-  // length_, width_, height_, area_ live in ShapeModelBase.
+  // length_, width_, height_, footprint_, footprint_valid_, area_ live in ShapeModelBase.
   object_model::ObjectModel object_model_;
+  rclcpp::Time last_footprint_update_time_;
+
+  static constexpr double FOOTPRINT_TIMEOUT_S = 1.0;  // [s] footprint expiry
 
   void clampToLimits();
 };

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/shape_model/pedestrian_shape_model.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/shape_model/pedestrian_shape_model.hpp
@@ -27,15 +27,10 @@ namespace autoware::multi_object_tracker
 {
 
 // Manages shape extension (length, width, height) for PedestrianTracker.
-// All input shape types (BOUNDING_BOX, CYLINDER, POLYGON) are accepted.
-// Internally always stores BOUNDING_BOX {length, width, height} in tracker heading frame.
-// Output type is always BOUNDING_BOX with explicit length and width.
+// Output type is always BOUNDING_BOX.
 //
 // The measurement footprint keeps its measured orientation: it is stored anchored at the object
-// position but aligned to the global axes (never rotated to the tracker heading), which also keeps
-// the float32 footprint coordinates small. At export it is re-expressed in the output object's
-// frame (message position and orientation), so it is shifted to the exported pose while its global
-// orientation is preserved.
+// position but aligned to the global axes (never rotated to the tracker heading).
 //
 // Data flow:
 //   init()    — force all input types to internal BOUNDING_BOX; apply model-derived sanity bounds
@@ -52,19 +47,11 @@ public:
   void init(const types::DynamicObject & object);
 
   // Update shape from new measurement.
-  // trust_extension: whether the channel provides reliable size measurements.
-  // tracker_yaw: current tracker heading; required for POLYGON branch.
-  // time: measurement time; stamps the stored footprint so it can expire at export.
-  // A non-empty measurement footprint is stored in the global frame (measured orientation kept).
-  // Returns false if update was rejected (implausible dimensions).
   bool update(
     const types::DynamicObject & object, bool trust_extension, double tracker_yaw,
     const rclcpp::Time & time);
 
   // Write shape into output object.
-  // Output type is always BOUNDING_BOX {length, width, height}. A stored footprint is re-expressed
-  // in the output object's local frame and emitted only while it is still fresh (see
-  // FOOTPRINT_TIMEOUT_S); otherwise it is cleared.
   void exportTo(types::DynamicObject & output) const;
 
 private:

--- a/perception/autoware_multi_object_tracker/lib/object_model/shapes_transform.cpp
+++ b/perception/autoware_multi_object_tracker/lib/object_model/shapes_transform.cpp
@@ -15,7 +15,6 @@
 #include "autoware/multi_object_tracker/object_model/shapes_transform.hpp"
 
 #include <autoware_utils_geometry/boost_geometry.hpp>
-#include <autoware_utils_geometry/boost_polygon_utils.hpp>
 #include <tf2/utils.hpp>
 
 #include <autoware_perception_msgs/msg/shape.hpp>
@@ -26,7 +25,6 @@
 #include <cmath>
 #include <limits>
 #include <optional>
-#include <vector>
 
 namespace
 {
@@ -252,23 +250,18 @@ geometry_msgs::msg::Polygon unionFootprints(
   const auto poly_a = to_boost(a);
   const auto poly_b = to_boost(b);
 
-  std::vector<autoware_utils_geometry::Polygon2d> union_result;
-  boost::geometry::union_(poly_a, poly_b, union_result);
-  if (union_result.empty()) return a;
-
-  // Single connected result — extract directly.
-  if (union_result.size() == 1u) {
-    return to_msg(union_result[0]);
-  }
-
-  // Disjoint components: compute convex hull of all component vertices so that both
-  // footprints are covered without discarding the smaller one.
+  // Merge by taking the convex hull of both footprints' vertices. The convex hull of the union of
+  // two polygons equals the convex hull of all their vertices combined, so this covers both
+  // footprints (whether overlapping or disjoint) with a single convex polygon.
   autoware_utils_geometry::Polygon2d all_points;
-  for (const auto & comp : union_result) {
-    for (const auto & pt : comp.outer()) {
-      all_points.outer().push_back(pt);
-    }
+  for (const auto & pt : poly_a.outer()) {
+    all_points.outer().push_back(pt);
   }
+  for (const auto & pt : poly_b.outer()) {
+    all_points.outer().push_back(pt);
+  }
+  if (all_points.outer().empty()) return a;
+
   autoware_utils_geometry::Polygon2d hull;
   boost::geometry::convex_hull(all_points, hull);
   return to_msg(hull);

--- a/perception/autoware_multi_object_tracker/lib/object_model/shapes_transform.cpp
+++ b/perception/autoware_multi_object_tracker/lib/object_model/shapes_transform.cpp
@@ -106,8 +106,8 @@ bool convertConvexHullToBoundingBox(
   };
 
   // Ego-facing pass: outward normal of CCW edge (ex,ey) is (ey,-ex).
-  // Edge faces ego when (ey,-ex)·(ego_local_x,ego_local_y) > 0, i.e. ey*ego_local_x -
-  // ex*ego_local_y > 0.
+  // Edge faces ego when (ey,-ex)·(ego_local_x,ego_local_y) > 0,
+  // i.e. ey*ego_local_x - ex*ego_local_y > 0.
   if (use_ego) {
     for (size_t i = 0; i < n; ++i) {
       const auto & p0 = points[i];
@@ -250,9 +250,7 @@ geometry_msgs::msg::Polygon unionFootprints(
   const auto poly_a = to_boost(a);
   const auto poly_b = to_boost(b);
 
-  // Merge by taking the convex hull of both footprints' vertices. The convex hull of the union of
-  // two polygons equals the convex hull of all their vertices combined, so this covers both
-  // footprints (whether overlapping or disjoint) with a single convex polygon.
+  // Merge by taking the convex hull of both footprints' vertices.
   autoware_utils_geometry::Polygon2d all_points;
   for (const auto & pt : poly_a.outer()) {
     all_points.outer().push_back(pt);

--- a/perception/autoware_multi_object_tracker/lib/object_model/shapes_transform.cpp
+++ b/perception/autoware_multi_object_tracker/lib/object_model/shapes_transform.cpp
@@ -258,7 +258,6 @@ geometry_msgs::msg::Polygon unionFootprints(
   for (const auto & pt : poly_b.outer()) {
     all_points.outer().push_back(pt);
   }
-  if (all_points.outer().empty()) return a;
 
   autoware_utils_geometry::Polygon2d hull;
   boost::geometry::convex_hull(all_points, hull);

--- a/perception/autoware_multi_object_tracker/lib/object_model/shapes_transform.cpp
+++ b/perception/autoware_multi_object_tracker/lib/object_model/shapes_transform.cpp
@@ -227,7 +227,6 @@ geometry_msgs::msg::Polygon unionFootprints(
     for (const auto & p : fp.points) {
       poly.outer().emplace_back(p.x, p.y);
     }
-    boost::geometry::correct(poly);
     return poly;
   };
 
@@ -252,6 +251,7 @@ geometry_msgs::msg::Polygon unionFootprints(
 
   // Merge by taking the convex hull of both footprints' vertices.
   autoware_utils_geometry::Polygon2d all_points;
+  all_points.outer().reserve(poly_a.outer().size() + poly_b.outer().size());
   for (const auto & pt : poly_a.outer()) {
     all_points.outer().push_back(pt);
   }

--- a/perception/autoware_multi_object_tracker/lib/tracker/shape_model/pedestrian_shape_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/shape_model/pedestrian_shape_model.cpp
@@ -16,6 +16,8 @@
 
 #include "autoware/multi_object_tracker/object_model/shapes_transform.hpp"
 
+#include <geometry_msgs/msg/pose.hpp>
+
 #include <algorithm>
 #include <cmath>
 
@@ -24,8 +26,23 @@ namespace autoware::multi_object_tracker
 
 using Shape = autoware_perception_msgs::msg::Shape;
 
+namespace
+{
+// A frame co-located with `position` but aligned to the global axes (zero yaw). Used with
+// transformFootprint() to keep the footprint's measured (global) orientation while anchoring its
+// coordinates at the tracker/object position — this avoids the float32 precision loss that storing
+// large absolute map coordinates in the footprint points would incur.
+geometry_msgs::msg::Pose globalFrameAt(const geometry_msgs::msg::Point & position)
+{
+  geometry_msgs::msg::Pose pose;
+  pose.position = position;
+  pose.orientation.w = 1.0;
+  return pose;
+}
+}  // namespace
+
 PedestrianShapeModel::PedestrianShapeModel(const object_model::ObjectModel & object_model)
-: object_model_(object_model)
+: object_model_(object_model), last_footprint_update_time_(rclcpp::Time(0, 0, RCL_ROS_TIME))
 {
 }
 
@@ -63,7 +80,8 @@ void PedestrianShapeModel::init(const types::DynamicObject & object)
 }
 
 bool PedestrianShapeModel::update(
-  const types::DynamicObject & object, bool trust_extension, double tracker_yaw)
+  const types::DynamicObject & object, bool trust_extension, double tracker_yaw,
+  const rclcpp::Time & time)
 {
   // Model-derived sanity bounds (permissive: 0.5× min … 1.5× max)
   const double len_max = object_model_.size_limit.length_max * 1.5;
@@ -118,6 +136,17 @@ bool PedestrianShapeModel::update(
     }
   }
 
+  // Store the footprint anchored at the object position but aligned to the global axes: its
+  // measured orientation is preserved (not rotated to the tracker heading), and coordinates stay
+  // small so the float32 footprint points keep their precision. Only measurements that carry a
+  // footprint update it.
+  if (!object.shape.footprint.points.empty()) {
+    footprint_ = shapes::transformFootprint(
+      object.shape.footprint, object.pose, globalFrameAt(object.pose.position));
+    footprint_valid_ = true;
+    last_footprint_update_time_ = time;
+  }
+
   clampToLimits();
   area_ = length_ * width_;
   return true;
@@ -130,7 +159,20 @@ void PedestrianShapeModel::exportTo(types::DynamicObject & output) const
   output.shape.dimensions.x = length_;
   output.shape.dimensions.y = width_;
   output.shape.dimensions.z = height_;
-  output.shape.footprint = footprint_;
+
+  // Emit the stored footprint only while it is still fresh; otherwise drop the stale geometry.
+  // The footprint is kept in a global-orientation frame, so re-express it in the output object's
+  // frame (message position and orientation): it is shifted to the exported pose while its measured
+  // (global) orientation is preserved, matching the DynamicObject footprint convention.
+  const bool footprint_fresh =
+    footprint_valid_ && (output.time - last_footprint_update_time_).seconds() < FOOTPRINT_TIMEOUT_S;
+  if (footprint_fresh) {
+    output.shape.footprint =
+      shapes::transformFootprint(footprint_, globalFrameAt(output.pose.position), output.pose);
+  } else {
+    output.shape.footprint.points.clear();
+  }
+
   output.area = types::getArea(output.shape);
 }
 

--- a/perception/autoware_multi_object_tracker/lib/tracker/shape_model/pedestrian_shape_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/shape_model/pedestrian_shape_model.cpp
@@ -156,8 +156,10 @@ void PedestrianShapeModel::exportTo(types::DynamicObject & output) const
 
   // The footprint is kept in a global-orientation frame, so re-express it in the output object's
   // frame (message position and orientation)
+  const rclcpp::Time output_time(
+    output.time.nanoseconds(), last_footprint_update_time_.get_clock_type());
   const bool footprint_fresh =
-    footprint_valid_ && (output.time - last_footprint_update_time_).seconds() < FOOTPRINT_TIMEOUT_S;
+    footprint_valid_ && (output_time - last_footprint_update_time_).seconds() < FOOTPRINT_TIMEOUT_S;
   if (footprint_fresh) {
     output.shape.footprint =
       shapes::transformFootprint(footprint_, globalFrameAt(output.pose.position), output.pose);

--- a/perception/autoware_multi_object_tracker/lib/tracker/shape_model/pedestrian_shape_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/shape_model/pedestrian_shape_model.cpp
@@ -130,7 +130,7 @@ void PedestrianShapeModel::exportTo(types::DynamicObject & output) const
   output.shape.dimensions.x = length_;
   output.shape.dimensions.y = width_;
   output.shape.dimensions.z = height_;
-  output.shape.footprint.points.clear();
+  output.shape.footprint = footprint_;
   output.area = types::getArea(output.shape);
 }
 

--- a/perception/autoware_multi_object_tracker/lib/tracker/shape_model/pedestrian_shape_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/shape_model/pedestrian_shape_model.cpp
@@ -28,10 +28,7 @@ using Shape = autoware_perception_msgs::msg::Shape;
 
 namespace
 {
-// A frame co-located with `position` but aligned to the global axes (zero yaw). Used with
-// transformFootprint() to keep the footprint's measured (global) orientation while anchoring its
-// coordinates at the tracker/object position — this avoids the float32 precision loss that storing
-// large absolute map coordinates in the footprint points would incur.
+// A frame co-located with `position` but aligned to the global axes (zero yaw).
 geometry_msgs::msg::Pose globalFrameAt(const geometry_msgs::msg::Point & position)
 {
   geometry_msgs::msg::Pose pose;
@@ -136,10 +133,7 @@ bool PedestrianShapeModel::update(
     }
   }
 
-  // Store the footprint anchored at the object position but aligned to the global axes: its
-  // measured orientation is preserved (not rotated to the tracker heading), and coordinates stay
-  // small so the float32 footprint points keep their precision. Only measurements that carry a
-  // footprint update it.
+  // Store the footprint anchored at the object position but aligned to the global axes
   if (!object.shape.footprint.points.empty()) {
     footprint_ = shapes::transformFootprint(
       object.shape.footprint, object.pose, globalFrameAt(object.pose.position));
@@ -160,10 +154,8 @@ void PedestrianShapeModel::exportTo(types::DynamicObject & output) const
   output.shape.dimensions.y = width_;
   output.shape.dimensions.z = height_;
 
-  // Emit the stored footprint only while it is still fresh; otherwise drop the stale geometry.
   // The footprint is kept in a global-orientation frame, so re-express it in the output object's
-  // frame (message position and orientation): it is shifted to the exported pose while its measured
-  // (global) orientation is preserved, matching the DynamicObject footprint convention.
+  // frame (message position and orientation)
   const bool footprint_fresh =
     footprint_valid_ && (output.time - last_footprint_update_time_).seconds() < FOOTPRINT_TIMEOUT_S;
   if (footprint_fresh) {

--- a/perception/autoware_multi_object_tracker/lib/tracker/shape_model/pedestrian_shape_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/shape_model/pedestrian_shape_model.cpp
@@ -156,10 +156,9 @@ void PedestrianShapeModel::exportTo(types::DynamicObject & output) const
 
   // The footprint is kept in a global-orientation frame, so re-express it in the output object's
   // frame (message position and orientation)
-  const rclcpp::Time output_time(
-    output.time.nanoseconds(), last_footprint_update_time_.get_clock_type());
+  const double footprint_age = (output.time - last_footprint_update_time_).seconds();
   const bool footprint_fresh =
-    footprint_valid_ && (output_time - last_footprint_update_time_).seconds() < FOOTPRINT_TIMEOUT_S;
+    footprint_valid_ && footprint_age >= 0.0 && footprint_age < FOOTPRINT_TIMEOUT_S;
   if (footprint_fresh) {
     output.shape.footprint =
       shapes::transformFootprint(footprint_, globalFrameAt(output.pose.position), output.pose);

--- a/perception/autoware_multi_object_tracker/lib/tracker/shape_model/vehicle_shape_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/shape_model/vehicle_shape_model.cpp
@@ -127,9 +127,9 @@ void VehicleShapeModel::mergeFrom(
   const auto transformed = shapes::transformFootprint(footprint, src_pose, winner_pose);
   // Only union with the existing footprint if it is still within the freshness window; otherwise
   // discard the stale stored geometry and start fresh with the incoming footprint.
+  const double existing_age = (latest_measurement_time - last_footprint_update_time_).seconds();
   const bool existing_fresh =
-    footprint_valid_ &&
-    (latest_measurement_time - last_footprint_update_time_).seconds() < FOOTPRINT_TIMEOUT_S;
+    footprint_valid_ && existing_age >= 0.0 && existing_age < FOOTPRINT_TIMEOUT_S;
   footprint_ = existing_fresh ? shapes::unionFootprints(footprint_, transformed) : transformed;
   footprint_valid_ = true;
   last_footprint_update_time_ = latest_measurement_time;
@@ -142,8 +142,9 @@ void VehicleShapeModel::exportTo(types::DynamicObject & output, double vehicle_l
   output.shape.dimensions.y = width_;
   output.shape.dimensions.z = height_;
 
+  const double footprint_age = (output.time - last_footprint_update_time_).seconds();
   const bool footprint_fresh =
-    footprint_valid_ && (output.time - last_footprint_update_time_).seconds() < FOOTPRINT_TIMEOUT_S;
+    footprint_valid_ && footprint_age >= 0.0 && footprint_age < FOOTPRINT_TIMEOUT_S;
   if (footprint_fresh) {
     output.shape.footprint = footprint_;
   } else {

--- a/perception/autoware_multi_object_tracker/lib/tracker/trackers/pedestrian_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/trackers/pedestrian_tracker.cpp
@@ -130,7 +130,7 @@ bool PedestrianTracker::measure(
 
   updateKinematics(object);
 
-  shape_model_.update(object, channel_info.trust_extension, motion_model_.getYawState());
+  shape_model_.update(object, channel_info.trust_extension, motion_model_.getYawState(), time);
 
   removeCache();
   return true;


### PR DESCRIPTION
## Description

This PR contains two related footprint changes in `autoware_multi_object_tracker`.


### 1. Merge footprints using the convex hull


|before|<img width="1415" height="612" alt="Screenshot from 2026-07-07 16-04-02" src="https://github.com/user-attachments/assets/94a71bcd-8621-4a3c-b247-220d5ae40718" />|
|-|-|
|after|<img width="1415" height="612" alt="Screenshot from 2026-07-07 16-01-52" src="https://github.com/user-attachments/assets/396451ef-9f1d-4614-9057-dbd1c030111c" />|







Change the footprint merger to merge two footprints by taking the **convex hull** of their combined vertices.

Footprint merging happens during the redundant-tracker (overlap) merge cycle: when a winner tracker absorbs a loser, the loser's footprint is transformed into the winner's local frame and unioned into the winner's stored footprint (`VehicleShapeModel::mergeFrom` → `shapes::unionFootprints`, gated by a 1 s freshness window).

Previously `unionFootprints` ran a full `boost::geometry::union_`:

- if the two footprints overlapped, it returned the (possibly **concave**) union ring;
- only when the footprints were disjoint did it fall back to a convex hull.

This produced inconsistent, sometimes concave merged footprints. Since the convex hull of the union of two polygons equals the convex hull of all their combined vertices, the merge is now a single `boost::geometry::convex_hull` over the vertices of both footprints. The result is always a single convex polygon that covers both inputs whether they overlap or are disjoint, and the `union_` + disjoint-branching is no longer needed.

Also removed two now-unused includes (`<vector>`, `boost_polygon_utils.hpp`).

### 2. Pedestrian shape: export a fresh footprint

https://github.com/user-attachments/assets/455ac1ba-5d85-4176-b1f2-25de9f81fa67

The model now carries the measurement footprint instead of always clearing it:

- **`update()`** stores a non-empty input footprint anchored at the object position but **aligned to the global axes** (zero yaw, via the new `globalFrameAt()` helper) — never rotated into the tracker heading frame — and records the update time. It gained a `const rclcpp::Time & time` parameter; `PedestrianTracker::measure()` is updated to pass `time`.
- **`exportTo()`** re-expresses the stored footprint from the global-axis frame into the output object's frame and emits it, but only while the footprint is still **fresh** (`< FOOTPRINT_TIMEOUT_S = 1.0 s` relative to the output time). When stale or never set, the footprint is cleared.

The header/data-flow comments and the `unionFootprints` header doc are updated to match.

## Related links

**Parent Issue:**

- N/A

## How was this PR tested?

- Local build of `autoware_multi_object_tracker`.
- Existing package unit tests.

(No tests asserted the previous concave-union or CYLINDER-export behavior.)

## Notes for reviewers

- **Footprint merge:** merged footprints are now always convex. Overlapping footprints that previously kept a concave union boundary will now be slightly expanded to the convex hull. No API/signature change — `shapes::unionFootprints` keeps the same signature and return contract (exterior ring, no closing duplicate vertex); only the shape of the merged polygon changes.
- **Pedestrian footprint:** the exported object now carries the stored measurement footprint (re-expressed into the output frame) instead of an empty one, gated by a 1 s freshness window. `PedestrianShapeModel::update()` signature changed — it now takes the measurement `time`; the only caller (`PedestrianTracker::measure`) is updated in this PR.

## Interface changes

None at the message/ROS-API level (message and topic signatures unchanged). Internal C++ signature change: `PedestrianShapeModel::update()` gains a `const rclcpp::Time & time` parameter. Behavioral changes: pedestrian output shape type is always `BOUNDING_BOX` and carries a fresh footprint, and merged footprints are always convex.

## Effects on system behavior

- Merged vehicle footprints from redundant-tracker absorption are now convex. This can marginally enlarge merged footprints where the true union was concave; the merge flow, freshness gating (1 s), and shape-type selection are unchanged.
