### PR TITLE
feat(perception_analytics_publisher): apply `agnocast_wrapper::Node` to `perception_analytics_publisher`

### DIFF
--- a/evaluator/autoware_perception_online_evaluator/CMakeLists.txt
+++ b/evaluator/autoware_perception_online_evaluator/CMakeLists.txt
@@ -22,9 +22,11 @@ rclcpp_components_register_node(${PROJECT_NAME}
   EXECUTABLE autoware_perception_online_evaluator_node
 )
 
-rclcpp_components_register_node(${PROJECT_NAME}
+autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   PLUGIN   "autoware::perception_diagnostics::PerceptionAnalyticsPublisherNode"
   EXECUTABLE autoware_perception_analytics_publisher_node
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
+  ROS2_EXECUTOR SingleThreadedExecutor
 )
 
 if(BUILD_TESTING)

--- a/evaluator/autoware_perception_online_evaluator/include/autoware/perception_online_evaluator/perception_analytics_calculator.hpp
+++ b/evaluator/autoware_perception_online_evaluator/include/autoware/perception_online_evaluator/perception_analytics_calculator.hpp
@@ -15,7 +15,7 @@
 #ifndef AUTOWARE__PERCEPTION_ONLINE_EVALUATOR__PERCEPTION_ANALYTICS_CALCULATOR_HPP_
 #define AUTOWARE__PERCEPTION_ONLINE_EVALUATOR__PERCEPTION_ANALYTICS_CALCULATOR_HPP_
 
-#include "tf2_ros/buffer.h"
+#include <autoware/agnocast_wrapper/tf2.hpp>
 
 #include "autoware_perception_msgs/msg/predicted_objects.hpp"
 
@@ -78,7 +78,7 @@ public:
    * @param tf_buffer   TF buffer used for transforms
    * @return FrameMetrics
    */
-  FrameMetrics calculate(const tf2_ros::Buffer & tf_buffer) const;
+  FrameMetrics calculate(const autoware::agnocast_wrapper::Buffer & tf_buffer) const;
 
 private:
   mutable std::mutex predicted_objects_mutex_;

--- a/evaluator/autoware_perception_online_evaluator/include/autoware/perception_online_evaluator/perception_analytics_publisher_node.hpp
+++ b/evaluator/autoware_perception_online_evaluator/include/autoware/perception_online_evaluator/perception_analytics_publisher_node.hpp
@@ -18,10 +18,9 @@
 #include "autoware/perception_online_evaluator/parameters.hpp"
 #include "autoware/perception_online_evaluator/perception_analytics_calculator.hpp"
 #include "rclcpp/rclcpp.hpp"
-#include "tf2_ros/buffer.h"
-#include "tf2_ros/transform_listener.h"
 
 #include <autoware/agnocast_wrapper/node.hpp>
+#include <autoware/agnocast_wrapper/tf2.hpp>
 
 #include "autoware_perception_msgs/msg/object_classification.hpp"
 #include "autoware_perception_msgs/msg/predicted_objects.hpp"
@@ -79,8 +78,8 @@ private:
   std::array<double, autoware::perception_diagnostics::LATENCY_TOPIC_NUM> latencies_;
 
   // TF
-  std::unique_ptr<tf2_ros::Buffer> tf_buffer_;
-  std::shared_ptr<tf2_ros::TransformListener> transform_listener_{nullptr};
+  std::unique_ptr<autoware::agnocast_wrapper::Buffer> tf_buffer_;
+  std::shared_ptr<autoware::agnocast_wrapper::TransformListener> transform_listener_{nullptr};
 
   // Parameters
   std::shared_ptr<AnalyticsParameters> parameters_;

--- a/evaluator/autoware_perception_online_evaluator/include/autoware/perception_online_evaluator/perception_analytics_publisher_node.hpp
+++ b/evaluator/autoware_perception_online_evaluator/include/autoware/perception_online_evaluator/perception_analytics_publisher_node.hpp
@@ -21,6 +21,8 @@
 #include "tf2_ros/buffer.h"
 #include "tf2_ros/transform_listener.h"
 
+#include <autoware/agnocast_wrapper/node.hpp>
+
 #include "autoware_perception_msgs/msg/object_classification.hpp"
 #include "autoware_perception_msgs/msg/predicted_objects.hpp"
 #include "nav_msgs/msg/odometry.hpp"
