### PR TITLE
fix(map_based_prediction): validate header stamp in TrackedObjects to prevent negative time errors

### DIFF
--- a/perception/autoware_map_based_prediction/lib/map_based_prediction_node/callbacks.cpp
+++ b/perception/autoware_map_based_prediction/lib/map_based_prediction_node/callbacks.cpp
@@ -104,6 +104,17 @@ void ObjectsCallback::trafficSignalsCallback(
 void ObjectsCallback::objectsCallback(
   const AUTOWARE_MESSAGE_CONST_SHARED_PTR(TrackedObjects) & in_objects)
 {
+  // Drop corrupt messages: a negative sec makes every rclcpp::Time(stamp) on the path throw.
+  const auto & input_stamp = in_objects->header.stamp;
+  if (input_stamp.sec < 0 || input_stamp.nanosec >= 1000000000u) {
+    static rclcpp::Clock throttle_clock(RCL_STEADY_TIME);
+    RCLCPP_WARN_THROTTLE(
+      rclcpp::get_logger("map_based_prediction"), throttle_clock, 1000,
+      "Dropped TrackedObjects with invalid header stamp (sec=%d nanosec=%u).", input_stamp.sec,
+      input_stamp.nanosec);
+    return;
+  }
+
   std::unique_ptr<ScopedTimeTrack> st_ptr;
   if (state_.time_keeper) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *state_.time_keeper);
 
@@ -192,12 +203,16 @@ void ObjectsCallback::objectsCallback(
       output.objects.end(), retrieved_objects.objects.begin(), retrieved_objects.objects.end());
   }
 
+  // Capture before publish() moves output_msg; reading output.header.stamp afterwards is a
+  // use-after-move that can feed a garbage (possibly negative) time into diagnostics_->update().
+  const auto output_stamp = output.header.stamp;
+
   publish(std::move(output_msg), debug_markers);
 
   const auto processing_time_ms = stop_watch_ptr_->toc("processing_time", true);
   const auto cyclic_time_ms = stop_watch_ptr_->toc("cyclic_time", true);
 
-  if (diagnostics_) diagnostics_->update(output.header.stamp, processing_time_ms, cyclic_time_ms);
+  if (diagnostics_) diagnostics_->update(output_stamp, processing_time_ms, cyclic_time_ms);
 }
 
 void ObjectsCallback::publish(


### PR DESCRIPTION
## Description

`map_based_prediction`'s `objectsCallback` could throw and crash when it received `TrackedObjects` with a malformed `header.stamp`. A negative `sec` (or an out-of-range `nanosec`) makes every `rclcpp::Time(stamp)` constructed along the prediction path throw, taking down the node.

This PR hardens the callback against such corrupt input:

- **Drop corrupt messages early.** At the top of `objectsCallback`, reject any message whose `header.stamp` has `sec < 0` or `nanosec >= 1e9`, with a throttled warning, before any `rclcpp::Time` is built from it.
- **Fix a use-after-move.** `output.header.stamp` was read *after* `publish(std::move(output_msg), ...)` had already moved `output_msg`, which could feed a garbage (possibly negative) time into `diagnostics_->update()`. The stamp is now captured into `output_stamp` before the move.

## Related links
Bug introduced by https://github.com/autowarefoundation/autoware_universe/pull/12879

## How was this PR tested?

Local build. The guard converts a hard crash on malformed input into a dropped message plus a throttled warning.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None under valid input. Malformed `TrackedObjects` (negative/out-of-range stamp) are now dropped with a throttled warning instead of crashing the node.
