### PR TITLE
fix(diffusion_planner, trajectory ranker): remove builder pattern

### DIFF
--- a/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
@@ -533,19 +533,17 @@ PlannerOutput DiffusionPlannerCore::create_planner_output(
       output.trajectory = trajectory;
     }
 
-    const auto candidate_trajectory = autoware_internal_planning_msgs::build<
-                                        autoware_internal_planning_msgs::msg::CandidateTrajectory>()
-                                        .header(trajectory.header)
-                                        .generator_id(generator_uuid)
-                                        .points(trajectory.points);
+    autoware_internal_planning_msgs::msg::CandidateTrajectory candidate_trajectory;
+    candidate_trajectory.header = trajectory.header;
+    candidate_trajectory.generator_id = generator_uuid;
+    candidate_trajectory.points = trajectory.points;
 
     std_msgs::msg::String generator_name_msg;
     generator_name_msg.data = std::string("DiffusionPlanner_batch_") + std::to_string(i);
 
-    const auto generator_info =
-      autoware_internal_planning_msgs::build<autoware_internal_planning_msgs::msg::GeneratorInfo>()
-        .generator_id(generator_uuid)
-        .generator_name(generator_name_msg);
+    autoware_internal_planning_msgs::msg::GeneratorInfo generator_info;
+    generator_info.generator_id = generator_uuid;
+    generator_info.generator_name = generator_name_msg;
 
     output.candidate_trajectories.candidate_trajectories.push_back(candidate_trajectory);
     output.candidate_trajectories.generator_info.push_back(generator_info);

--- a/planning/autoware_trajectory_ranker/src/trajectory_ranker_node.cpp
+++ b/planning/autoware_trajectory_ranker/src/trajectory_ranker_node.cpp
@@ -154,16 +154,13 @@ ScoredCandidateTrajectories::ConstSharedPtr TrajectoryRanker::score(
   }
 
   for (const auto & result : evaluator_->results()) {
-    const auto candidate = autoware_internal_planning_msgs::build<
-                             autoware_internal_planning_msgs::msg::CandidateTrajectory>()
-                             .header(result->header())
-                             .generator_id(result->uuid())
-                             .points(*result->original());
-    const auto scored_trajectory =
-      autoware_internal_planning_msgs::build<
-        autoware_internal_planning_msgs::msg::ScoredCandidateTrajectory>()
-        .candidate_trajectory(candidate)
-        .score(result->total());
+    autoware_internal_planning_msgs::msg::CandidateTrajectory candidate;
+    candidate.header = result->header();
+    candidate.generator_id = result->uuid();
+    candidate.points = *result->original();
+    autoware_internal_planning_msgs::msg::ScoredCandidateTrajectory scored_trajectory;
+    scored_trajectory.candidate_trajectory = candidate;
+    scored_trajectory.score = result->total();
     trajectories.push_back(scored_trajectory);
   }
 


### PR DESCRIPTION
## Description
Removes the builder pattern to make it easy to add new fields, in order to apply https://github.com/autowarefoundation/autoware_internal_msgs/pull/89.

## Related links
- https://github.com/autowarefoundation/autoware_internal_msgs/pull/89
- https://github.com/autowarefoundation/autoware_universe/pull/12922

## How was this PR tested?
- psim
- Confirmed that universe builds successfully with the changes from https://github.com/autowarefoundation/autoware_internal_msgs/pull/89 applied

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
