### PR TITLE
refactor(autoware_traffic_light_classifier): clean up ColorClassifier config handling and dead code

### DIFF
--- a/perception/autoware_traffic_light_classifier/src/classifier/color_classifier.cpp
+++ b/perception/autoware_traffic_light_classifier/src/classifier/color_classifier.cpp
@@ -233,34 +233,41 @@ bool update_param(
   }
   return false;
 }
+
+// Declare the 18 HSV threshold parameters on `node`, seeding each from the HSVConfig
+// defaults, and return the resulting config. Lets the constructor build the core's
+// thresholds in a single pass instead of default-constructing then reconfiguring.
+HSVConfig declare_hsv_config(rclcpp::Node * node)
+{
+  HSVConfig config;
+  config.green_min_h = node->declare_parameter("green_min_h", config.green_min_h);
+  config.green_min_s = node->declare_parameter("green_min_s", config.green_min_s);
+  config.green_min_v = node->declare_parameter("green_min_v", config.green_min_v);
+  config.green_max_h = node->declare_parameter("green_max_h", config.green_max_h);
+  config.green_max_s = node->declare_parameter("green_max_s", config.green_max_s);
+  config.green_max_v = node->declare_parameter("green_max_v", config.green_max_v);
+  config.yellow_min_h = node->declare_parameter("yellow_min_h", config.yellow_min_h);
+  config.yellow_min_s = node->declare_parameter("yellow_min_s", config.yellow_min_s);
+  config.yellow_min_v = node->declare_parameter("yellow_min_v", config.yellow_min_v);
+  config.yellow_max_h = node->declare_parameter("yellow_max_h", config.yellow_max_h);
+  config.yellow_max_s = node->declare_parameter("yellow_max_s", config.yellow_max_s);
+  config.yellow_max_v = node->declare_parameter("yellow_max_v", config.yellow_max_v);
+  config.red_min_h = node->declare_parameter("red_min_h", config.red_min_h);
+  config.red_min_s = node->declare_parameter("red_min_s", config.red_min_s);
+  config.red_min_v = node->declare_parameter("red_min_v", config.red_min_v);
+  config.red_max_h = node->declare_parameter("red_max_h", config.red_max_h);
+  config.red_max_s = node->declare_parameter("red_max_s", config.red_max_s);
+  config.red_max_v = node->declare_parameter("red_max_v", config.red_max_v);
+  return config;
+}
 }  // namespace
 
