### PR TITLE
feat(autoware_map_based_prediction): add planning-aware prediction fidelity allocation

### DIFF
--- a/perception/autoware_map_based_prediction/CMakeLists.txt
+++ b/perception/autoware_map_based_prediction/CMakeLists.txt
@@ -32,6 +32,7 @@ ament_auto_add_library(map_based_prediction_node SHARED
   lib/predictor_vru/history.cpp
   lib/predictor_vru/traffic_signal.cpp
   lib/predictor_vru/fence.cpp
+  lib/relevance_classifier.cpp
   lib/utils.cpp
 )
 

--- a/perception/autoware_map_based_prediction/README.md
+++ b/perception/autoware_map_based_prediction/README.md
@@ -223,11 +223,13 @@ In the case where the target object is inside the road, the additional path(s) t
 
 ### Input
 
-| Name                                                     | Type                                                    | Description                                                |
-| -------------------------------------------------------- | ------------------------------------------------------- | ---------------------------------------------------------- |
-| `~/perception/object_recognition/tracking/objects`       | `autoware_perception_msgs::msg::TrackedObjects`         | tracking objects without predicted path.                   |
-| `~/vector_map`                                           | `autoware_map_msgs::msg::LaneletMapBin`                 | binary data of Lanelet2 Map.                               |
-| `~/perception/traffic_light_recognition/traffic_signals` | `autoware_perception_msgs::msg::TrafficLightGroupArray` | rearranged information on the corresponding traffic lights |
+| Name                                                     | Type                                                    | Description                                                                 |
+| -------------------------------------------------------- | ------------------------------------------------------- | --------------------------------------------------------------------------- |
+| `~/perception/object_recognition/tracking/objects`       | `autoware_perception_msgs::msg::TrackedObjects`         | tracking objects without predicted path.                                    |
+| `~/vector_map`                                           | `autoware_map_msgs::msg::LaneletMapBin`                 | binary data of Lanelet2 Map.                                                |
+| `~/perception/traffic_light_recognition/traffic_signals` | `autoware_perception_msgs::msg::TrafficLightGroupArray` | rearranged information on the corresponding traffic lights                  |
+| `~/input/ego_trajectory`                                 | `autoware_planning_msgs::msg::Trajectory`               | ego planned trajectory, used only by `planning_aware_prediction` (optional) |
+| `~/input/ego_odometry`                                   | `nav_msgs::msg::Odometry`                               | ego kinematic state, used only by `planning_aware_prediction` (optional)    |
 
 ### Output
 
@@ -257,6 +259,44 @@ In the case where the target object is inside the road, the additional path(s) t
 | `object_buffer_time_length`                                      | [s]   | double | Time span of object history to store the information                                                                                  |
 | `history_time_length`                                            | [s]   | double | Time span of object information used for prediction                                                                                   |
 | `prediction_time_horizon_rate_for_validate_shoulder_lane_length` | [-]   | double | prediction path will disabled when the estimated path length exceeds lanelet length. This parameter control the estimated path length |
