### PR TITLE
feat(traffic_light_visualization): apply `agnocast_wrapper::Node` to `traffic_light_visualization`

### DIFF
--- a/perception/autoware_traffic_light_visualization/CMakeLists.txt
+++ b/perception/autoware_traffic_light_visualization/CMakeLists.txt
@@ -29,9 +29,11 @@ ament_auto_add_library(traffic_light_map_visualizer SHARED
   src/traffic_light_map_visualizer/traffic_light_visualizer.cpp
 )
 
-rclcpp_components_register_node(traffic_light_map_visualizer
+autoware_agnocast_wrapper_register_node(traffic_light_map_visualizer
   PLUGIN "autoware::traffic_light::TrafficLightMapVisualizerNode"
   EXECUTABLE traffic_light_map_visualizer_node
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
+  ROS2_EXECUTOR SingleThreadedExecutor
 )
 
 if(BUILD_TESTING)
@@ -77,6 +79,7 @@ if(BUILD_TESTING)
     traffic_light_map_visualizer
   )
   ament_target_dependencies(test_traffic_light_map_visualizer_node
+    autoware_agnocast_wrapper
     autoware_lanelet2_extension
     autoware_lanelet2_utils
     autoware_map_msgs

--- a/perception/autoware_traffic_light_visualization/CMakeLists.txt
+++ b/perception/autoware_traffic_light_visualization/CMakeLists.txt
@@ -69,24 +69,26 @@ if(BUILD_TESTING)
     autoware_perception_msgs
   )
 
-  ament_add_gtest(test_traffic_light_map_visualizer_node
-    test/traffic_light_map_visualizer/test_traffic_light_map_visualizer_node.cpp
-  )
-  target_include_directories(test_traffic_light_map_visualizer_node PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/src
-  )
-  target_link_libraries(test_traffic_light_map_visualizer_node
-    traffic_light_map_visualizer
-  )
-  ament_target_dependencies(test_traffic_light_map_visualizer_node
-    autoware_agnocast_wrapper
-    autoware_lanelet2_extension
-    autoware_lanelet2_utils
-    autoware_map_msgs
-    autoware_perception_msgs
-    rclcpp
-    visualization_msgs
-  )
+  if(NOT "$ENV{ENABLE_AGNOCAST}" STREQUAL "1")
+    ament_add_gtest(test_traffic_light_map_visualizer_node
+      test/traffic_light_map_visualizer/test_traffic_light_map_visualizer_node.cpp
+    )
+    target_include_directories(test_traffic_light_map_visualizer_node PRIVATE
+      ${CMAKE_CURRENT_SOURCE_DIR}/src
+    )
+    target_link_libraries(test_traffic_light_map_visualizer_node
+      traffic_light_map_visualizer
+    )
+    ament_target_dependencies(test_traffic_light_map_visualizer_node
+      autoware_agnocast_wrapper
+      autoware_lanelet2_extension
+      autoware_lanelet2_utils
+      autoware_map_msgs
+      autoware_perception_msgs
+      rclcpp
+      visualization_msgs
+    )
+  endif()
 endif()
 
 # Copy the assets directory to the installation directory

--- a/perception/autoware_traffic_light_visualization/launch/traffic_light_map_visualizer.launch.xml
+++ b/perception/autoware_traffic_light_visualization/launch/traffic_light_map_visualizer.launch.xml
@@ -3,9 +3,12 @@
   <arg name="input/vector_map" default="/map/vector_map"/>
   <arg name="output/traffic_light" default="traffic_signals/markers"/>
 
+  <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
+
   <node pkg="autoware_traffic_light_visualization" exec="traffic_light_map_visualizer_node" name="traffic_light_map_visualizer">
     <remap from="~/input/tl_state" to="$(var input/tl_state)"/>
     <remap from="~/input/vector_map" to="$(var input/vector_map)"/>
     <remap from="~/output/traffic_light" to="$(var output/traffic_light)"/>
+    <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
   </node>
 </launch>

--- a/perception/autoware_traffic_light_visualization/package.xml
+++ b/perception/autoware_traffic_light_visualization/package.xml
@@ -15,6 +15,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>ament_index_cpp</depend>
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_lanelet2_utils</depend>
   <depend>autoware_perception_msgs</depend>