@@ -46,7 +48,7 @@ using TFMessage = tf2_msgs::msg::TFMessage;
 /**
  * @brief Node for publishing perception analytics
  */
-class PerceptionAnalyticsPublisherNode : public rclcpp::Node
+class PerceptionAnalyticsPublisherNode : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit PerceptionAnalyticsPublisherNode(const rclcpp::NodeOptions & node_options);
@@ -56,7 +58,7 @@ public:
    * @brief callback on receiving a dynamic objects array
    * @param [in] objects_msg received dynamic object array message
    */
-  void onObjects(const PredictedObjects::ConstSharedPtr objects_msg);
+  void onObjects(const AUTOWARE_MESSAGE_CONST_SHARED_PTR(PredictedObjects) & objects_msg);
 
 private:
   // Label list
@@ -68,10 +70,10 @@ private:
   };
 
   // Subscribers and publishers
-  rclcpp::Subscription<PredictedObjects>::SharedPtr objects_sub_;
-  rclcpp::Subscription<Float64Stamped>::SharedPtr meas_to_tracked_latency_sub_;
-  rclcpp::Subscription<Float64Stamped>::SharedPtr prediction_latency_sub_;
-  rclcpp::Publisher<tier4_metric_msgs::msg::MetricArray>::SharedPtr perception_analytics_pub_;
+  AUTOWARE_SUBSCRIPTION_PTR(PredictedObjects) objects_sub_;
+  AUTOWARE_SUBSCRIPTION_PTR(Float64Stamped) meas_to_tracked_latency_sub_;
+  AUTOWARE_SUBSCRIPTION_PTR(Float64Stamped) prediction_latency_sub_;
+  AUTOWARE_PUBLISHER_PTR(tier4_metric_msgs::msg::MetricArray) perception_analytics_pub_;
 
   // Latency cache (by topic id)
   std::array<double, autoware::perception_diagnostics::LATENCY_TOPIC_NUM> latencies_;
@@ -85,7 +87,7 @@ private:
   void initParameter();
   rcl_interfaces::msg::SetParametersResult onParameter(
     const std::vector<rclcpp::Parameter> & parameters);
-  OnSetParametersCallbackHandle::SharedPtr set_param_res_;
+  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr set_param_res_;
 
   // Metrics Calculator
   PerceptionAnalyticsCalculator perception_analytics_calculator_;

--- a/evaluator/autoware_perception_online_evaluator/launch/perception_analytics_publisher.launch.xml
+++ b/evaluator/autoware_perception_online_evaluator/launch/perception_analytics_publisher.launch.xml
@@ -1,12 +1,15 @@
 <launch>
   <arg name="input/objects" default="/perception/object_recognition/objects"/>
 
+  <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
+
   <!-- perception analytics publisher -->
   <group>
     <node pkg="autoware_perception_online_evaluator" exec="autoware_perception_analytics_publisher_node">
       <param from="$(find-pkg-share autoware_perception_online_evaluator)/param/perception_analytics_publisher.defaults.yaml"/>
       <remap from="~/input/objects" to="$(var input/objects)"/>
       <remap from="~/perception_analytics" to="/perception/perception_analytics_publisher/perception_analytics"/>
+      <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
     </node>
   </group>
 </launch>

--- a/evaluator/autoware_perception_online_evaluator/package.xml
+++ b/evaluator/autoware_perception_online_evaluator/package.xml
@@ -17,6 +17,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_object_recognition_utils</depend>
   <depend>autoware_perception_msgs</depend>

--- a/evaluator/autoware_perception_online_evaluator/src/perception_analytics_calculator.cpp
+++ b/evaluator/autoware_perception_online_evaluator/src/perception_analytics_calculator.cpp
@@ -39,7 +39,8 @@ void PerceptionAnalyticsCalculator::setLatencies(
   latencies_ = latencies;
 }
 