-ColorClassifier::ColorClassifier(rclcpp::Node * node_ptr) : node_ptr_(node_ptr)
+ColorClassifier::ColorClassifier(rclcpp::Node * node_ptr)
+: node_ptr_(node_ptr), hsv_config_(declare_hsv_config(node_ptr)), core_(hsv_config_)
 {
   using std::placeholders::_1;
   image_pub_ = image_transport::create_publisher(
     node_ptr_, "~/debug/image", rclcpp::QoS{1}.get_rmw_qos_profile());
-
-  hsv_config_.green_min_h = node_ptr_->declare_parameter("green_min_h", hsv_config_.green_min_h);
-  hsv_config_.green_min_s = node_ptr_->declare_parameter("green_min_s", hsv_config_.green_min_s);
-  hsv_config_.green_min_v = node_ptr_->declare_parameter("green_min_v", hsv_config_.green_min_v);
-  hsv_config_.green_max_h = node_ptr_->declare_parameter("green_max_h", hsv_config_.green_max_h);
-  hsv_config_.green_max_s = node_ptr_->declare_parameter("green_max_s", hsv_config_.green_max_s);
-  hsv_config_.green_max_v = node_ptr_->declare_parameter("green_max_v", hsv_config_.green_max_v);
-  hsv_config_.yellow_min_h = node_ptr_->declare_parameter("yellow_min_h", hsv_config_.yellow_min_h);
-  hsv_config_.yellow_min_s = node_ptr_->declare_parameter("yellow_min_s", hsv_config_.yellow_min_s);
-  hsv_config_.yellow_min_v = node_ptr_->declare_parameter("yellow_min_v", hsv_config_.yellow_min_v);
-  hsv_config_.yellow_max_h = node_ptr_->declare_parameter("yellow_max_h", hsv_config_.yellow_max_h);
-  hsv_config_.yellow_max_s = node_ptr_->declare_parameter("yellow_max_s", hsv_config_.yellow_max_s);
-  hsv_config_.yellow_max_v = node_ptr_->declare_parameter("yellow_max_v", hsv_config_.yellow_max_v);
-  hsv_config_.red_min_h = node_ptr_->declare_parameter("red_min_h", hsv_config_.red_min_h);
-  hsv_config_.red_min_s = node_ptr_->declare_parameter("red_min_s", hsv_config_.red_min_s);
-  hsv_config_.red_min_v = node_ptr_->declare_parameter("red_min_v", hsv_config_.red_min_v);
-  hsv_config_.red_max_h = node_ptr_->declare_parameter("red_max_h", hsv_config_.red_max_h);
-  hsv_config_.red_max_s = node_ptr_->declare_parameter("red_max_s", hsv_config_.red_max_s);
-  hsv_config_.red_max_v = node_ptr_->declare_parameter("red_max_v", hsv_config_.red_max_v);
-
-  core_.set_config(hsv_config_);
 
   // set parameter callback
   set_param_res_ = node_ptr_->add_on_set_parameters_callback(

--- a/perception/autoware_traffic_light_classifier/src/classifier/color_classifier.cpp
+++ b/perception/autoware_traffic_light_classifier/src/classifier/color_classifier.cpp
@@ -35,6 +35,11 @@ void ColorClassifierCore::set_config(const HSVConfig & config)
   update_thresholds();
 }
 
+const HSVConfig & ColorClassifierCore::get_config() const
+{
+  return hsv_config_;
+}
+
 void ColorClassifierCore::update_thresholds()
 {
   min_hsv_green_ =
@@ -263,7 +268,7 @@ HSVConfig declare_hsv_config(rclcpp::Node * node)
 }  // namespace
 
 ColorClassifier::ColorClassifier(rclcpp::Node * node_ptr)
-: node_ptr_(node_ptr), hsv_config_(declare_hsv_config(node_ptr)), core_(hsv_config_)
+: node_ptr_(node_ptr), core_(declare_hsv_config(node_ptr))
 {
   using std::placeholders::_1;
   image_pub_ = image_transport::create_publisher(
@@ -313,26 +318,27 @@ bool ColorClassifier::getTrafficSignals(
 rcl_interfaces::msg::SetParametersResult ColorClassifier::parametersCallback(
   const std::vector<rclcpp::Parameter> & parameters)
 {
-  update_param(parameters, "green_min_h", hsv_config_.green_min_h);
-  update_param(parameters, "green_min_s", hsv_config_.green_min_s);
-  update_param(parameters, "green_min_v", hsv_config_.green_min_v);
-  update_param(parameters, "green_max_h", hsv_config_.green_max_h);
-  update_param(parameters, "green_max_s", hsv_config_.green_max_s);
-  update_param(parameters, "green_max_v", hsv_config_.green_max_v);
-  update_param(parameters, "yellow_min_h", hsv_config_.yellow_min_h);
-  update_param(parameters, "yellow_min_s", hsv_config_.yellow_min_s);
-  update_param(parameters, "yellow_min_v", hsv_config_.yellow_min_v);
-  update_param(parameters, "yellow_max_h", hsv_config_.yellow_max_h);
-  update_param(parameters, "yellow_max_s", hsv_config_.yellow_max_s);
-  update_param(parameters, "yellow_max_v", hsv_config_.yellow_max_v);
-  update_param(parameters, "red_min_h", hsv_config_.red_min_h);
-  update_param(parameters, "red_min_s", hsv_config_.red_min_s);
-  update_param(parameters, "red_min_v", hsv_config_.red_min_v);
-  update_param(parameters, "red_max_h", hsv_config_.red_max_h);
-  update_param(parameters, "red_max_s", hsv_config_.red_max_s);
-  update_param(parameters, "red_max_v", hsv_config_.red_max_v);
+  HSVConfig config = core_.get_config();
+  update_param(parameters, "green_min_h", config.green_min_h);
+  update_param(parameters, "green_min_s", config.green_min_s);
+  update_param(parameters, "green_min_v", config.green_min_v);
+  update_param(parameters, "green_max_h", config.green_max_h);
+  update_param(parameters, "green_max_s", config.green_max_s);
+  update_param(parameters, "green_max_v", config.green_max_v);
+  update_param(parameters, "yellow_min_h", config.yellow_min_h);
+  update_param(parameters, "yellow_min_s", config.yellow_min_s);
+  update_param(parameters, "yellow_min_v", config.yellow_min_v);
+  update_param(parameters, "yellow_max_h", config.yellow_max_h);
+  update_param(parameters, "yellow_max_s", config.yellow_max_s);
+  update_param(parameters, "yellow_max_v", config.yellow_max_v);
+  update_param(parameters, "red_min_h", config.red_min_h);
+  update_param(parameters, "red_min_s", config.red_min_s);
+  update_param(parameters, "red_min_v", config.red_min_v);
+  update_param(parameters, "red_max_h", config.red_max_h);
+  update_param(parameters, "red_max_s", config.red_max_s);
+  update_param(parameters, "red_max_v", config.red_max_v);
 
-  core_.set_config(hsv_config_);
+  core_.set_config(config);
 
   rcl_interfaces::msg::SetParametersResult result;
   result.successful = true;

--- a/perception/autoware_traffic_light_classifier/src/classifier/color_classifier.hpp
+++ b/perception/autoware_traffic_light_classifier/src/classifier/color_classifier.hpp
@@ -88,6 +88,10 @@ public:
   // Replace the HSV thresholds and rebuild the color bands (dynamic reconfigure).
   void set_config(const HSVConfig & config);
 
+  // Current HSV thresholds. The ROS adapter reads these to apply incremental
+  // parameter updates (read-modify-write) without keeping its own copy.
+  const HSVConfig & get_config() const;
+
 private:
   // The three pipeline stages of one color channel: filtered = cv::inRange output,
   // binarized = post-threshold, denoised = post-erode/dilate. classify_element reads
@@ -159,7 +163,6 @@ private:
   rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr set_param_res_;
   rclcpp::Node * node_ptr_;
 
-  HSVConfig hsv_config_;
   ColorClassifierCore core_;
 };
 

--- a/perception/autoware_traffic_light_classifier/src/classifier/color_classifier.hpp
+++ b/perception/autoware_traffic_light_classifier/src/classifier/color_classifier.hpp
@@ -157,7 +157,6 @@ private:
   rcl_interfaces::msg::SetParametersResult parametersCallback(
     const std::vector<rclcpp::Parameter> & parameters);
 
-private:
   image_transport::Publisher image_pub_;
 
   rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr set_param_res_;

--- a/perception/autoware_traffic_light_classifier/src/classifier/color_classifier.hpp
+++ b/perception/autoware_traffic_light_classifier/src/classifier/color_classifier.hpp
@@ -19,7 +19,6 @@
 
 #include <image_transport/image_transport.hpp>
 #include <opencv2/core/core.hpp>
-#include <opencv2/highgui/highgui.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <tier4_perception_msgs/msg/traffic_light_array.hpp>
@@ -155,11 +154,6 @@ private:
     const std::vector<rclcpp::Parameter> & parameters);
 
 private:
-  enum HSV {
-    Hue = 0,
-    Sat = 1,
-    Val = 2,
-  };
   image_transport::Publisher image_pub_;
 
   rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr set_param_res_;


### PR DESCRIPTION
## Description

Follow-up cleanup on `ColorClassifier` after the Node-free `ColorClassifierCore` extraction (#12916). **No behavior change** — this is an internal tidy-up of the `color_classifier` translation unit. Four small, independent refactors (one per commit):

1. **Remove dead code / unused include** — the `enum HSV {Hue, Sat, Val}` in `ColorClassifier` is a leftover from before the core split and is referenced nowhere; `<opencv2/highgui/highgui.hpp>` is unused by this TU (highgui stays available transitively via `classifier_interface.hpp` for downstream consumers).
2. **Build HSV thresholds in one pass at construction** — add a `declare_hsv_config()` helper and initialize `ColorClassifierCore` directly in the constructor initializer list, so the bands are built once from the declared parameters instead of default-constructing the core and then reconfiguring it (which ran `update_thresholds()` twice). Construction-time band building is preserved.
3. **Make the core the single source of the HSV config** — add `ColorClassifierCore::get_config()` and drop the adapter's shadow `HSVConfig` copy; `parametersCallback` now reads the current config back from the core (read-modify-write) instead of maintaining a duplicate.
4. **Merge the redundant `private:` sections** in `ColorClassifier` (the split lost its purpose once the dead enum was removed).

## Related links

**Parent Issue:**

- Follow-up to #12916

## How was this PR tested?

- `colcon build --packages-select autoware_traffic_light_classifier` (Release) — green.
- `colcon test --packages-select autoware_traffic_light_classifier` — **54 tests, 0 failures** (ROS-free `ColorClassifierCore` tests, the ROS-isolated adapter test including the dynamic-reconfigure path, and the integration test), run with `RMW_IMPLEMENTATION=rmw_fastrtps_cpp` and `ROS_LOCALHOST_ONLY=1`.

## Notes for reviewers

Pure internal refactor; public API and node behavior are unchanged. `get_config()` is a new method on the internal `ColorClassifierCore` only (not a node/topic/parameter interface), and exists solely to serve `parametersCallback`'s read-modify-write — it is expected to be removed together with the callback once dynamic reconfigure is moved to the node.

## Interface changes

None.

## Effects on system behavior

None.