+
+### Planning-aware prediction (optional)
+
+Inspired by the "perception in plan" design of end-to-end driving research (e.g. VeteranAD, AAAI 2026),
+this optional feature feeds the planning intent back to prediction so that computational resources are
+concentrated on the traffic participants that matter for the plan, instead of processing every object
+uniformly.
+
+When `planning_aware_prediction.enable` is `true`, each vehicle-class object is classified by its
+relevance to the ego planned trajectory (the previous planning cycle's output):
+
+- **HIGH relevance** — the object is near the ego vehicle, inside a corridor around the planned
+  trajectory (the corridor widens with the arc length to reflect the growing uncertainty of the plan
+  further ahead), or approaching the corridor within `time_to_corridor_threshold`. It receives the
+  full lanelet-based multi-mode prediction (unchanged behavior).
+- **LOW relevance** — everything else. It receives a lightweight constant-velocity prediction with the
+  shorter `low_fidelity_time_horizon`. Nothing is dropped from the output.
+
+Safety design:
+
+- Fail-safe: if the ego trajectory is missing or older than `ego_trajectory_timeout`, every object is
+  treated as HIGH relevance, which is identical to disabling the feature.
+- Hysteresis: promotion to HIGH is immediate; demotion to LOW requires `demote_frame_count`
+  consecutive LOW classifications.
+- Pedestrians, bicycles, and unknown-class objects always receive their regular prediction.
+
+See `design/planning-aware-prediction.md` for details.
+
+| Parameter                                              | Unit     | Type   | Description                                                                    |
+| ------------------------------------------------------ | -------- | ------ | ------------------------------------------------------------------------------ |
+| `planning_aware_prediction.enable`                     | [-]      | bool   | enable planning-aware prediction fidelity allocation (default: `false`)        |
+| `planning_aware_prediction.ego_trajectory_timeout`     | [s]      | double | ego trajectory freshness limit; a stale trajectory disables the classification |
+| `planning_aware_prediction.always_relevant_radius`     | [m]      | double | objects within this distance of the ego vehicle are always HIGH relevance      |
+| `planning_aware_prediction.lateral_margin_base`        | [m]      | double | corridor half width around the planned trajectory at the ego position          |
+| `planning_aware_prediction.lateral_margin_rate`        | [m/m]    | double | corridor half width growth per meter of arc length                             |
+| `planning_aware_prediction.time_to_corridor_threshold` | [s]      | double | objects approaching the corridor within this time are HIGH relevance           |
+| `planning_aware_prediction.demote_frame_count`         | [frames] | int    | consecutive LOW classifications required before demotion                       |
+| `planning_aware_prediction.low_fidelity_time_horizon`  | [s]      | double | prediction horizon of the lightweight prediction for LOW relevance vehicles    |
 
 ## Assumptions / Known limits
 

--- a/perception/autoware_map_based_prediction/config/map_based_prediction.param.yaml
+++ b/perception/autoware_map_based_prediction/config/map_based_prediction.param.yaml
@@ -53,6 +53,20 @@
 
     reference_path_resolution: 0.5 #[m]
 
+    # planning-aware prediction fidelity allocation
+    # Concentrates the expensive lanelet-based multi-mode prediction on the vehicles
+    # relevant to the ego planned trajectory. Low-relevance vehicles receive a
+    # lightweight constant-velocity prediction instead. Disabled by default.
+    planning_aware_prediction:
+      enable: false
+      ego_trajectory_timeout: 1.0 #[s]
+      always_relevant_radius: 20.0 #[m]
+      lateral_margin_base: 3.0 #[m]
+      lateral_margin_rate: 0.1 #[m/m]
+      time_to_corridor_threshold: 5.0 #[s]
+      demote_frame_count: 5 #[frames]
+      low_fidelity_time_horizon: 3.0 #[s]
+
     # debug parameters
     publish_processing_time: false
     publish_processing_time_detail: false

--- a/perception/autoware_map_based_prediction/design/planning-aware-prediction.md
+++ b/perception/autoware_map_based_prediction/design/planning-aware-prediction.md
@@ -1,0 +1,117 @@
+# Planning-Aware Prediction Fidelity Allocation
+
+## Motivation
+
+`map_based_prediction` processes every tracked object uniformly: each vehicle goes through
+lanelet search, maneuver detection, and multi-mode reference path generation, regardless of
+whether the object can ever interact with the ego vehicle's plan. In dense traffic this
+uniform treatment dominates the node's processing time — the package already ships a
+processing-time diagnostic (`processing_time_tolerance`) precisely because this is a known
+operational concern.
+
+Recent end-to-end driving research reached state-of-the-art results by inverting the
+conventional "perception → planning" data flow. VeteranAD ("Perception in Plan: Coupled
+Perception and Planning for End-to-End Autonomous Driving", AAAI 2026) uses planning priors
+(anchored trajectories) to guide perception, concentrating computation on the traffic
+elements along the intended path instead of processing the whole scene uniformly.
+
+This design generalizes that idea to Autoware's modular architecture:
+
+> Do not spend equal computation on information irrelevant to driving. Let the planning
+> intent decide where perception fidelity is needed.
+
+In a modular stack the "planning intent" is readily available: the previous planning cycle's
+trajectory. This feature feeds it back into prediction and grades the prediction fidelity per
+object.
+
+## Architecture
+
+```text
+                       +--------------------------------------+
+   /localization/      |        map_based_prediction          |
+   kinematic_state --->|  +--------------------------------+  |
+                       |  |      RelevanceClassifier       |  |
+   /planning/          |  |  corridor distance + approach  |  |
+   scenario_planning/ ->|  |  test + per-object hysteresis  |  |
+   trajectory          |  +---------------+----------------+  |
+                       |                  |                   |
+   tracking/objects -->|   HIGH relevance | LOW relevance     |
+                       |        v         v                   |
+                       |  full lanelet-   constant-velocity   |
+                       |  based multi-    single-mode path,   |
+                       |  mode prediction short horizon       |
+                       +--------------------------------------+
+```
+
+- `RelevanceClassifier` (`relevance_classifier.hpp` / `lib/relevance_classifier.cpp`) is a
+  pure-logic component with no ROS dependencies beyond message types, so it is unit-testable
+  and reusable by other nodes.
+- The classification is evaluated only for vehicle classes (car, bus, trailer, motorcycle,
+  truck) inside `ObjectsCallback::objectsCallback()`.
+
+### Relevance rules
+
+An object is **HIGH** relevance if any of the following holds:
+
+1. It is within `always_relevant_radius` of the ego vehicle.
+2. Its lateral distance to the planned trajectory polyline is smaller than
+   `lateral_margin_base + lateral_margin_rate * s`, where `s` is the arc length of the
+   nearest trajectory point. The widening corridor reflects the growing uncertainty of the
+   plan further ahead, analogous to how VeteranAD focuses precisely on near-future guide
+   points and more loosely on far-future ones.
+3. Its velocity vector points toward the corridor and the time to reach it is below
+   `time_to_corridor_threshold` (cut-in / crossing precaution).
+
+Everything else is **LOW** relevance and receives `PathGenerator::generatePathForNonVehicleObject()`
+(a constant-velocity straight path — the same generator already used for unknown-class
+objects) with the shorter `low_fidelity_time_horizon`.
+
+## Safety design
+
+This feature allocates fidelity; it never drops objects.
+
+- **Default off.** `planning_aware_prediction.enable` defaults to `false`; the default
+  behavior of the node is bit-identical to the previous implementation.
+- **Fail-safe.** If the ego trajectory has not been received, has fewer than 2 points, or is
+  older than `ego_trajectory_timeout`, every object is classified HIGH — identical to the
+  feature being disabled. A planning outage therefore degrades gracefully to the previous
+  behavior.
+- **Asymmetric hysteresis.** Promotion LOW → HIGH is immediate. Demotion HIGH → LOW requires
+  `demote_frame_count` consecutive LOW classifications. This prevents mode flapping and errs
+  on the side of full fidelity.
+- **VRUs are exempt.** Pedestrians and bicycles always receive their regular prediction:
+  they are safety-critical, and skipping `PredictorVru::predict()` would interfere with the
+  crosswalk-user history bookkeeping (`retrieveUndetectedObjects()` re-emits history entries
+  that were not predicted in the current frame).
+- **Downstream compatibility.** LOW relevance vehicles still appear in the output with a
+  valid single-mode path (`confidence = 1.0`), so downstream planning modules keep seeing
+  every object.
+
+## Debugging
+
+With `publish_debug_markers: true` and the feature enabled, a sphere marker is published per
+vehicle in the `relevance` namespace: green = HIGH, gray = LOW.
+
+For benchmarking, use `publish_processing_time_detail: true` and compare
+`~/debug/processing_time_detail_ms` with the feature enabled and disabled on the same rosbag.
+
+## Future work (generalization roadmap)
+
+The relevance interface deliberately depends only on the planned trajectory and object
+kinematics, so the same classification can guide other perception stages:
+
+- **Prediction (this package):** graded maneuver-mode count and horizon instead of the
+  current binary fidelity split; multi-candidate corridors once planners publish candidate
+  trajectories.
+- **Detection:** prioritized ROI selection for camera detectors along the projected
+  corridor; higher-rate processing of corridor-relevant point cloud regions.
+- **Tracking:** measurement-update rate allocation by relevance.
+- **Occupancy grid:** finer resolution or higher update rates inside the corridor.
+
+Promoting `RelevanceClassifier` to a shared package is intentionally deferred until a second
+consumer exists.
+
+## References
+
+1. B. Zhang, J. Li, N. Song, L. Zhang, "Perception in Plan: Coupled Perception and Planning
+   for End-to-End Autonomous Driving," AAAI 2026.

--- a/perception/autoware_map_based_prediction/include/autoware/map_based_prediction/map_based_prediction_node/callbacks.hpp
+++ b/perception/autoware_map_based_prediction/include/autoware/map_based_prediction/map_based_prediction_node/callbacks.hpp
@@ -20,6 +20,7 @@
 #include "autoware/map_based_prediction/path_generator/path_generator.hpp"
 #include "autoware/map_based_prediction/predictor_vehicle/predictor_vehicle.hpp"
 #include "autoware/map_based_prediction/predictor_vru/predictor_vru.hpp"
+#include "autoware/map_based_prediction/relevance_classifier.hpp"
 
 #include <autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp>
 #include <autoware/agnocast_wrapper/node.hpp>
@@ -29,6 +30,8 @@
 #include <autoware_utils/system/time_keeper.hpp>
 #include <rclcpp/rclcpp.hpp>
 
+#include <autoware_planning_msgs/msg/trajectory.hpp>
+#include <nav_msgs/msg/odometry.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
 #include <chrono>
@@ -36,6 +39,9 @@
 
 namespace autoware::map_based_prediction
 {
+
+using autoware_planning_msgs::msg::Trajectory;
+using nav_msgs::msg::Odometry;
 
 class Diagnostics;
 
@@ -46,6 +52,7 @@ struct NodeState
   std::shared_ptr<PredictorVehicle> predictor_vehicle;
   std::shared_ptr<PredictorVru> predictor_vru;
   std::shared_ptr<PathGenerator> path_generator;
+  std::shared_ptr<RelevanceClassifier> relevance_classifier;
   std::shared_ptr<autoware_utils::TimeKeeper> time_keeper;
 };
 
@@ -81,6 +88,8 @@ private:
   NodeState & state_;
 
   AUTOWARE_POLLING_SUBSCRIBER_PTR(TrafficLightGroupArray) sub_traffic_signals_;
+  AUTOWARE_POLLING_SUBSCRIBER_PTR(Trajectory) sub_ego_trajectory_;
+  AUTOWARE_POLLING_SUBSCRIBER_PTR(Odometry) sub_ego_odometry_;
   TfListener transform_listener_;
   std::unique_ptr<autoware_utils::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_;
 
@@ -91,6 +100,8 @@ private:
 
   void trafficSignalsCallback(
     const AUTOWARE_MESSAGE_CONST_SHARED_PTR(TrafficLightGroupArray) & msg);
+  void updateRelevanceClassifier(const double objects_detected_time);
+  PredictedObject predictLowFidelityVehicle(const TrackedObject & object) const;
   void publish(
     AUTOWARE_MESSAGE_UNIQUE_PTR(PredictedObjects) output,
     const visualization_msgs::msg::MarkerArray & debug_markers) const;

--- a/perception/autoware_map_based_prediction/include/autoware/map_based_prediction/relevance_classifier.hpp
+++ b/perception/autoware_map_based_prediction/include/autoware/map_based_prediction/relevance_classifier.hpp
@@ -1,0 +1,142 @@
+// Copyright 2026 The Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__MAP_BASED_PREDICTION__RELEVANCE_CLASSIFIER_HPP_
+#define AUTOWARE__MAP_BASED_PREDICTION__RELEVANCE_CLASSIFIER_HPP_
+
+#include "autoware/map_based_prediction/data_structure.hpp"
+
+#include <geometry_msgs/msg/point.hpp>
+
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace autoware::map_based_prediction
+{
+
+/**
+ * @brief Relevance of an object to the ego vehicle's planned trajectory.
+ *
+ * HIGH relevance objects receive full-fidelity prediction (lanelet search, maneuver
+ * detection, multi-mode paths). LOW relevance objects receive a lightweight
+ * constant-velocity prediction with a shorter time horizon. Nothing is dropped.
+ */
+enum class Relevance { HIGH, LOW };
+
+struct RelevanceParams
+{
+  bool enable{false};
+  double ego_trajectory_timeout{1.0};      //!< [s] corridor older than this is ignored (fail-safe)
+  double always_relevant_radius{20.0};     //!< [m] objects within this distance of ego are HIGH
+  double lateral_margin_base{3.0};         //!< [m] corridor half width at the ego position
+  double lateral_margin_rate{0.1};         //!< [m/m] corridor half width growth per arc length
+  double time_to_corridor_threshold{5.0};  //!< [s] approaching objects closer in time are HIGH
+  int demote_frame_count{5};               //!< [frames] consecutive LOW frames required to demote
+  double low_fidelity_time_horizon{3.0};   //!< [s] prediction horizon for LOW relevance objects
+};
+
+/**
+ * @brief Distance of a point to a corridor polyline.
+ */
+struct CorridorDistance
+{
+  double lateral_distance;  //!< [m] distance from the point to the nearest polyline point
+  double arc_length;        //!< [m] arc length of the nearest polyline point from the start
+  geometry_msgs::msg::Point nearest_point;  //!< nearest foot point on the polyline
+};
+
+/**
+ * @brief Compute the lateral distance and arc length of a point relative to a polyline.
+ *
+ * The nearest point is searched over all segments; queries beyond the polyline ends are
+ * clamped to the end points.
+ *
+ * @param polyline corridor center line in the map frame (at least 2 points)
+ * @param point query position in the map frame
+ * @return distance decomposition, or std::nullopt if the polyline has fewer than 2 points
+ */
+std::optional<CorridorDistance> computeCorridorDistance(
+  const std::vector<geometry_msgs::msg::Point> & polyline, const geometry_msgs::msg::Point & point);
+
+/**
+ * @brief Classifies tracked objects by their relevance to the ego planned trajectory.
+ *
+ * This class embodies a "perception in plan" design: the planning intent (the previous
+ * planning cycle's trajectory) is fed back to perception so that computational resources
+ * are concentrated on the traffic participants that matter for the plan.
+ *
+ * Safety design:
+ * - Fail-safe: without a fresh ego trajectory every object is HIGH (identical to the
+ *   behavior when the feature is disabled).
+ * - Hysteresis: promotion to HIGH is immediate; demotion to LOW requires
+ *   demote_frame_count consecutive LOW classifications.
+ * - Approach detection: objects moving toward the corridor are promoted before they
+ *   enter it (cut-in and crossing precaution).
+ */
+class RelevanceClassifier
+{
+public:
+  explicit RelevanceClassifier(const RelevanceParams & params);
+
+  void setParams(const RelevanceParams & params) { params_ = params; }
+  const RelevanceParams & getParams() const { return params_; }
+
+  /**
+   * @brief Set the ego data used as the planning prior for the current cycle.
+   * @param trajectory_points planned trajectory positions in the map frame
+   * @param ego_position current ego position in the map frame
+   * @param trajectory_time [s] stamp of the trajectory message
+   */
+  void setEgoData(
+    const std::vector<geometry_msgs::msg::Point> & trajectory_points,
+    const geometry_msgs::msg::Point & ego_position, const double trajectory_time);
+
+  /**
+   * @brief Classify one object and update its hysteresis state.
+   * @param object tracked object (pose in the map frame)
+   * @param current_time [s] stamp of the tracked objects message
+   */
+  Relevance classify(const TrackedObject & object, const double current_time);
+
+  /**
+   * @brief Remove hysteresis entries not observed within buffer_time.
+   */
+  void removeOldHistory(const double current_time, const double buffer_time);
+
+private:
+  struct ObjectState
+  {
+    Relevance relevance{Relevance::HIGH};
+    int consecutive_low_count{0};
+    double last_seen_time{0.0};
+  };
+
+  /**
+   * @brief Stateless single-frame classification (no hysteresis).
+   */
+  Relevance classifyOnce(const TrackedObject & object) const;
+
+  RelevanceParams params_;
+  std::vector<geometry_msgs::msg::Point> trajectory_points_;
+  geometry_msgs::msg::Point ego_position_;
+  double trajectory_time_{0.0};
+  bool has_ego_data_{false};
+  std::unordered_map<std::string, ObjectState> object_states_;
+};
+
+}  // namespace autoware::map_based_prediction
+
+#endif  // AUTOWARE__MAP_BASED_PREDICTION__RELEVANCE_CLASSIFIER_HPP_

--- a/perception/autoware_map_based_prediction/launch/map_based_prediction.launch.xml
+++ b/perception/autoware_map_based_prediction/launch/map_based_prediction.launch.xml
@@ -6,6 +6,8 @@
   <arg name="traffic_signals_topic" default="/perception/traffic_light_recognition/traffic_signals"/>
   <arg name="output_topic" default="objects"/>
   <arg name="input_topic" default="/perception/object_recognition/tracking/objects"/>
+  <arg name="ego_trajectory_topic" default="/planning/scenario_planning/trajectory"/>
+  <arg name="ego_odometry_topic" default="/localization/kinematic_state"/>
 
   <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
 
@@ -15,6 +17,8 @@
     <remap from="/traffic_signals" to="$(var traffic_signals_topic)"/>
     <remap from="~/output/objects" to="$(var output_topic)"/>
     <remap from="~/input/objects" to="$(var input_topic)"/>
+    <remap from="~/input/ego_trajectory" to="$(var ego_trajectory_topic)"/>
+    <remap from="~/input/ego_odometry" to="$(var ego_odometry_topic)"/>
     <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
   </node>
 </launch>

--- a/perception/autoware_map_based_prediction/lib/map_based_prediction_node/callbacks.cpp
+++ b/perception/autoware_map_based_prediction/lib/map_based_prediction_node/callbacks.cpp
@@ -29,10 +29,43 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <vector>
 
 namespace autoware::map_based_prediction
 {
 using autoware_utils::ScopedTimeTrack;
+
+namespace
+{
+
+void appendRelevanceMarker(
+  const TrackedObject & object, const Relevance relevance, const std_msgs::msg::Header & header,
+  visualization_msgs::msg::MarkerArray & debug_markers)
+{
+  visualization_msgs::msg::Marker marker;
+  marker.header = header;
+  marker.ns = "relevance";
+  marker.id = static_cast<int32_t>(debug_markers.markers.size());
+  marker.type = visualization_msgs::msg::Marker::SPHERE;
+  marker.action = visualization_msgs::msg::Marker::ADD;
+  marker.pose = object.kinematics.pose_with_covariance.pose;
+  marker.pose.position.z += 2.0;
+  marker.scale.x = 1.0;
+  marker.scale.y = 1.0;
+  marker.scale.z = 1.0;
+  marker.color.a = 0.8;
+  if (relevance == Relevance::HIGH) {
+    marker.color.g = 1.0;
+  } else {
+    marker.color.r = 0.5;
+    marker.color.g = 0.5;
+    marker.color.b = 0.5;
+  }
+  marker.lifetime = rclcpp::Duration::from_seconds(0.2);
+  debug_markers.markers.push_back(marker);
+}
+
+}  // namespace
 
 // ---------------------------------------------------------------------------
 // MapCallback
@@ -74,6 +107,10 @@ ObjectsCallback::ObjectsCallback(autoware::agnocast_wrapper::Node * node, NodeSt
 {
   sub_traffic_signals_ =
     node->create_polling_subscriber<TrafficLightGroupArray>("/traffic_signals", rclcpp::QoS{1});
+  sub_ego_trajectory_ =
+    node->create_polling_subscriber<Trajectory>("~/input/ego_trajectory", rclcpp::QoS{1});
+  sub_ego_odometry_ =
+    node->create_polling_subscriber<Odometry>("~/input/ego_odometry", rclcpp::QoS{1});
   stop_watch_ptr_ = std::make_unique<autoware_utils::StopWatch<std::chrono::milliseconds>>();
   stop_watch_ptr_->tic("cyclic_time");
   stop_watch_ptr_->tic("processing_time");
@@ -101,6 +138,38 @@ void ObjectsCallback::trafficSignalsCallback(
   state_.predictor_vru->setTrafficSignal(*msg);
 }
 
+void ObjectsCallback::updateRelevanceClassifier(const double objects_detected_time)
+{
+  if (!state_.relevance_classifier || !state_.relevance_classifier->getParams().enable) {
+    return;
+  }
+
+  const auto trajectory_msg = sub_ego_trajectory_->take_data();
+  const auto odometry_msg = sub_ego_odometry_->take_data();
+  if (trajectory_msg && odometry_msg) {
+    std::vector<geometry_msgs::msg::Point> trajectory_points;
+    trajectory_points.reserve(trajectory_msg->points.size());
+    for (const auto & point : trajectory_msg->points) {
+      trajectory_points.push_back(point.pose.position);
+    }
+    state_.relevance_classifier->setEgoData(
+      trajectory_points, odometry_msg->pose.pose.position,
+      rclcpp::Time(trajectory_msg->header.stamp).seconds());
+  }
+  state_.relevance_classifier->removeOldHistory(
+    objects_detected_time, state_.params.object_buffer_time_length);
+}
+
+PredictedObject ObjectsCallback::predictLowFidelityVehicle(const TrackedObject & object) const
+{
+  auto predicted_object = utils::convertToPredictedObject(object);
+  PredictedPath predicted_path = state_.path_generator->generatePathForNonVehicleObject(
+    object, state_.relevance_classifier->getParams().low_fidelity_time_horizon);
+  predicted_path.confidence = 1.0;
+  predicted_object.kinematics.predicted_paths.push_back(predicted_path);
+  return predicted_object;
+}
+
 void ObjectsCallback::objectsCallback(
   const AUTOWARE_MESSAGE_CONST_SHARED_PTR(TrackedObjects) & in_objects)
 {
@@ -126,6 +195,8 @@ void ObjectsCallback::objectsCallback(
   }
 
   const double objects_detected_time = rclcpp::Time(in_objects->header.stamp).seconds();
+
+  updateRelevanceClassifier(objects_detected_time);
 
   state_.predictor_vehicle->removeOldHistory(
     objects_detected_time, state_.params.object_buffer_time_length);
@@ -168,6 +239,23 @@ void ObjectsCallback::objectsCallback(
       case ObjectClassification::TRAILER:
       case ObjectClassification::MOTORCYCLE:
       case ObjectClassification::TRUCK: {
+        // Planning-aware fidelity allocation: vehicles with low relevance to the ego
+        // planned trajectory receive a lightweight constant-velocity prediction instead
+        // of the full lanelet-based multi-mode prediction. VRU classes are always
+        // predicted with full fidelity.
+        const auto relevance =
+          state_.relevance_classifier
+            ? state_.relevance_classifier->classify(transformed_object, objects_detected_time)
+            : Relevance::HIGH;
+        if (
+          pub_debug_markers_ && state_.relevance_classifier &&
+          state_.relevance_classifier->getParams().enable) {
+          appendRelevanceMarker(transformed_object, relevance, output.header, debug_markers);
+        }
+        if (relevance == Relevance::LOW) {
+          output.objects.push_back(predictLowFidelityVehicle(transformed_object));
+          break;
+        }
         const auto predicted_object_opt = state_.predictor_vehicle->predict(
           output.header, transformed_object, objects_detected_time,
           pub_debug_markers_ ? &debug_markers : nullptr);

--- a/perception/autoware_map_based_prediction/lib/relevance_classifier.cpp
+++ b/perception/autoware_map_based_prediction/lib/relevance_classifier.cpp
@@ -1,0 +1,190 @@
+// Copyright 2026 The Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/map_based_prediction/relevance_classifier.hpp"
+
+#include <autoware_utils/ros/uuid_helper.hpp>
+#include <tf2/utils.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <string>
+#include <vector>
+
+namespace autoware::map_based_prediction
+{
+
+namespace
+{
+
+double squaredDistance2d(const geometry_msgs::msg::Point & a, const geometry_msgs::msg::Point & b)
+{
+  const double dx = a.x - b.x;
+  const double dy = a.y - b.y;
+  return dx * dx + dy * dy;
+}
+
+}  // namespace
+
+std::optional<CorridorDistance> computeCorridorDistance(
+  const std::vector<geometry_msgs::msg::Point> & polyline, const geometry_msgs::msg::Point & point)
+{
+  if (polyline.size() < 2) {
+    return std::nullopt;
+  }
+
+  double best_squared_distance = std::numeric_limits<double>::max();
+  double best_arc_length = 0.0;
+  geometry_msgs::msg::Point best_foot = polyline.front();
+  double accumulated_arc_length = 0.0;
+
+  for (size_t i = 0; i + 1 < polyline.size(); ++i) {
+    const auto & p0 = polyline[i];
+    const auto & p1 = polyline[i + 1];
+    const double seg_dx = p1.x - p0.x;
+    const double seg_dy = p1.y - p0.y;
+    const double seg_squared_length = seg_dx * seg_dx + seg_dy * seg_dy;
+
+    double t = 0.0;
+    if (seg_squared_length > std::numeric_limits<double>::epsilon()) {
+      t = ((point.x - p0.x) * seg_dx + (point.y - p0.y) * seg_dy) / seg_squared_length;
+      t = std::clamp(t, 0.0, 1.0);
+    }
+
+    geometry_msgs::msg::Point foot;
+    foot.x = p0.x + t * seg_dx;
+    foot.y = p0.y + t * seg_dy;
+
+    const double squared_distance = squaredDistance2d(point, foot);
+    if (squared_distance < best_squared_distance) {
+      best_squared_distance = squared_distance;
+      best_arc_length = accumulated_arc_length + t * std::sqrt(seg_squared_length);
+      best_foot = foot;
+    }
+    accumulated_arc_length += std::sqrt(seg_squared_length);
+  }
+
+  CorridorDistance result;
+  result.lateral_distance = std::sqrt(best_squared_distance);
+  result.arc_length = best_arc_length;
+  result.nearest_point = best_foot;
+  return result;
+}
+
+RelevanceClassifier::RelevanceClassifier(const RelevanceParams & params) : params_(params)
+{
+}
+
+void RelevanceClassifier::setEgoData(
+  const std::vector<geometry_msgs::msg::Point> & trajectory_points,
+  const geometry_msgs::msg::Point & ego_position, const double trajectory_time)
+{
+  trajectory_points_ = trajectory_points;
+  ego_position_ = ego_position;
+  trajectory_time_ = trajectory_time;
+  has_ego_data_ = true;
+}
+
+Relevance RelevanceClassifier::classify(const TrackedObject & object, const double current_time)
+{
+  // Fail-safe: without a usable planning prior, treat every object as HIGH so that the
+  // behavior is identical to the feature being disabled.
+  const bool corridor_is_stale =
+    !has_ego_data_ || (current_time - trajectory_time_) > params_.ego_trajectory_timeout;
+  if (!params_.enable || corridor_is_stale || trajectory_points_.size() < 2) {
+    return Relevance::HIGH;
+  }
+
+  const auto object_id = autoware_utils::to_hex_string(object.object_id);
+  auto & state = object_states_[object_id];
+  state.last_seen_time = current_time;
+
+  const Relevance one_shot = classifyOnce(object);
+
+  if (one_shot == Relevance::HIGH) {
+    // Promote immediately (safe side).
+    state.relevance = Relevance::HIGH;
+    state.consecutive_low_count = 0;
+    return state.relevance;
+  }
+
+  // Demote only after demote_frame_count consecutive LOW classifications.
+  state.consecutive_low_count += 1;
+  if (state.consecutive_low_count >= params_.demote_frame_count) {
+    state.relevance = Relevance::LOW;
+  }
+  return state.relevance;
+}
+
+Relevance RelevanceClassifier::classifyOnce(const TrackedObject & object) const
+{
+  const auto & object_position = object.kinematics.pose_with_covariance.pose.position;
+
+  // Condition 1: close to the ego vehicle.
+  const double squared_distance_to_ego = squaredDistance2d(object_position, ego_position_);
+  if (squared_distance_to_ego < params_.always_relevant_radius * params_.always_relevant_radius) {
+    return Relevance::HIGH;
+  }
+
+  const auto corridor_distance = computeCorridorDistance(trajectory_points_, object_position);
+  if (!corridor_distance) {
+    return Relevance::HIGH;
+  }
+
+  // Condition 2: inside the corridor. The margin widens with the arc length to reflect
+  // the growing uncertainty of the plan further ahead.
+  const double lateral_margin =
+    params_.lateral_margin_base + params_.lateral_margin_rate * corridor_distance->arc_length;
+  if (corridor_distance->lateral_distance < lateral_margin) {
+    return Relevance::HIGH;
+  }
+
+  // Condition 3: approaching the corridor (cut-in / crossing precaution). The object
+  // twist is given in the object body frame, so rotate it to the map frame first.
+  const double yaw = tf2::getYaw(object.kinematics.pose_with_covariance.pose.orientation);
+  const auto & twist = object.kinematics.twist_with_covariance.twist;
+  const double velocity_x = twist.linear.x * std::cos(yaw) - twist.linear.y * std::sin(yaw);
+  const double velocity_y = twist.linear.x * std::sin(yaw) + twist.linear.y * std::cos(yaw);
+
+  const double toward_corridor_x = corridor_distance->nearest_point.x - object_position.x;
+  const double toward_corridor_y = corridor_distance->nearest_point.y - object_position.y;
+
+  const double distance_to_corridor = std::hypot(toward_corridor_x, toward_corridor_y);
+  if (distance_to_corridor > std::numeric_limits<double>::epsilon()) {
+    const double closing_speed =
+      (velocity_x * toward_corridor_x + velocity_y * toward_corridor_y) / distance_to_corridor;
+    if (closing_speed > std::numeric_limits<double>::epsilon()) {
+      const double time_to_corridor = distance_to_corridor / closing_speed;
+      if (time_to_corridor < params_.time_to_corridor_threshold) {
+        return Relevance::HIGH;
+      }
+    }
+  }
+
+  return Relevance::LOW;
+}
+
+void RelevanceClassifier::removeOldHistory(const double current_time, const double buffer_time)
+{
+  for (auto it = object_states_.begin(); it != object_states_.end();) {
+    if (current_time - it->second.last_seen_time > buffer_time) {
+      it = object_states_.erase(it);
+    } else {
+      ++it;
+    }
+  }
+}
+
+}  // namespace autoware::map_based_prediction

--- a/perception/autoware_map_based_prediction/lib/relevance_classifier.cpp
+++ b/perception/autoware_map_based_prediction/lib/relevance_classifier.cpp
@@ -17,6 +17,8 @@
 #include <autoware_utils/ros/uuid_helper.hpp>
 #include <tf2/utils.hpp>
 
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+
 #include <algorithm>
 #include <cmath>
 #include <limits>

--- a/perception/autoware_map_based_prediction/package.xml
+++ b/perception/autoware_map_based_prediction/package.xml
@@ -23,7 +23,9 @@
   <depend>autoware_motion_utils</depend>
   <depend>autoware_object_recognition_utils</depend>
   <depend>autoware_perception_msgs</depend>
+  <depend>autoware_planning_msgs</depend>
   <depend>autoware_utils</depend>
+  <depend>nav_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>tf2</depend>

--- a/perception/autoware_map_based_prediction/schema/map_based_prediction.schema.json
+++ b/perception/autoware_map_based_prediction/schema/map_based_prediction.schema.json
@@ -276,6 +276,61 @@
         "processing_time_consecutive_excess_tolerance": {
           "type": "number",
           "default": 1.0
+        },
+        "planning_aware_prediction": {
+          "type": "object",
+          "properties": {
+            "enable": {
+              "type": "boolean",
+              "default": false,
+              "description": "enable planning-aware prediction fidelity allocation. When disabled, every object receives full-fidelity prediction (previous behavior)"
+            },
+            "ego_trajectory_timeout": {
+              "type": "number",
+              "default": 1.0,
+              "description": "[s] if the ego planned trajectory is older than this, every object is treated as highly relevant (fail-safe)"
+            },
+            "always_relevant_radius": {
+              "type": "number",
+              "default": 20.0,
+              "description": "[m] objects within this distance of the ego vehicle always receive full-fidelity prediction"
+            },
+            "lateral_margin_base": {
+              "type": "number",
+              "default": 3.0,
+              "description": "[m] corridor half width around the ego planned trajectory at the ego position"
+            },
+            "lateral_margin_rate": {
+              "type": "number",
+              "default": 0.1,
+              "description": "[m/m] corridor half width growth per meter of arc length along the planned trajectory"
+            },
+            "time_to_corridor_threshold": {
+              "type": "number",
+              "default": 5.0,
+              "description": "[s] objects approaching the corridor within this time receive full-fidelity prediction"
+            },
+            "demote_frame_count": {
+              "type": "integer",
+              "default": 5,
+              "description": "[frames] consecutive low-relevance classifications required before an object is demoted to lightweight prediction"
+            },
+            "low_fidelity_time_horizon": {
+              "type": "number",
+              "default": 3.0,
+              "description": "[s] prediction time horizon of the lightweight constant-velocity prediction for low-relevance vehicles"
+            }
+          },
+          "required": [
+            "enable",
+            "ego_trajectory_timeout",
+            "always_relevant_radius",
+            "lateral_margin_base",
+            "lateral_margin_rate",
+            "time_to_corridor_threshold",
+            "demote_frame_count",
+            "low_fidelity_time_horizon"
+          ]
         }
       },
       "required": [
@@ -309,7 +364,8 @@
         "publish_processing_time_detail",
         "publish_debug_markers",
         "processing_time_tolerance",
-        "processing_time_consecutive_excess_tolerance"
+        "processing_time_consecutive_excess_tolerance",
+        "planning_aware_prediction"
       ]
     }
   },

--- a/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
@@ -15,6 +15,7 @@
 #include "map_based_prediction_node.hpp"
 
 #include "autoware/map_based_prediction/params.hpp"
+#include "autoware/map_based_prediction/relevance_classifier.hpp"
 
 #include <autoware_utils/ros/update_param.hpp>
 
@@ -129,6 +130,27 @@ MapBasedPredictionNode::MapBasedPredictionNode(const rclcpp::NodeOptions & node_
   // --- Path generator for unknown-class objects ---
   state_.path_generator = std::make_shared<PathGenerator>(prediction_sampling_dt);
 
+  // --- Planning-aware relevance classifier ---
+  {
+    RelevanceParams relevance_params;
+    relevance_params.enable = declare_parameter<bool>("planning_aware_prediction.enable");
+    relevance_params.ego_trajectory_timeout =
+      declare_parameter<double>("planning_aware_prediction.ego_trajectory_timeout");
+    relevance_params.always_relevant_radius =
+      declare_parameter<double>("planning_aware_prediction.always_relevant_radius");
+    relevance_params.lateral_margin_base =
+      declare_parameter<double>("planning_aware_prediction.lateral_margin_base");
+    relevance_params.lateral_margin_rate =
+      declare_parameter<double>("planning_aware_prediction.lateral_margin_rate");
+    relevance_params.time_to_corridor_threshold =
+      declare_parameter<double>("planning_aware_prediction.time_to_corridor_threshold");
+    relevance_params.demote_frame_count =
+      static_cast<int>(declare_parameter<int64_t>("planning_aware_prediction.demote_frame_count"));
+    relevance_params.low_fidelity_time_horizon =
+      declare_parameter<double>("planning_aware_prediction.low_fidelity_time_horizon");
+    state_.relevance_classifier = std::make_shared<RelevanceClassifier>(relevance_params);
+  }
+
   // --- Node params ---
   state_.params.object_buffer_time_length = declare_parameter<double>("object_buffer_time_length");
   state_.params.remember_lost_crosswalk_users =
@@ -221,6 +243,22 @@ rcl_interfaces::msg::SetParametersResult MapBasedPredictionNode::onParam(
   update_param(
     parameters, "acceleration_exponential_half_life", pp.acceleration_exponential_half_life);
   state_.predictor_vehicle->setParams(vehicle_params);
+
+  auto relevance_params = state_.relevance_classifier->getParams();
+  update_param(parameters, "planning_aware_prediction.enable", relevance_params.enable);
+  update_param(
+    parameters, "planning_aware_prediction.always_relevant_radius",
+    relevance_params.always_relevant_radius);
+  update_param(
+    parameters, "planning_aware_prediction.lateral_margin_base",
+    relevance_params.lateral_margin_base);
+  update_param(
+    parameters, "planning_aware_prediction.lateral_margin_rate",
+    relevance_params.lateral_margin_rate);
+  update_param(
+    parameters, "planning_aware_prediction.time_to_corridor_threshold",
+    relevance_params.time_to_corridor_threshold);
+  state_.relevance_classifier->setParams(relevance_params);
 
   rcl_interfaces::msg::SetParametersResult result;
   result.successful = true;

--- a/perception/autoware_map_based_prediction/test/map_based_prediction/test_relevance_classifier.cpp
+++ b/perception/autoware_map_based_prediction/test/map_based_prediction/test_relevance_classifier.cpp
@@ -1,0 +1,214 @@
+// Copyright 2026 The Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/map_based_prediction/relevance_classifier.hpp"
+
+#include <tf2/LinearMath/Quaternion.hpp>
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+namespace
+{
+
+using autoware::map_based_prediction::computeCorridorDistance;
+using autoware::map_based_prediction::Relevance;
+using autoware::map_based_prediction::RelevanceClassifier;
+using autoware::map_based_prediction::RelevanceParams;
+using autoware_perception_msgs::msg::TrackedObject;
+
+geometry_msgs::msg::Point makePoint(const double x, const double y)
+{
+  geometry_msgs::msg::Point point;
+  point.x = x;
+  point.y = y;
+  return point;
+}
+
+// A straight corridor along the x axis: (0,0) -> (100,0).
+std::vector<geometry_msgs::msg::Point> makeStraightTrajectory()
+{
+  std::vector<geometry_msgs::msg::Point> points;
+  for (int i = 0; i <= 10; ++i) {
+    points.push_back(makePoint(10.0 * i, 0.0));
+  }
+  return points;
+}
+
+TrackedObject makeObject(
+  const double x, const double y, const double yaw, const double velocity, const uint8_t id_seed)
+{
+  TrackedObject object;
+  object.object_id.uuid.fill(id_seed);
+  object.kinematics.pose_with_covariance.pose.position.x = x;
+  object.kinematics.pose_with_covariance.pose.position.y = y;
+  tf2::Quaternion quaternion;
+  quaternion.setRPY(0.0, 0.0, yaw);
+  object.kinematics.pose_with_covariance.pose.orientation.x = quaternion.x();
+  object.kinematics.pose_with_covariance.pose.orientation.y = quaternion.y();
+  object.kinematics.pose_with_covariance.pose.orientation.z = quaternion.z();
+  object.kinematics.pose_with_covariance.pose.orientation.w = quaternion.w();
+  object.kinematics.twist_with_covariance.twist.linear.x = velocity;
+  return object;
+}
+
+RelevanceParams makeEnabledParams()
+{
+  RelevanceParams params;
+  params.enable = true;
+  params.ego_trajectory_timeout = 1.0;
+  params.always_relevant_radius = 20.0;
+  params.lateral_margin_base = 3.0;
+  params.lateral_margin_rate = 0.1;
+  params.time_to_corridor_threshold = 5.0;
+  params.demote_frame_count = 3;
+  params.low_fidelity_time_horizon = 3.0;
+  return params;
+}
+
+}  // namespace
+
+TEST(ComputeCorridorDistance, degenerate_polyline_returns_nullopt)
+{
+  const std::vector<geometry_msgs::msg::Point> empty;
+  EXPECT_FALSE(computeCorridorDistance(empty, makePoint(0.0, 0.0)).has_value());
+
+  const std::vector<geometry_msgs::msg::Point> single{makePoint(0.0, 0.0)};
+  EXPECT_FALSE(computeCorridorDistance(single, makePoint(0.0, 0.0)).has_value());
+}
+
+TEST(ComputeCorridorDistance, lateral_distance_and_arc_length)
+{
+  const auto polyline = makeStraightTrajectory();
+
+  // 5 m beside the corridor at x = 30.
+  const auto result = computeCorridorDistance(polyline, makePoint(30.0, 5.0));
+  ASSERT_TRUE(result.has_value());
+  EXPECT_NEAR(result->lateral_distance, 5.0, 1e-6);
+  EXPECT_NEAR(result->arc_length, 30.0, 1e-6);
+  EXPECT_NEAR(result->nearest_point.x, 30.0, 1e-6);
+  EXPECT_NEAR(result->nearest_point.y, 0.0, 1e-6);
+
+  // Beyond the far end: clamped to the last point.
+  const auto beyond = computeCorridorDistance(polyline, makePoint(110.0, 0.0));
+  ASSERT_TRUE(beyond.has_value());
+  EXPECT_NEAR(beyond->lateral_distance, 10.0, 1e-6);
+  EXPECT_NEAR(beyond->arc_length, 100.0, 1e-6);
+}
+
+TEST(RelevanceClassifier, disabled_returns_high)
+{
+  auto params = makeEnabledParams();
+  params.enable = false;
+  RelevanceClassifier classifier(params);
+  classifier.setEgoData(makeStraightTrajectory(), makePoint(0.0, 0.0), 0.0);
+
+  const auto far_object = makeObject(50.0, 100.0, 0.0, 0.0, 1);
+  EXPECT_EQ(classifier.classify(far_object, 0.0), Relevance::HIGH);
+}
+
+TEST(RelevanceClassifier, stale_trajectory_returns_high)
+{
+  RelevanceClassifier classifier(makeEnabledParams());
+  classifier.setEgoData(makeStraightTrajectory(), makePoint(0.0, 0.0), 0.0);
+
+  const auto far_object = makeObject(50.0, 100.0, 0.0, 0.0, 1);
+  // 2.0 s after the trajectory stamp > ego_trajectory_timeout (1.0 s).
+  EXPECT_EQ(classifier.classify(far_object, 2.0), Relevance::HIGH);
+}
+
+TEST(RelevanceClassifier, no_trajectory_returns_high)
+{
+  RelevanceClassifier classifier(makeEnabledParams());
+  const auto far_object = makeObject(50.0, 100.0, 0.0, 0.0, 1);
+  EXPECT_EQ(classifier.classify(far_object, 0.0), Relevance::HIGH);
+}
+
+TEST(RelevanceClassifier, object_near_ego_is_high)
+{
+  RelevanceClassifier classifier(makeEnabledParams());
+  classifier.setEgoData(makeStraightTrajectory(), makePoint(0.0, 0.0), 0.0);
+
+  // 100 m beside the corridor but only 15 m from ego (within always_relevant_radius).
+  const auto object = makeObject(0.0, 15.0, 0.0, 0.0, 1);
+  EXPECT_EQ(classifier.classify(object, 0.0), Relevance::HIGH);
+}
+
+TEST(RelevanceClassifier, object_inside_corridor_is_high)
+{
+  RelevanceClassifier classifier(makeEnabledParams());
+  classifier.setEgoData(makeStraightTrajectory(), makePoint(0.0, 0.0), 0.0);
+
+  // At arc length 50 the corridor half width is 3.0 + 0.1 * 50 = 8.0 m.
+  const auto object = makeObject(50.0, 7.0, 0.0, 0.0, 1);
+  EXPECT_EQ(classifier.classify(object, 0.0), Relevance::HIGH);
+}
+
+TEST(RelevanceClassifier, approaching_object_is_high)
+{
+  RelevanceClassifier classifier(makeEnabledParams());
+  classifier.setEgoData(makeStraightTrajectory(), makePoint(0.0, 0.0), 0.0);
+
+  // 30 m beside the corridor, heading straight at it (-y) with 10 m/s:
+  // time to corridor = 3 s < threshold 5 s.
+  const auto object = makeObject(50.0, 30.0, -M_PI_2, 10.0, 1);
+  EXPECT_EQ(classifier.classify(object, 0.0), Relevance::HIGH);
+}
+
+TEST(RelevanceClassifier, distant_receding_object_demotes_after_hysteresis)
+{
+  RelevanceClassifier classifier(makeEnabledParams());
+  classifier.setEgoData(makeStraightTrajectory(), makePoint(0.0, 0.0), 0.0);
+
+  // 50 m beside the corridor, moving away from it (+y).
+  const auto object = makeObject(50.0, 50.0, M_PI_2, 5.0, 1);
+
+  // demote_frame_count = 3: the first two frames stay HIGH, the third demotes.
+  EXPECT_EQ(classifier.classify(object, 0.0), Relevance::HIGH);
+  EXPECT_EQ(classifier.classify(object, 0.1), Relevance::HIGH);
+  EXPECT_EQ(classifier.classify(object, 0.2), Relevance::LOW);
+  EXPECT_EQ(classifier.classify(object, 0.3), Relevance::LOW);
+}
+
+TEST(RelevanceClassifier, promotion_is_immediate)
+{
+  RelevanceClassifier classifier(makeEnabledParams());
+  classifier.setEgoData(makeStraightTrajectory(), makePoint(0.0, 0.0), 0.0);
+
+  const auto far_object = makeObject(50.0, 50.0, M_PI_2, 5.0, 1);
+  classifier.classify(far_object, 0.0);
+  classifier.classify(far_object, 0.1);
+  ASSERT_EQ(classifier.classify(far_object, 0.2), Relevance::LOW);
+
+  // The same object enters the corridor: promoted immediately.
+  const auto near_object = makeObject(50.0, 2.0, M_PI_2, 5.0, 1);
+  EXPECT_EQ(classifier.classify(near_object, 0.3), Relevance::HIGH);
+}
+
+TEST(RelevanceClassifier, history_cleanup_resets_hysteresis)
+{
+  RelevanceClassifier classifier(makeEnabledParams());
+  classifier.setEgoData(makeStraightTrajectory(), makePoint(0.0, 0.0), 0.0);
+
+  const auto object = makeObject(50.0, 50.0, M_PI_2, 5.0, 1);
+  classifier.classify(object, 0.0);
+  classifier.classify(object, 0.1);
+  ASSERT_EQ(classifier.classify(object, 0.2), Relevance::LOW);
+
+  // After the entry is removed, demotion must be re-earned.
+  classifier.removeOldHistory(10.0, 2.0);
+  classifier.setEgoData(makeStraightTrajectory(), makePoint(0.0, 0.0), 10.0);
+  EXPECT_EQ(classifier.classify(object, 10.0), Relevance::HIGH);
+}


### PR DESCRIPTION
## Description

This PR adds an **opt-in** planning-aware prediction fidelity allocation feature to `autoware_map_based_prediction`.

Currently the node processes every tracked object uniformly: each vehicle goes through lanelet search, maneuver detection, and multi-mode reference path generation whether or not it can ever interact with the ego vehicle. In dense traffic this uniform processing dominates the node's cycle time — the package already ships processing-time diagnostics (`processing_time_tolerance`) because this is a known operational concern.

This PR generalizes the "perception in plan" principle from recent end-to-end driving research (e.g. VeteranAD, "Perception in Plan: Coupled Perception and Planning for End-to-End Autonomous Driving," AAAI 2026) to Autoware's modular architecture: **let the planning intent decide where perception fidelity is needed.** The ego planned trajectory (the previous planning cycle's output) is fed back to prediction, and each vehicle-class object is classified by a new unit-tested, pure-logic `RelevanceClassifier`:

- **HIGH relevance** (full prediction, unchanged behavior) if the object is (1) within `always_relevant_radius` of the ego vehicle, (2) inside a corridor around the planned trajectory whose half width grows with arc length, or (3) moving toward the corridor with time-to-corridor below a threshold (cut-in / crossing precaution).
- **LOW relevance** otherwise: a single constant-velocity path with a shorter horizon, generated by the same `PathGenerator` API already used for unknown-class objects (`confidence = 1.0`). **Nothing is dropped from the output.**

Safety design:

- **Opt-in, default off.** With `planning_aware_prediction.enable: false` (default) the node behavior is unchanged.
- **Fail-safe.** If the ego trajectory is missing, degenerate, or older than `ego_trajectory_timeout`, every object is classified HIGH — a planning outage degrades gracefully to the current behavior.
- **Asymmetric hysteresis.** Promotion to HIGH is immediate; demotion to LOW requires `demote_frame_count` consecutive LOW frames.
- **VRUs exempt.** Pedestrians and bicycles always receive their regular prediction (also avoids interfering with the crosswalk-user history bookkeeping in `retrieveUndetectedObjects()`).

See `design/planning-aware-prediction.md` (added in this PR) for the architecture, the rationale, and a generalization roadmap (the same relevance interface can later guide detection ROI selection, tracking update rates, and occupancy grid resolution).

## Related links

**Parent Issue:**

- None yet. If maintainers prefer, I am happy to open a Design Discussion for the architectural question of feeding the planning output back into a perception node; the fail-safe ensures perception never blocks on planning.

## How was this PR tested?

- `colcon build --packages-up-to autoware_map_based_prediction` on ROS 2 Humble / Ubuntu 22.04: 35 packages built successfully.
- `colcon test --packages-select autoware_map_based_prediction`: **94 tests, 0 errors, 0 failures** (37 skipped are the pre-existing disabled linters).
- New gtest suite `test/map_based_prediction/test_relevance_classifier.cpp` (11 cases): corridor geometry (lateral distance / arc length / end clamping), each HIGH condition, demotion hysteresis, immediate promotion, history cleanup, and the fail-safe paths (disabled / missing / stale trajectory). The pre-existing 6 tests also pass unchanged.
- pre-commit equivalent checks run with the repository versions: clang-format 21.1.8, cpplint 2.0.2, markdownlint, prettier, yamllint; `map_based_prediction.param.yaml` validated against the updated JSON schema.
- Rosbag processing-time benchmarks (enabled vs. disabled on identical data) are planned as a follow-up; I will attach numbers in a comment. Qualitative verification is possible in RViz via the new `relevance` debug marker namespace (green = HIGH, gray = LOW).

## Notes for reviewers

- The relevance classification is intentionally kept package-local (`relevance_classifier.hpp` / `lib/relevance_classifier.cpp`, no ROS node dependencies) so it can be promoted to a shared package once a second consumer exists.
- The binary HIGH/LOW fidelity split is a deliberate first iteration; a graded scheme (maneuver-mode count / horizon scaling) is listed as future work in the design document.

## Interface changes

### Topic changes

#### Additions and removals

| Change type | Topic Type | Topic Name              | Message Type                              | Description                                                      |
| :---------- | :--------- | :---------------------- | :---------------------------------------- | :--------------------------------------------------------------- |
| Added       | Sub        | `~/input/ego_trajectory` | `autoware_planning_msgs/msg/Trajectory`   | Ego planned trajectory; polled only when the feature is enabled |
| Added       | Sub        | `~/input/ego_odometry`   | `nav_msgs/msg/Odometry`                   | Ego kinematic state; polled only when the feature is enabled    |

### ROS Parameter Changes

#### Additions and removals

| Change type | Parameter Name                                          | Type     | Default Value | Description                                                        |
| :---------- | :------------------------------------------------------ | :------- | :------------ | :------------------------------------------------------------------ |
| Added       | `planning_aware_prediction.enable`                      | `bool`   | `false`       | Enable planning-aware prediction fidelity allocation               |
| Added       | `planning_aware_prediction.ego_trajectory_timeout`      | `double` | `1.0`         | [s] stale-trajectory fail-safe threshold                           |
| Added       | `planning_aware_prediction.always_relevant_radius`      | `double` | `20.0`        | [m] objects within this distance of ego are always HIGH            |
| Added       | `planning_aware_prediction.lateral_margin_base`         | `double` | `3.0`         | [m] corridor half width at the ego position                        |
| Added       | `planning_aware_prediction.lateral_margin_rate`         | `double` | `0.1`         | [m/m] corridor half width growth per meter of arc length           |
| Added       | `planning_aware_prediction.time_to_corridor_threshold`  | `double` | `5.0`         | [s] approach-detection threshold                                   |
| Added       | `planning_aware_prediction.demote_frame_count`          | `int`    | `5`           | [frames] consecutive LOW frames required before demotion           |
| Added       | `planning_aware_prediction.low_fidelity_time_horizon`   | `double` | `3.0`         | [s] horizon of the lightweight prediction for LOW relevance objects |

## Effects on system behavior

None by default (`planning_aware_prediction.enable: false` keeps the current behavior bit-identical). When enabled, vehicles classified as low-relevance to the ego planned trajectory receive a single constant-velocity predicted path with a shorter horizon instead of the lanelet-based multi-mode prediction; all objects remain present in the output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