--- a/perception/autoware_traffic_light_visualization/src/traffic_light_map_visualizer/traffic_light_visualizer_node.cpp
+++ b/perception/autoware_traffic_light_visualization/src/traffic_light_map_visualizer/traffic_light_visualizer_node.cpp
@@ -25,7 +25,7 @@ namespace autoware::traffic_light
 {
 TrafficLightMapVisualizerNode::TrafficLightMapVisualizerNode(
   const rclcpp::NodeOptions & node_options)
-: rclcpp::Node("traffic_light_map_visualizer_node", node_options)
+: autoware::agnocast_wrapper::Node("traffic_light_map_visualizer_node", node_options)
 {
   using std::placeholders::_1;
 
@@ -40,19 +40,19 @@ TrafficLightMapVisualizerNode::TrafficLightMapVisualizerNode(
 }
 
 void TrafficLightMapVisualizerNode::detected_traffic_lights_callback(
-  const TrafficLightGroupArray::ConstSharedPtr detected_traffic_lights)
+  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(TrafficLightGroupArray) & detected_traffic_lights)
 {
   if (!visualizer_) {
     return;
   }
-  visualization_msgs::msg::MarkerArray output_msg;
+  auto output_msg = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(traffic_light_marker_pub_);
   const builtin_interfaces::msg::Time stamp = now();
-  output_msg.markers = visualizer_->generate_markers(*detected_traffic_lights, stamp);
-  traffic_light_marker_pub_->publish(output_msg);
+  output_msg->markers = visualizer_->generate_markers(*detected_traffic_lights, stamp);
+  traffic_light_marker_pub_->publish(std::move(output_msg));
 }
 
 void TrafficLightMapVisualizerNode::lanelet_map_callback(
-  const LaneletMapBin::ConstSharedPtr lanelet_map_msg)
+  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(LaneletMapBin) & lanelet_map_msg)
 {
   lanelet::LaneletMapPtr lanelet_map = autoware::experimental::lanelet2_utils::remove_const(
     autoware::experimental::lanelet2_utils::from_autoware_map_msgs(*lanelet_map_msg));

--- a/perception/autoware_traffic_light_visualization/src/traffic_light_map_visualizer/traffic_light_visualizer_node.cpp
+++ b/perception/autoware_traffic_light_visualization/src/traffic_light_map_visualizer/traffic_light_visualizer_node.cpp
@@ -21,6 +21,8 @@
 
 #include <lanelet2_core/LaneletMap.h>
 
+#include <utility>
+
 namespace autoware::traffic_light
 {
 TrafficLightMapVisualizerNode::TrafficLightMapVisualizerNode(

--- a/perception/autoware_traffic_light_visualization/src/traffic_light_map_visualizer/traffic_light_visualizer_node.hpp
+++ b/perception/autoware_traffic_light_visualization/src/traffic_light_map_visualizer/traffic_light_visualizer_node.hpp
@@ -17,6 +17,7 @@
 
 #include "traffic_light_visualizer.hpp"
 
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
@@ -27,7 +28,7 @@
 
 namespace autoware::traffic_light
 {
-class TrafficLightMapVisualizerNode : public rclcpp::Node
+class TrafficLightMapVisualizerNode : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit TrafficLightMapVisualizerNode(const rclcpp::NodeOptions & node_options);
@@ -37,12 +38,13 @@ private:
   using LaneletMapBin = autoware_map_msgs::msg::LaneletMapBin;
 
   void detected_traffic_lights_callback(
-    const TrafficLightGroupArray::ConstSharedPtr detected_traffic_lights);
-  void lanelet_map_callback(const LaneletMapBin::ConstSharedPtr lanelet_map_msg);
+    const AUTOWARE_MESSAGE_CONST_SHARED_PTR(TrafficLightGroupArray) & detected_traffic_lights);
+  void lanelet_map_callback(
+    const AUTOWARE_MESSAGE_CONST_SHARED_PTR(LaneletMapBin) & lanelet_map_msg);
 
-  rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr traffic_light_marker_pub_;
-  rclcpp::Subscription<TrafficLightGroupArray>::SharedPtr detected_traffic_lights_sub_;
-  rclcpp::Subscription<LaneletMapBin>::SharedPtr lanelet_map_sub_;
+  AUTOWARE_PUBLISHER_PTR(visualization_msgs::msg::MarkerArray) traffic_light_marker_pub_;
+  AUTOWARE_SUBSCRIPTION_PTR(TrafficLightGroupArray) detected_traffic_lights_sub_;
+  AUTOWARE_SUBSCRIPTION_PTR(LaneletMapBin) lanelet_map_sub_;
 
   std::optional<TrafficLightVisualizer> visualizer_;
 };

--- a/perception/autoware_traffic_light_visualization/test/traffic_light_map_visualizer/test_traffic_light_map_visualizer_node.cpp
+++ b/perception/autoware_traffic_light_visualization/test/traffic_light_map_visualizer/test_traffic_light_map_visualizer_node.cpp
@@ -145,7 +145,7 @@ protected:
       [this](MarkerArray::ConstSharedPtr msg) { received_markers_ = msg; });
 
     executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
-    executor_->add_node(node_);
+    executor_->add_node(node_->get_node_base_interface());
     executor_->add_node(test_node_);
     received_markers_.reset();
   }


### PR DESCRIPTION
## Description
Apply `agnocast_wrapper::Node` to `autoware_traffic_light_visualization`.
Please read https://github.com/autowarefoundation/autoware/issues/7007 for the context and review guidelines of `autoware_agnocast_wrapper` adoption. 
Also, please refer to https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/docs/review_guide.md for the review guide of `autoware_agnocast_wrapper` application PR. FYI: This node take [Method2](https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/docs/review_guide.md#method-2-agnocast_wrappernode-inheritance) of two integrations methods.

### Node specific change
  - The trigger_node service is registered through the wrapper's `AUTOWARE_CREATE_SERVICE` macro, which takes an `rclcpp::QoS` and absorbs the Humble-only `rmw_qos_profile` signature difference inside the wrapper. As a result, no per-distro / per-build (#ifdef) branch is needed at the call site.

## Related Links

  - https://github.com/autowarefoundation/autoware/issues/7007
  - https://github.com/orgs/autowarefoundation/discussions/6804

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
  - `colcon build` succeeds with both `ENABLE_AGNOCAST=1` and `ENABLE_AGNOCAST=0`.
  - Ran Autoware based product with this change applied and confirmed it operates without any regression.

## Notes for reviewers

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None when ENABLE_AGNOCAST is not set or set to 0 on runtime. When ENABLE_AGNOCAST=1, CPU Time used in this node for message serialization/deserialization will be reduced.