-FrameMetrics PerceptionAnalyticsCalculator::calculate(const tf2_ros::Buffer & tf_buffer) const
+FrameMetrics PerceptionAnalyticsCalculator::calculate(
+  const autoware::agnocast_wrapper::Buffer & tf_buffer) const
 {
   PredictedObjects::ConstSharedPtr ptr;
   {

--- a/evaluator/autoware_perception_online_evaluator/src/perception_analytics_publisher_node.cpp
+++ b/evaluator/autoware_perception_online_evaluator/src/perception_analytics_publisher_node.cpp
@@ -15,7 +15,6 @@
 #include "autoware/perception_online_evaluator/perception_analytics_publisher_node.hpp"
 
 #include "autoware/object_recognition_utils/object_classification.hpp"
-#include "autoware_utils/ros/parameter.hpp"
 #include "autoware_utils/ros/update_param.hpp"
 
 #include <fstream>
@@ -53,11 +52,13 @@ PerceptionAnalyticsPublisherNode::PerceptionAnalyticsPublisherNode(
   const auto latency_topic_prediction =
     this->get_parameter("prediction_latency_topic_name").as_string();
   meas_to_tracked_latency_sub_ = create_subscription<Float64Stamped>(
-    latency_topic_meas_to_tracked, 1, [this](const Float64Stamped::ConstSharedPtr msg) {
+    latency_topic_meas_to_tracked, 1,
+    [this](const AUTOWARE_MESSAGE_CONST_SHARED_PTR(Float64Stamped) & msg) {
       latencies_[LATENCY_TOPIC_ID_MEAS_TO_TRACKED] = msg->data;
     });
   prediction_latency_sub_ = create_subscription<Float64Stamped>(
-    latency_topic_prediction, 1, [this](const Float64Stamped::ConstSharedPtr msg) {
+    latency_topic_prediction, 1,
+    [this](const AUTOWARE_MESSAGE_CONST_SHARED_PTR(Float64Stamped) & msg) {
       latencies_[LATENCY_TOPIC_ID_PREDICTION] = msg->data;
     });
 
@@ -69,11 +70,10 @@ void PerceptionAnalyticsPublisherNode::publishPerceptionAnalytics()
 {
   auto metrics = perception_analytics_calculator_.calculate(*tf_buffer_);
 
-  // DiagnosticArray metrics_msg;
-  tier4_metric_msgs::msg::MetricArray metrics_msg;
+  auto metrics_msg = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(perception_analytics_pub_);
 
   // all object count
-  metrics_msg.metric_array.emplace_back(
+  metrics_msg->metric_array.emplace_back(
     tier4_metric_msgs::build<tier4_metric_msgs::msg::Metric>()
       .name("all_object_count")
       .unit("count")
@@ -81,7 +81,7 @@ void PerceptionAnalyticsPublisherNode::publishPerceptionAnalytics()
 
   // object count per label
   for (auto & label : label_list_) {
-    metrics_msg.metric_array.emplace_back(
+    metrics_msg->metric_array.emplace_back(
       tier4_metric_msgs::build<tier4_metric_msgs::msg::Metric>()
         .name("object_count_" + convertLabelToString(label))
         .unit("count")
@@ -90,7 +90,7 @@ void PerceptionAnalyticsPublisherNode::publishPerceptionAnalytics()
 
   // max distance per label (value 0 for no object)
   for (auto & label : label_list_) {
-    metrics_msg.metric_array.emplace_back(
+    metrics_msg->metric_array.emplace_back(
       tier4_metric_msgs::build<tier4_metric_msgs::msg::Metric>()
         .name("max_distance_" + convertLabelToString(label))
         .unit("m")
@@ -98,33 +98,36 @@ void PerceptionAnalyticsPublisherNode::publishPerceptionAnalytics()
   }
 
   // latency by topic
-  metrics_msg.metric_array.emplace_back(
+  metrics_msg->metric_array.emplace_back(
     tier4_metric_msgs::build<tier4_metric_msgs::msg::Metric>()
       .name("meas_to_tracked_latency")
       .unit("ms")
       .value(std::to_string(metrics.latency_by_topic_id[LATENCY_TOPIC_ID_MEAS_TO_TRACKED])));
-  metrics_msg.metric_array.emplace_back(
+  metrics_msg->metric_array.emplace_back(
     tier4_metric_msgs::build<tier4_metric_msgs::msg::Metric>()
       .name("prediction_latency")
       .unit("ms")
       .value(std::to_string(metrics.latency_by_topic_id[LATENCY_TOPIC_ID_PREDICTION])));
 
   // total latency
-  metrics_msg.metric_array.emplace_back(
+  metrics_msg->metric_array.emplace_back(
     tier4_metric_msgs::build<tier4_metric_msgs::msg::Metric>()
       .name("total_latency")
       .unit("ms")
       .value(std::to_string(metrics.total_latency)));
 
-  if (!metrics_msg.metric_array.empty()) {
-    metrics_msg.stamp = now();
-    perception_analytics_pub_->publish(metrics_msg);
+  if (!metrics_msg->metric_array.empty()) {
+    metrics_msg->stamp = now();
+    perception_analytics_pub_->publish(std::move(metrics_msg));
   }
 }
 
-void PerceptionAnalyticsPublisherNode::onObjects(const PredictedObjects::ConstSharedPtr objects_msg)
+void PerceptionAnalyticsPublisherNode::onObjects(
+  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(PredictedObjects) & objects_msg)
 {
-  perception_analytics_calculator_.setPredictedObjects(objects_msg);
+  // Copy out of the (possibly loaned) message so the calculator can retain it as a ConstSharedPtr.
+  perception_analytics_calculator_.setPredictedObjects(
+    std::make_shared<PredictedObjects>(*objects_msg));
   perception_analytics_calculator_.setLatencies(latencies_);
   publishPerceptionAnalytics();
 }
@@ -149,13 +152,18 @@ rcl_interfaces::msg::SetParametersResult PerceptionAnalyticsPublisherNode::onPar
 
 void PerceptionAnalyticsPublisherNode::initParameter()
 {
-  using autoware_utils::get_or_declare_parameter;
   auto & p = parameters_;
 
-  p->meas_to_tracked_latency_topic_name =
-    get_or_declare_parameter<std::string>(*this, "meas_to_tracked_latency_topic_name");
-  p->prediction_latency_topic_name =
-    get_or_declare_parameter<std::string>(*this, "prediction_latency_topic_name");
+  // autoware_utils::get_or_declare_parameter hard-takes rclcpp::Node &, which does not bind to the
+  // agnocast_wrapper::Node under ENABLE_AGNOCAST=1. Use the node's own parameter members instead
+  // (available in both modes).
+  const auto get_or_declare = [this](const std::string & name) {
+    return this->has_parameter(name) ? this->get_parameter(name).as_string()
+                                     : this->declare_parameter<std::string>(name);
+  };
+
+  p->meas_to_tracked_latency_topic_name = get_or_declare("meas_to_tracked_latency_topic_name");
+  p->prediction_latency_topic_name = get_or_declare("prediction_latency_topic_name");
 }
 }  // namespace autoware::perception_diagnostics
 

--- a/evaluator/autoware_perception_online_evaluator/src/perception_analytics_publisher_node.cpp
+++ b/evaluator/autoware_perception_online_evaluator/src/perception_analytics_publisher_node.cpp
@@ -63,14 +63,16 @@ PerceptionAnalyticsPublisherNode::PerceptionAnalyticsPublisherNode(
       latencies_[LATENCY_TOPIC_ID_PREDICTION] = msg->data;
     });
 
-  tf_buffer_ = std::make_unique<tf2_ros::Buffer>(this->get_clock());
-  transform_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
+  tf_buffer_ = std::make_unique<autoware::agnocast_wrapper::Buffer>(this->get_clock());
+  transform_listener_ =
+    std::make_shared<autoware::agnocast_wrapper::TransformListener>(*tf_buffer_, *this);
 }
 
 void PerceptionAnalyticsPublisherNode::publishPerceptionAnalytics()
 {
   auto metrics = perception_analytics_calculator_.calculate(*tf_buffer_);
 
+  // DiagnosticArray metrics_msg;
   auto metrics_msg = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(perception_analytics_pub_);
 
   // all object count
@@ -126,7 +128,6 @@ void PerceptionAnalyticsPublisherNode::publishPerceptionAnalytics()
 void PerceptionAnalyticsPublisherNode::onObjects(
   const AUTOWARE_MESSAGE_CONST_SHARED_PTR(PredictedObjects) & objects_msg)
 {
-  // Copy out of the (possibly loaned) message so the calculator can retain it as a ConstSharedPtr.
   perception_analytics_calculator_.setPredictedObjects(
     std::make_shared<PredictedObjects>(*objects_msg));
   perception_analytics_calculator_.setLatencies(latencies_);
@@ -153,12 +154,13 @@ rcl_interfaces::msg::SetParametersResult PerceptionAnalyticsPublisherNode::onPar
 
 void PerceptionAnalyticsPublisherNode::initParameter()
 {
+  using autoware_utils::get_or_declare_parameter;
   auto & p = parameters_;
 
-  p->meas_to_tracked_latency_topic_name = autoware_utils::get_or_declare_parameter<std::string>(
-    *this, "meas_to_tracked_latency_topic_name");
+  p->meas_to_tracked_latency_topic_name =
+    get_or_declare_parameter<std::string>(*this, "meas_to_tracked_latency_topic_name");
   p->prediction_latency_topic_name =
-    autoware_utils::get_or_declare_parameter<std::string>(*this, "prediction_latency_topic_name");
+    get_or_declare_parameter<std::string>(*this, "prediction_latency_topic_name");
 }
 }  // namespace autoware::perception_diagnostics
 

--- a/evaluator/autoware_perception_online_evaluator/src/perception_analytics_publisher_node.cpp
+++ b/evaluator/autoware_perception_online_evaluator/src/perception_analytics_publisher_node.cpp
@@ -15,6 +15,7 @@
 #include "autoware/perception_online_evaluator/perception_analytics_publisher_node.hpp"
 
 #include "autoware/object_recognition_utils/object_classification.hpp"
+#include "autoware_utils/ros/parameter.hpp"
 #include "autoware_utils/ros/update_param.hpp"
 
 #include <fstream>
@@ -154,16 +155,10 @@ void PerceptionAnalyticsPublisherNode::initParameter()
 {
   auto & p = parameters_;
 
-  // autoware_utils::get_or_declare_parameter hard-takes rclcpp::Node &, which does not bind to the
-  // agnocast_wrapper::Node under ENABLE_AGNOCAST=1. Use the node's own parameter members instead
-  // (available in both modes).
-  const auto get_or_declare = [this](const std::string & name) {
-    return this->has_parameter(name) ? this->get_parameter(name).as_string()
-                                     : this->declare_parameter<std::string>(name);
-  };
-
-  p->meas_to_tracked_latency_topic_name = get_or_declare("meas_to_tracked_latency_topic_name");
-  p->prediction_latency_topic_name = get_or_declare("prediction_latency_topic_name");
+  p->meas_to_tracked_latency_topic_name = autoware_utils::get_or_declare_parameter<std::string>(
+    *this, "meas_to_tracked_latency_topic_name");
+  p->prediction_latency_topic_name =
+    autoware_utils::get_or_declare_parameter<std::string>(*this, "prediction_latency_topic_name");
 }
 }  // namespace autoware::perception_diagnostics
 


### PR DESCRIPTION
## Description
Apply `agnocast_wrapper::Node` to `autoware_perception_analytics_publisher`.
Please read https://github.com/autowarefoundation/autoware/issues/7007 for the context and review guidelines of `autoware_agnocast_wrapper` adoption. 
Also, please refer to https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/docs/review_guide.md for the review guide of `autoware_agnocast_wrapper` application PR. FYI: This node take [Method2](https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/docs/review_guide.md#method-2-agnocast_wrappernode-inheritance) of two integrations methods.

### Node specific change
  - The trigger_node service is registered through the wrapper's `AUTOWARE_CREATE_SERVICE` macro, which takes an `rclcpp::QoS` and absorbs the Humble-only `rmw_qos_profile` signature difference inside the wrapper. As a result, no per-distro / per-build (#ifdef) branch is needed at the call site.

## Related Links

  - https://github.com/autowarefoundation/autoware/issues/7007
  - https://github.com/orgs/autowarefoundation/discussions/6804

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
  - `colcon build` succeeds with both `ENABLE_AGNOCAST=1` and `ENABLE_AGNOCAST=0`.
  - Ran Autoware based product with this change applied and confirmed it operates without any regression.

## Notes for reviewers

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None when ENABLE_AGNOCAST is not set or set to 0 on runtime. When ENABLE_AGNOCAST=1, CPU Time used in this node for message serialization/deserialization will be reduced.
