### PR TITLE
fix(multi_object_tracker): enforce BOUNDING_BOX output type in PedestrianShapeModel export

### DIFF
--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/shape_model/pedestrian_shape_model.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/shape_model/pedestrian_shape_model.hpp
@@ -24,16 +24,16 @@
 namespace autoware::multi_object_tracker
 {
 
-// Manages shape extension (length, width, height, output type) for PedestrianTracker.
+// Manages shape extension (length, width, height) for PedestrianTracker.
 // All input shape types (BOUNDING_BOX, CYLINDER, POLYGON) are accepted.
 // Internally always stores BOUNDING_BOX {length, width, height} in tracker heading frame.
-// Output type (BOUNDING_BOX or CYLINDER) is decided at export time based on shape symmetry.
+// Output type is always BOUNDING_BOX with explicit length and width.
 //
 // Data flow:
 //   init()    — force all input types to internal BOUNDING_BOX; apply model-derived sanity bounds
 //   update()  — 3-branch update by input type (BBOX / CYLINDER / POLYGON);
 //               gains differ by type and trust_extension
-//   exportTo() — assemble output with correct shape type
+//   exportTo() — assemble output as a BOUNDING_BOX filling length and width
 class PedestrianShapeModel : public ShapeModelBase
 {
 public:

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/shape_model/pedestrian_shape_model.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/shape_model/pedestrian_shape_model.hpp
@@ -43,14 +43,9 @@ public:
   void init(const types::DynamicObject & object);
 
   // Update shape from new measurement.
-  // trust_extension: whether the channel provides reliable size measurements.
-  // tracker_yaw: current tracker heading; required for POLYGON branch.
-  // Returns false if update was rejected (implausible dimensions).
   bool update(const types::DynamicObject & object, bool trust_extension, double tracker_yaw);
 
   // Write shape into output object.
-  // Output type is CYLINDER when shape is nearly symmetric and not inflated; otherwise
-  // BOUNDING_BOX.
   void exportTo(types::DynamicObject & output) const;
 
 private:

--- a/perception/autoware_multi_object_tracker/lib/tracker/shape_model/pedestrian_shape_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/shape_model/pedestrian_shape_model.cpp
@@ -125,21 +125,11 @@ bool PedestrianShapeModel::update(
 
 void PedestrianShapeModel::exportTo(types::DynamicObject & output) const
 {
-  const double asymmetry = std::abs(length_ - width_) / std::max({length_, width_, 1e-6});
-
-  if (asymmetry < 0.15) {
-    // Nearly circular → CYLINDER
-    const double diameter = (length_ + width_) * 0.5;
-    output.shape.type = Shape::CYLINDER;
-    output.shape.dimensions.x = diameter;
-    output.shape.dimensions.y = diameter;
-    output.shape.dimensions.z = height_;
-  } else {
-    output.shape.type = Shape::BOUNDING_BOX;
-    output.shape.dimensions.x = length_;
-    output.shape.dimensions.y = width_;
-    output.shape.dimensions.z = height_;
-  }
+  // Always export a BOUNDING_BOX with explicit length (x) and width (y).
+  output.shape.type = Shape::BOUNDING_BOX;
+  output.shape.dimensions.x = length_;
+  output.shape.dimensions.y = width_;
+  output.shape.dimensions.z = height_;
   output.shape.footprint.points.clear();
   output.area = types::getArea(output.shape);
 }

--- a/perception/autoware_multi_object_tracker/lib/tracker/trackers/pedestrian_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/trackers/pedestrian_tracker.cpp
@@ -154,7 +154,7 @@ bool PedestrianTracker::getTrackedObject(
     updateCache(object, time);
   }
 
-  // Export shape from extend manager (type selection: CYLINDER vs BOUNDING_BOX)
+  // Export shape from extend manager
   assembleShapeTo(object, to_publish);
 
   if (to_publish) {


### PR DESCRIPTION
## Description

`PedestrianShapeModel::exportTo()` previously switched its output shape type between `CYLINDER` and `BOUNDING_BOX` based on a length/width asymmetry heuristic (nearly-circular footprints were exported as `CYLINDER`). This made the pedestrian tracker's output shape type unstable and inconsistent for downstream consumers.

This change enforces a single, explicit output contract: `PedestrianShapeModel` always exports a `BOUNDING_BOX` with explicit `length` (x) and `width` (y). Input shape types (`BOUNDING_BOX`, `CYLINDER`, `POLYGON`) are still all accepted and normalized internally to a bounding box; only the export path is simplified. The header documentation is updated to match.

## Related links

**Parent Issue:**

- Link

## How was this PR tested?

- Built `autoware_multi_object_tracker` locally.
- Existing `multi_object_tracker` unit tests pass.

## Notes for reviewers

The asymmetry-based `CYLINDER` vs `BOUNDING_BOX` branch is removed from `exportTo()`; footprint is cleared and `area` recomputed as before.

## Interface changes

None. (Message/topic/parameter interfaces unchanged; only the exported `shape.type` value produced by the pedestrian tracker changes from a heuristic choice to always `BOUNDING_BOX`.)

## Effects on system behavior

Pedestrian tracks are now always published with `shape.type == BOUNDING_BOX`. Previously, near-symmetric pedestrian footprints could be published as `CYLINDER`. Downstream consumers relying on `CYLINDER` output for pedestrians will now receive equivalent bounding boxes.
