### PR TITLE
test(autoware_traffic_light_classifier): drive ColorClassifierCore tests ROS-free and extend coverage

### DIFF
--- a/perception/autoware_traffic_light_classifier/CMakeLists.txt
+++ b/perception/autoware_traffic_light_classifier/CMakeLists.txt
@@ -142,11 +142,20 @@ if(BUILD_TESTING)
     ${OpenCV_LIBRARIES}
   )
 
-  # ColorClassifier unit tests (ROS-isolated: the classifier currently needs a node).
-  ament_add_ros_isolated_gtest(test_color_classifier
+  # ROS-free unit tests for the color classification core (ColorClassifierCore).
+  ament_auto_add_gtest(test_color_classifier
     test/test_color_classifier.cpp
   )
   target_link_libraries(test_color_classifier
+    ${PROJECT_NAME}
+    ${OpenCV_LIBRARIES}
+  )
+
+  # ColorClassifier ROS adapter tests (the size guard needs the node's logger).
+  ament_add_ros_isolated_gtest(test_color_classifier_adapter
+    test/test_color_classifier_adapter.cpp
+  )
+  target_link_libraries(test_color_classifier_adapter
     ${PROJECT_NAME}
     ${OpenCV_LIBRARIES}
   )

--- a/perception/autoware_traffic_light_classifier/test/test_color_classifier.cpp
+++ b/perception/autoware_traffic_light_classifier/test/test_color_classifier.cpp
@@ -13,13 +13,17 @@
 // limitations under the License.
 
 //
-// Unit tests for ColorClassifier.
+// Unit tests for the ROS-free ColorClassifierCore.
 //
-// ColorClassifier currently takes an rclcpp::Node * and reads its HSV thresholds
-// from parameters, so these tests host a node and prime the thresholds via
-// set_parameter() (which synchronously fires the on-set-parameter callback that
-// populates the thresholds). A later refactor removes that ROS coupling; only
-// the Arrange (construction/priming) changes then, the assertions stay the same.
+// The core is constructed directly from an HSVConfig and its classify() /
+// make_debug_image() are exercised over in-memory cv::Mat inputs -- no rclcpp,
+// no node, no parameters. (Earlier revisions drove this through the ROS
+// ColorClassifier adapter and a hosted node; the Act now talks to the core
+// directly, but the classification assertions are unchanged.)
+//
+// The adapter-only concerns (the images/signals size guard, logging, debug-image
+// publishing) live at other layers -- see test_color_classifier_adapter and
+// test_traffic_light_classifier_integration.
 //
 // Tests follow Arrange-Act-Assert.
 //
@@ -27,14 +31,12 @@
 #include "../src/classifier/color_classifier.hpp"
 
 #include <opencv2/imgproc.hpp>
-#include <rclcpp/rclcpp.hpp>
 
 #include <tier4_perception_msgs/msg/traffic_light_array.hpp>
 
 #include <gtest/gtest.h>
 
 #include <cstddef>
-#include <memory>
 #include <vector>
 
 namespace
@@ -50,7 +52,7 @@ using tier4_perception_msgs::msg::TrafficLightElement;
 // yields N*N matching pixels (erode/dilate preserve a solid region), so side <
 // confidence_saturation_side keeps confidence in (0, 1) and side >= it clamps to
 // exactly 1.0. They must be kept in sync with the 20*20 divisor in
-// ColorClassifier::getTrafficSignals.
+// ColorClassifierCore::classify_element.
 // TODO(follow-up): once production exposes the saturation threshold as a named
 // constant, derive the sizes from it and drop this manual sync.
 constexpr int confidence_saturation_side = 20;
@@ -61,7 +63,7 @@ static_assert(
   "sizes must straddle the confidence saturation threshold");
 
 // Solid image whose every pixel maps to the given OpenCV HSV triple, built in
-// HSV then converted to BGR (ColorClassifier::filterHSV does BGR2HSV).
+// HSV then converted to BGR (ColorClassifierCore::filter_hsv does BGR2HSV).
 cv::Mat make_solid_hsv_image(int h, int s, int v, int size = unsaturated_side)
 {
   cv::Mat hsv(size, size, CV_8UC3, cv::Scalar(h, s, v));
@@ -89,87 +91,68 @@ const TrafficLightElement & element_at(const TrafficLightArray & signals, std::s
   return signals.signals.at(slot).elements.at(0);
 }
 
-// Hosts a node and a ColorClassifier with its HSV thresholds primed to the
-// declared defaults. Setting any HSV parameter fires the on-set-parameter
-// callback that populates all thresholds.
-class ColorClassifierTest : public ::testing::Test
+// A default-configured core. The constructor builds the HSV bands from the
+// default HSVConfig, so no priming is needed.
+class ColorClassifierCoreTest : public ::testing::Test
 {
 protected:
-  void SetUp() override
-  {
-    node_ = std::make_shared<rclcpp::Node>("color_classifier_test");
-    classifier_ = std::make_unique<tl::ColorClassifier>(node_.get());
-    // Prime all HSV thresholds: the ctor leaves min_/max_hsv_* unset, and only
-    // the on-set-parameter callback builds them (rebuilding ALL bands from
-    // hsv_config_ on any change), so setting one param to its default suffices.
-    // TODO(follow-up): drop this once the ctor initializes the thresholds.
-    node_->set_parameter(rclcpp::Parameter("green_min_h", 50));
-  }
-
-  std::shared_ptr<rclcpp::Node> node_;
-  std::unique_ptr<tl::ColorClassifier> classifier_;
+  tl::ColorClassifierCore core_;
 };
 
 // One batched call classifies each in-band solid into its HSV band.
-TEST_F(ColorClassifierTest, ClassifiesByHsvBand)
+TEST_F(ColorClassifierCoreTest, ClassifiesByHsvBand)
 {
   // Arrange
   const std::vector<cv::Mat> images{green_image, amber_image, red_image};
-  TrafficLightArray signals;
-  signals.signals.resize(images.size());
 
   // Act
-  const bool ok = classifier_->getTrafficSignals(images, signals);
+  const auto result = core_.classify(images);
 
   // Assert
-  ASSERT_TRUE(ok);
-  ASSERT_EQ(signals.signals.size(), 3u);
+  ASSERT_TRUE(result.success);
+  ASSERT_EQ(result.signals.signals.size(), 3u);
   // Each classified image yields exactly one element; element_at() reads .at(0),
   // so pin the count here rather than discover a regression via a thrown .at().
-  for (const auto & signal : signals.signals) {
+  for (const auto & signal : result.signals.signals) {
     ASSERT_EQ(signal.elements.size(), 1u);
   }
-  EXPECT_EQ(element_at(signals, 0).color, TrafficLightElement::GREEN);
-  EXPECT_EQ(element_at(signals, 1).color, TrafficLightElement::AMBER);
-  EXPECT_EQ(element_at(signals, 2).color, TrafficLightElement::RED);
+  EXPECT_EQ(element_at(result.signals, 0).color, TrafficLightElement::GREEN);
+  EXPECT_EQ(element_at(result.signals, 1).color, TrafficLightElement::AMBER);
+  EXPECT_EQ(element_at(result.signals, 2).color, TrafficLightElement::RED);
 }
 
 // An image outside every color band yields UNKNOWN with zero confidence.
-TEST_F(ColorClassifierTest, OutOfBandImageIsUnknown)
+TEST_F(ColorClassifierCoreTest, OutOfBandImageIsUnknown)
 {
   // Arrange
   const std::vector<cv::Mat> images{black_image};
-  TrafficLightArray signals;
-  signals.signals.resize(1);
 
   // Act
-  const bool ok = classifier_->getTrafficSignals(images, signals);
+  const auto result = core_.classify(images);
 
   // Assert
-  ASSERT_TRUE(ok);
-  ASSERT_EQ(signals.signals.size(), 1u);
-  EXPECT_EQ(element_at(signals, 0).color, TrafficLightElement::UNKNOWN);
-  EXPECT_EQ(element_at(signals, 0).confidence, 0.0f);
+  ASSERT_TRUE(result.success);
+  ASSERT_EQ(result.signals.signals.size(), 1u);
+  EXPECT_EQ(element_at(result.signals, 0).color, TrafficLightElement::UNKNOWN);
+  EXPECT_EQ(element_at(result.signals, 0).confidence, 0.0f);
 }
 
 // A matched color below the saturation pixel count reports confidence strictly
 // inside (0, 1) -- enough to confirm a match scores positive without yet hitting
 // the clamp (the clamp itself is covered by SaturatedConfidenceClampsToOne).
-TEST_F(ColorClassifierTest, MatchedConfidenceIsPositiveAndBounded)
+TEST_F(ColorClassifierCoreTest, MatchedConfidenceIsPositiveAndBounded)
 {
   // Arrange
   const std::vector<cv::Mat> images{green_image};  // unsaturated_side -> below clamp
-  TrafficLightArray signals;
-  signals.signals.resize(1);
 
   // Act
-  const bool ok = classifier_->getTrafficSignals(images, signals);
+  const auto result = core_.classify(images);
 
   // Assert
-  ASSERT_TRUE(ok);
-  ASSERT_EQ(signals.signals.size(), 1u);
-  EXPECT_GT(element_at(signals, 0).confidence, 0.0f);
-  EXPECT_LT(element_at(signals, 0).confidence, 1.0f);
+  ASSERT_TRUE(result.success);
+  ASSERT_EQ(result.signals.signals.size(), 1u);
+  EXPECT_GT(element_at(result.signals, 0).confidence, 0.0f);
+  EXPECT_LT(element_at(result.signals, 0).confidence, 1.0f);
 }
 
 // CHARACTERIZATION (remove on promotion to a contract test): a match with enough
@@ -177,70 +160,92 @@ TEST_F(ColorClassifierTest, MatchedConfidenceIsPositiveAndBounded)
 // std::min(1.0, ...) upper bound. This pins the current pixel-count formula; a
 // contract test would instead assert "a strong-enough match reaches 1.0" without
 // depending on the 20*20 threshold.
-TEST_F(ColorClassifierTest, SaturatedConfidenceClampsToOne)
+TEST_F(ColorClassifierCoreTest, SaturatedConfidenceClampsToOne)
 {
   // Arrange
   const std::vector<cv::Mat> images{green_image_saturated};  // saturated_side -> at/over clamp
-  TrafficLightArray signals;
-  signals.signals.resize(1);
 
   // Act
-  const bool ok = classifier_->getTrafficSignals(images, signals);
+  const auto result = core_.classify(images);
 
   // Assert
-  ASSERT_TRUE(ok);
-  ASSERT_EQ(signals.signals.size(), 1u);
-  EXPECT_EQ(element_at(signals, 0).color, TrafficLightElement::GREEN);
-  EXPECT_EQ(element_at(signals, 0).confidence, 1.0f);
+  ASSERT_TRUE(result.success);
+  ASSERT_EQ(result.signals.signals.size(), 1u);
+  EXPECT_EQ(element_at(result.signals, 0).color, TrafficLightElement::GREEN);
+  EXPECT_EQ(element_at(result.signals, 0).confidence, 1.0f);
 }
 
 // The thresholds actually drive classification: narrowing the green band to
-// exclude the green image's hue turns its result from GREEN into UNKNOWN.
-TEST_F(ColorClassifierTest, ConfigDrivesClassification)
+// exclude the green image's hue turns its result from GREEN into UNKNOWN. Also
+// exercises set_config() rebuilding the bands.
+TEST_F(ColorClassifierCoreTest, ConfigDrivesClassification)
 {
   // Arrange
-  node_->set_parameter(rclcpp::Parameter("green_max_h", 60));  // green hue 85 now out of band
+  tl::HSVConfig config;     // defaults
+  config.green_max_h = 60;  // green hue 85 now out of band
+  core_.set_config(config);
   const std::vector<cv::Mat> images{green_image};
-  TrafficLightArray signals;
-  signals.signals.resize(1);
 
   // Act
-  const bool ok = classifier_->getTrafficSignals(images, signals);
+  const auto result = core_.classify(images);
 
   // Assert
-  ASSERT_TRUE(ok);
-  ASSERT_EQ(signals.signals.size(), 1u);
-  EXPECT_EQ(element_at(signals, 0).color, TrafficLightElement::UNKNOWN);
-}
-
-// A mismatched images/signals count is rejected.
-TEST_F(ColorClassifierTest, MismatchedSizesReturnFalse)
-{
-  // Arrange
-  const std::vector<cv::Mat> images{green_image};
-  TrafficLightArray signals;
-  signals.signals.resize(2);
-
-  // Act
-  const bool ok = classifier_->getTrafficSignals(images, signals);
-
-  // Assert
-  EXPECT_FALSE(ok);
+  ASSERT_TRUE(result.success);
+  ASSERT_EQ(result.signals.signals.size(), 1u);
+  EXPECT_EQ(element_at(result.signals, 0).color, TrafficLightElement::UNKNOWN);
 }
 
 // An empty batch is a successful no-op.
-TEST_F(ColorClassifierTest, EmptyBatchReturnsTrue)
+TEST_F(ColorClassifierCoreTest, EmptyBatchSucceeds)
 {
   // Arrange
   const std::vector<cv::Mat> images;
-  TrafficLightArray signals;
 
   // Act
-  const bool ok = classifier_->getTrafficSignals(images, signals);
+  const auto result = core_.classify(images);
 
   // Assert
-  EXPECT_TRUE(ok);
-  EXPECT_TRUE(signals.signals.empty());
+  EXPECT_TRUE(result.success);
+  EXPECT_TRUE(result.signals.signals.empty());
+}
+
+// CHARACTERIZATION (pins the current debug-mosaic layout, a visualization format
+// rather than a stable contract): make_debug_image lays out a 3-column x 4-row
+// mosaic of the ROI -- a raw row on top, then the green / yellow / red rows, each
+// showing filtered | binarized | denoised -- rendered in color. A non-square ROI
+// makes an accidental rows/cols swap detectable.
+TEST_F(ColorClassifierCoreTest, DebugImageMosaicGeometry)
+{
+  // Arrange -- distinct width and height so the 3x vs 4x factors can't be confused.
+  const int roi_width = 12;
+  const int roi_height = 8;
+  cv::Mat roi;
+  cv::cvtColor(
+    cv::Mat(roi_height, roi_width, CV_8UC3, cv::Scalar(85, 150, 200)), roi, cv::COLOR_HSV2BGR);
+
+  // Act
+  const cv::Mat debug_image = core_.make_debug_image(roi);
+
+  // Assert
+  EXPECT_EQ(debug_image.cols, roi_width * 3);
+  EXPECT_EQ(debug_image.rows, roi_height * 4);
+  EXPECT_EQ(debug_image.type(), CV_8UC3);
+}
+
+// The mosaic is input-dependent: two same-sized ROIs of different colors produce
+// different mosaics (their raw strips and lit color panels both differ). Robust
+// against the exact layout -- it only pins that make_debug_image renders the
+// input rather than a constant/blank image.
+TEST_F(ColorClassifierCoreTest, DebugImageReflectsInput)
+{
+  // Act
+  const cv::Mat green_debug = core_.make_debug_image(green_image);
+  const cv::Mat red_debug = core_.make_debug_image(red_image);
+
+  // Assert
+  ASSERT_EQ(green_debug.size(), red_debug.size());
+  ASSERT_EQ(green_debug.type(), red_debug.type());
+  EXPECT_GT(cv::norm(green_debug, red_debug, cv::NORM_INF), 0.0);
 }
 
 }  // namespace
@@ -248,8 +253,5 @@ TEST_F(ColorClassifierTest, EmptyBatchReturnsTrue)
 int main(int argc, char ** argv)
 {
   testing::InitGoogleTest(&argc, argv);
-  rclcpp::init(argc, argv);
-  const int ret = RUN_ALL_TESTS();
-  rclcpp::shutdown();
-  return ret;
+  return RUN_ALL_TESTS();
 }

--- a/perception/autoware_traffic_light_classifier/test/test_color_classifier.cpp
+++ b/perception/autoware_traffic_light_classifier/test/test_color_classifier.cpp
@@ -13,17 +13,10 @@
 // limitations under the License.
 
 //
-// Unit tests for the ROS-free ColorClassifierCore.
+// Unit tests for ColorClassifierCore.
 //
-// The core is constructed directly from an HSVConfig and its classify() /
-// make_debug_image() are exercised over in-memory cv::Mat inputs -- no rclcpp,
-// no node, no parameters. (Earlier revisions drove this through the ROS
-// ColorClassifier adapter and a hosted node; the Act now talks to the core
-// directly, but the classification assertions are unchanged.)
-//
-// The adapter-only concerns (the images/signals size guard, logging, debug-image
-// publishing) live at other layers -- see test_color_classifier_adapter and
-// test_traffic_light_classifier_integration.
+// The core is constructed from an HSVConfig and its classify() and
+// make_debug_image() are exercised over in-memory cv::Mat inputs.
 //
 // Tests follow Arrange-Act-Assert.
 //

--- a/perception/autoware_traffic_light_classifier/test/test_color_classifier.cpp
+++ b/perception/autoware_traffic_light_classifier/test/test_color_classifier.cpp
@@ -131,6 +131,30 @@ TEST(ColorClassifierCoreTest, OutOfBandImageIsUnknown)
   EXPECT_EQ(element_at(result.signals, 0).confidence, 0.0f);
 }
 
+// Ambiguous evidence -- strong but split between two colors -- yields UNKNOWN
+// rather than an arbitrary pick. This pins the "strict dominance" design: a color
+// wins only when its ratio strictly beats BOTH others, so a tie falls through to
+// UNKNOWN. Distinct from OutOfBandImageIsUnknown, where there is no evidence at
+// all; here each half is individually a confident match (see ClassifiesByHsvBand).
+TEST(ColorClassifierCoreTest, AmbiguousEvidenceIsUnknown)
+{
+  // Arrange -- half green / half red. Equal-sized blocks keep the green and red
+  // pixel counts symmetric through the mirror-symmetric erode/dilate, so
+  // green_ratio == red_ratio exactly and neither strictly dominates.
+  tl::ColorClassifierCore core;
+  cv::Mat ambiguous_image;
+  cv::hconcat(green_image, red_image, ambiguous_image);
+  const std::vector<cv::Mat> images{ambiguous_image};
+
+  // Act
+  const auto result = core.classify(images);
+
+  // Assert
+  ASSERT_TRUE(result.success);
+  ASSERT_EQ(result.signals.signals.size(), 1u);
+  EXPECT_EQ(element_at(result.signals, 0).color, TrafficLightElement::UNKNOWN);
+}
+
 // A matched color below the saturation pixel count reports confidence strictly
 // inside (0, 1) -- enough to confirm a match scores positive without yet hitting
 // the clamp (the clamp itself is covered by SaturatedConfidenceClampsToOne).

--- a/perception/autoware_traffic_light_classifier/test/test_color_classifier.cpp
+++ b/perception/autoware_traffic_light_classifier/test/test_color_classifier.cpp
@@ -91,22 +91,15 @@ const TrafficLightElement & element_at(const TrafficLightArray & signals, std::s
   return signals.signals.at(slot).elements.at(0);
 }
 
-// A default-configured core. The constructor builds the HSV bands from the
-// default HSVConfig, so no priming is needed.
-class ColorClassifierCoreTest : public ::testing::Test
-{
-protected:
-  tl::ColorClassifierCore core_;
-};
-
 // One batched call classifies each in-band solid into its HSV band.
-TEST_F(ColorClassifierCoreTest, ClassifiesByHsvBand)
+TEST(ColorClassifierCoreTest, ClassifiesByHsvBand)
 {
   // Arrange
+  tl::ColorClassifierCore core;
   const std::vector<cv::Mat> images{green_image, amber_image, red_image};
 
   // Act
-  const auto result = core_.classify(images);
+  const auto result = core.classify(images);
 
   // Assert
   ASSERT_TRUE(result.success);
@@ -122,13 +115,14 @@ TEST_F(ColorClassifierCoreTest, ClassifiesByHsvBand)
 }
 
 // An image outside every color band yields UNKNOWN with zero confidence.
-TEST_F(ColorClassifierCoreTest, OutOfBandImageIsUnknown)
+TEST(ColorClassifierCoreTest, OutOfBandImageIsUnknown)
 {
   // Arrange
+  tl::ColorClassifierCore core;
   const std::vector<cv::Mat> images{black_image};
 
   // Act
-  const auto result = core_.classify(images);
+  const auto result = core.classify(images);
 
   // Assert
   ASSERT_TRUE(result.success);
@@ -140,13 +134,14 @@ TEST_F(ColorClassifierCoreTest, OutOfBandImageIsUnknown)
 // A matched color below the saturation pixel count reports confidence strictly
 // inside (0, 1) -- enough to confirm a match scores positive without yet hitting
 // the clamp (the clamp itself is covered by SaturatedConfidenceClampsToOne).
-TEST_F(ColorClassifierCoreTest, MatchedConfidenceIsPositiveAndBounded)
+TEST(ColorClassifierCoreTest, MatchedConfidenceIsPositiveAndBounded)
 {
   // Arrange
+  tl::ColorClassifierCore core;
   const std::vector<cv::Mat> images{green_image};  // unsaturated_side -> below clamp
 
   // Act
-  const auto result = core_.classify(images);
+  const auto result = core.classify(images);
 
   // Assert
   ASSERT_TRUE(result.success);
@@ -160,13 +155,14 @@ TEST_F(ColorClassifierCoreTest, MatchedConfidenceIsPositiveAndBounded)
 // std::min(1.0, ...) upper bound. This pins the current pixel-count formula; a
 // contract test would instead assert "a strong-enough match reaches 1.0" without
 // depending on the 20*20 threshold.
-TEST_F(ColorClassifierCoreTest, SaturatedConfidenceClampsToOne)
+TEST(ColorClassifierCoreTest, SaturatedConfidenceClampsToOne)
 {
   // Arrange
+  tl::ColorClassifierCore core;
   const std::vector<cv::Mat> images{green_image_saturated};  // saturated_side -> at/over clamp
 
   // Act
-  const auto result = core_.classify(images);
+  const auto result = core.classify(images);
 
   // Assert
   ASSERT_TRUE(result.success);
@@ -178,16 +174,17 @@ TEST_F(ColorClassifierCoreTest, SaturatedConfidenceClampsToOne)
 // The thresholds actually drive classification: narrowing the green band to
 // exclude the green image's hue turns its result from GREEN into UNKNOWN. Also
 // exercises set_config() rebuilding the bands.
-TEST_F(ColorClassifierCoreTest, ConfigDrivesClassification)
+TEST(ColorClassifierCoreTest, ConfigDrivesClassification)
 {
   // Arrange
+  tl::ColorClassifierCore core;
   tl::HSVConfig config;     // defaults
   config.green_max_h = 60;  // green hue 85 now out of band
-  core_.set_config(config);
+  core.set_config(config);
   const std::vector<cv::Mat> images{green_image};
 
   // Act
-  const auto result = core_.classify(images);
+  const auto result = core.classify(images);
 
   // Assert
   ASSERT_TRUE(result.success);
@@ -196,13 +193,14 @@ TEST_F(ColorClassifierCoreTest, ConfigDrivesClassification)
 }
 
 // An empty batch is a successful no-op.
-TEST_F(ColorClassifierCoreTest, EmptyBatchSucceeds)
+TEST(ColorClassifierCoreTest, EmptyBatchSucceeds)
 {
   // Arrange
+  tl::ColorClassifierCore core;
   const std::vector<cv::Mat> images;
 
   // Act
-  const auto result = core_.classify(images);
+  const auto result = core.classify(images);
 
   // Assert
   EXPECT_TRUE(result.success);
@@ -214,9 +212,10 @@ TEST_F(ColorClassifierCoreTest, EmptyBatchSucceeds)
 // mosaic of the ROI -- a raw row on top, then the green / yellow / red rows, each
 // showing filtered | binarized | denoised -- rendered in color. A non-square ROI
 // makes an accidental rows/cols swap detectable.
-TEST_F(ColorClassifierCoreTest, DebugImageMosaicGeometry)
+TEST(ColorClassifierCoreTest, DebugImageMosaicGeometry)
 {
   // Arrange -- distinct width and height so the 3x vs 4x factors can't be confused.
+  tl::ColorClassifierCore core;
   const int roi_width = 12;
   const int roi_height = 8;
   cv::Mat roi;
@@ -224,7 +223,7 @@ TEST_F(ColorClassifierCoreTest, DebugImageMosaicGeometry)
     cv::Mat(roi_height, roi_width, CV_8UC3, cv::Scalar(85, 150, 200)), roi, cv::COLOR_HSV2BGR);
 
   // Act
-  const cv::Mat debug_image = core_.make_debug_image(roi);
+  const cv::Mat debug_image = core.make_debug_image(roi);
 
   // Assert
   EXPECT_EQ(debug_image.cols, roi_width * 3);
@@ -236,11 +235,14 @@ TEST_F(ColorClassifierCoreTest, DebugImageMosaicGeometry)
 // different mosaics (their raw strips and lit color panels both differ). Robust
 // against the exact layout -- it only pins that make_debug_image renders the
 // input rather than a constant/blank image.
-TEST_F(ColorClassifierCoreTest, DebugImageReflectsInput)
+TEST(ColorClassifierCoreTest, DebugImageReflectsInput)
 {
+  // Arrange
+  tl::ColorClassifierCore core;
+
   // Act
-  const cv::Mat green_debug = core_.make_debug_image(green_image);
-  const cv::Mat red_debug = core_.make_debug_image(red_image);
+  const cv::Mat green_debug = core.make_debug_image(green_image);
+  const cv::Mat red_debug = core.make_debug_image(red_image);
 
   // Assert
   ASSERT_EQ(green_debug.size(), red_debug.size());

--- a/perception/autoware_traffic_light_classifier/test/test_color_classifier_adapter.cpp
+++ b/perception/autoware_traffic_light_classifier/test/test_color_classifier_adapter.cpp
@@ -1,0 +1,70 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//
+// ROS adapter tests for ColorClassifier.
+//
+// Classification behavior is covered ROS-free in test_color_classifier (against
+// ColorClassifierCore). This file pins the one adapter concern that cannot move
+// to the core because it depends on the node: the images/signals size guard in
+// getTrafficSignals. The guard protects the element-merge loop from an
+// out-of-range access when the caller's signal count disagrees with the images,
+// so a regression here is a memory-safety bug, not just a wrong return value.
+//
+
+#include "../src/classifier/color_classifier.hpp"
+
+#include <opencv2/core.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <tier4_perception_msgs/msg/traffic_light_array.hpp>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <vector>
+
+namespace
+{
+namespace tl = autoware::traffic_light;
+
+using tier4_perception_msgs::msg::TrafficLightArray;
+
+// A mismatched images/signals count is rejected before any per-slot access.
+TEST(ColorClassifierAdapterTest, MismatchedSizesReturnFalse)
+{
+  // Arrange
+  auto node = std::make_shared<rclcpp::Node>("color_classifier_adapter_test");
+  tl::ColorClassifier classifier(node.get());
+  const std::vector<cv::Mat> images{cv::Mat(4, 4, CV_8UC3, cv::Scalar(0, 0, 0))};
+  TrafficLightArray signals;
+  signals.signals.resize(2);  // deliberately != images.size()
+
+  // Act
+  const bool ok = classifier.getTrafficSignals(images, signals);
+
+  // Assert
+  EXPECT_FALSE(ok);
+}
+
+}  // namespace
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+  const int ret = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return ret;
+}

--- a/perception/autoware_traffic_light_classifier/test/test_color_classifier_adapter.cpp
+++ b/perception/autoware_traffic_light_classifier/test/test_color_classifier_adapter.cpp
@@ -49,7 +49,7 @@ TEST(ColorClassifierAdapterTest, MismatchedSizesReturnFalse)
   tl::ColorClassifier classifier(node.get());
   const std::vector<cv::Mat> images{cv::Mat(4, 4, CV_8UC3, cv::Scalar(0, 0, 0))};
   TrafficLightArray signals;
-  signals.signals.resize(2);  // deliberately != images.size()
+  signals.signals.resize(2);  // two signals but one image -- the deliberate count mismatch
 
   // Act
   const bool ok = classifier.getTrafficSignals(images, signals);


### PR DESCRIPTION
## Description

Follow-up to #12916, which extracted a Node-free `ColorClassifierCore` but left its unit tests driving through the ROS `ColorClassifier` adapter (hosting an `rclcpp::Node` and priming HSV thresholds via parameters). This PR moves the core　tests onto the core itself and separates the remaining adapter-only concern, so the　classification logic is verified without ROS.

This is a **test-only** change — no production code is touched (`color_classifier.{hpp,cpp}` are byte-identical to `main`).

- **`test_color_classifier.cpp` now exercises `ColorClassifierCore` directly.**
  - The core is constructed from an `HSVConfig` and the tests assert on the `ClassifierResult` returned by `classify()`
  - No node, no parameters, no RMW. Switched from `ament_add_ros_isolated_gtest` to `ament_auto_add_gtest`. The classification / confidence / config assertions are unchanged; only Arrange/Act now talk to the core.
- **Added `make_debug_image` coverage**: mosaic geometry (3 cols × 4 rows, color) and input-dependence (different ROIs produce different mosaics).
- **Extracted the adapter-only concern into `test_color_classifier_adapter.cpp`** (a small ROS-isolated suite): the images/signals size-mismatch guard, which has no meaning at the core layer.
- **Added a new test; an ambiguous-evidence contract test**
  - An image split evenly between two color bands has no strictly-dominant color and must resolve to `UNKNOWN` rather
  than an arbitrary pick — this pins the "strict dominance" branch that no test previously covered.
- Characterization-only assertions (the exact confidence clamp, the mosaic layout) are labelled as such, with a note on what a future contract test would assert instead.

## Related links

**Parent Issue:**

- Follow-up to #12916 (extract a Node-free `ColorClassifierCore`)

## How was this PR tested?

Built and ran the package tests against the latest `main`:

```bash
colcon build --packages-select autoware_traffic_light_classifier --cmake-args -DBUILD_TESTING=ON
```

- `test_color_classifier` (ROS-free core): **9 tests passed**
- `test_color_classifier_adapter` (ROS-isolated): **1 test passed**

## Notes for reviewers

Test-only; production is unchanged from `main`. Reviewing per-commit is recommended — the four commits are self-contained: ROS-free rework + adapter split, fixture removal, ambiguous-evidence coverage, and a comment reword.

## Interface changes

None.

## Effects on system behavior

None.
