### PR TITLE
feat(minimum_rule_based_planner): introduce minimum_rule_based_planner package

### DIFF
--- a/planning/autoware_minimum_rule_based_planner/CMakeLists.txt
+++ b/planning/autoware_minimum_rule_based_planner/CMakeLists.txt
@@ -1,0 +1,75 @@
+cmake_minimum_required(VERSION 3.14)
+project(autoware_minimum_rule_based_planner)
+
+find_package(autoware_cmake REQUIRED)
+autoware_package()
+
+find_package(OpenCV REQUIRED)
+find_package(magic_enum CONFIG REQUIRED)
+
+generate_parameter_library(minimum_rule_based_planner_parameters
+  param/minimum_rule_based_planner_parameters.yaml
+)
+
+ament_auto_add_library(${PROJECT_NAME}_lib SHARED
+  src/minimum_rule_based_planner.cpp
+  src/path_planner.cpp
+  src/velocity_smoother.cpp
+)
+
+target_include_directories(${PROJECT_NAME}_lib PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/plugins>
+)
+
+target_include_directories(${PROJECT_NAME}_lib SYSTEM PUBLIC
+  ${EIGEN3_INCLUDE_DIR}
+)
+
+target_link_libraries(${PROJECT_NAME}_lib
+  ${OpenCV_LIBRARIES}
+  minimum_rule_based_planner_parameters
+)
+
+# Suppress deprecated-declarations warning from parameter_traits library
+target_compile_options(${PROJECT_NAME}_lib PRIVATE -Wno-deprecated-declarations)
+
+autoware_agnocast_wrapper_register_node(${PROJECT_NAME}_lib
+  PLUGIN "autoware::minimum_rule_based_planner::MinimumRuleBasedPlannerNode"
+  EXECUTABLE ${PROJECT_NAME}_node
+  ROS2_EXECUTOR SingleThreadedExecutor
+  AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
+)
+
+pluginlib_export_plugin_description_file(${PROJECT_NAME} plugins.xml)
+
+ament_auto_add_library(${PROJECT_NAME}_plugins SHARED
+  plugins/obstacle_stop.cpp
+  plugins/surround_obstacle_stop.cpp
+)
+
+target_include_directories(${PROJECT_NAME}_plugins PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/plugins
+)
+
+target_link_libraries(${PROJECT_NAME}_plugins
+  ${PROJECT_NAME}_lib
+)
+
+if(BUILD_TESTING)
+  file(GLOB_RECURSE TEST_SOURCES test/*.cpp)
+  ament_add_ros_isolated_gmock(test_${PROJECT_NAME} ${TEST_SOURCES})
+
+  target_include_directories(test_${PROJECT_NAME} PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
+  )
+
+  target_link_libraries(test_${PROJECT_NAME}
+    ${PROJECT_NAME}_lib
+  )
+endif()
+
+ament_auto_package(
+  INSTALL_TO_SHARE
+    config
+    launch
+)

--- a/planning/autoware_minimum_rule_based_planner/README.md
+++ b/planning/autoware_minimum_rule_based_planner/README.md
@@ -1,0 +1,49 @@
+# autoware_minimum_rule_based_planner
+
+## Overview
+
+A minimum rule-based trajectory planner that generates safe and feasible trajectories for autonomous driving. It follows the planned route by constructing trajectories from lanelet centerline and applies multi-stage optimization for geometric smoothness, velocity profiles, and obstacle avoidance.
+
+## Features
+
+- **Centerline-based path planning**: Generates paths along lanelet centerline from the HD map, extending backward and forward from the ego vehicle's position
+- **Smooth goal connection**: Refines the path near the goal pose for smooth stopping
+- **Path shifting**: Shifts the centerline path to start from the ego vehicle's current pose, using curvature-aware shift distance calculation based on ego velocity and lateral acceleration limits
+- **Trajectory smoothing**: Applies an Elastic Band smoother for geometric smoothing via a plugin interface
+- **Trajectory modification**: Applies modifier plugins (e.g., obstacle stop) for safety modifications
+- **Velocity optimization**: Computes a jerk-filtered velocity profile respecting constraints on acceleration, jerk, and lateral acceleration
+- **Test mode**: Supports bypassing path planning by directly receiving a `PathWithLaneId` topic
+
+## Inputs / Outputs
+
+### Inputs
+
+| Topic                            | Type                         | Description                       |
+| -------------------------------- | ---------------------------- | --------------------------------- |
+| `~/input/route`                  | `LaneletRoute`               | Planned route                     |
+| `~/input/vector_map`             | `LaneletMapBin`              | HD map                            |
+| `~/input/odometry`               | `Odometry`                   | Ego pose and velocity             |
+| `~/input/acceleration`           | `AccelWithCovarianceStamped` | Ego acceleration                  |
+| `~/input/objects`                | `PredictedObjects`           | Surrounding obstacles             |
+| `~/input/test/path_with_lane_id` | `PathWithLaneId`             | Test mode: bypasses path planning |
+
+### Outputs
+
+| Topic                                 | Type                    | Description                                   |
+| ------------------------------------- | ----------------------- | --------------------------------------------- |
+| `~/output/candidate_trajectories`     | `CandidateTrajectories` | Planned trajectory                            |
+| `~/debug/path_with_lane_id`           | `PathWithLaneId`        | Debug: planned path                           |
+| `~/debug/trajectory`                  | `Trajectory`            | Debug: final output trajectory                |
+| `~/debug/shifted_trajectory`          | `Trajectory`            | Debug: trajectory after path shifting         |
+| `~/debug/optimizer/{name}/trajectory` | `Trajectory`            | Debug: trajectory after each optimizer plugin |
+| `~/debug/modifier/{name}/trajectory`  | `Trajectory`            | Debug: trajectory after each modifier plugin  |
+| `~/debug/processing_time_detail_ms`   | `ProcessingTimeDetail`  | Debug: processing time breakdown              |
+
+## Parameters
+
+{{ json_to_markdown("planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json") }}
+
+Parameters can be set via YAML configuration files in the `config/` directory.
+
+Jerk-filtered smoother parameters are defined in `config/velocity_smoother/jerk_filtered_smoother.param.yaml`.
+EB smoother parameters are defined in `config/trajectory_optimizer_plugins/elastic_band_smoother.param.yaml`.

--- a/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
+++ b/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
@@ -1,0 +1,160 @@
+/**:
+  ros__parameters:
+    # generate_parameter_library parameters
+    planning_frequency_hz: 10.0
+    plugin_names:
+      - "autoware::minimum_rule_based_planner::plugin::ObstacleStop"
+      - "autoware::minimum_rule_based_planner::plugin::SurroundObstacleStop"
+
+    path_planning:
+      path_length:
+        backward: 5.0
+        forward: 300.0
+
+      smooth_goal_connection:
+        search_radius_range: 7.5
+        pre_goal_offset: 1.0
+
+      ego_nearest_lanelet:
+        dist_threshold: 3.0
+        yaw_threshold: 1.046
+
+      path_shift:
+        enable: true
+        minimum_shift_length: 0.5
+        minimum_shift_yaw: 0.349 # 20 deg
+        minimum_shift_distance: 5.0
+        min_speed_for_curvature: 2.77  # [m/s] 10 km/h
+        lateral_accel_limit: 1.0      # [m/s^2]
+
+      waypoint_group:
+        separation_threshold: 1.0
+        interval_margin_ratio: 10.0
+
+      output:
+        delta_arc_length: 0.5
+
+    obstacle_stop:
+      enable: true
+      use_objects: true
+      use_pointcloud: true
+      enable_stop_for_objects: true
+      enable_stop_for_pointcloud: false
+      stop_margin: 6.0
+      nominal_stopping_decel: 1.0 # [m/s^2]
+      maximum_stopping_decel: 4.0 # [m/s^2]
+      stopping_jerk: 3.0 # [m/s^3]
+      on_time_buffer: 0.5 # [s]
+      off_time_buffer: 0.7 # [s]
+      lateral_margin: 0.2     # lateral margin on top of ego width from trajectory to consider for obstacle stop [m]
+      arrived_distance_threshold: 0.5 # threshold to check if the ego vehicle has arrived at the stop point [m]
+
+      objects:
+        object_types: ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian", "hazard"] # object types to consider for obstacle stop
+        max_velocity_th: 3.0     # maximum velocity threshold for target object [m/s]
+        stopped_velocity_th: 0.3 # velocity threshold for target object to be considered as stopped [m/s]
+        max_lateral_velocity_th: 1.0 # maximum lateral velocity threshold for target object [m/s]
+        safety_buffer: 0.1       # safety buffer to expand object shape [m]
+
+      pointcloud:
+        height_buffer: 0.5  # height buffer to add above ego height [m]
+        min_height: 0.2  # minimum height of pointcloud [m]
+        voxel_grid_filter:
+          x: 0.2
+          y: 0.2
+          z: 0.2
+          min_size: 3
+        clustering:
+          tolerance: 0.5  #[m]
+          min_height: 0.5
+          min_size: 10
+          max_size: 10000
+
+      rss_params:
+        enable: true
+        object_decel:
+          car: 1.5
+          truck: 1.5
+          bus: 1.5
+          trailer: 1.5
+          motorcycle: 2.0
+          bicycle: 3.0
+          pedestrian: 5.0
+        ego_decel: 2.5           # [m/s^2]
+        reaction_time: 0.2       # [s]
+        safety_margin: 2.0       # [m]
+        lookahead_horizon: 1.5   # [s]
+
+    surround_obstacle_stop:
+      enable: true
+      use_objects: true
+      use_pointcloud: false
+      object_types: ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian", "hazard", "animal", "unknown"] # object types to consider for surround obstacle stop
+      front_distance_th:
+        car: 0.5
+        truck: 0.5
+        bus: 0.5
+        trailer: 0.5
+        motorcycle: 0.5
+        bicycle: 0.5
+        pedestrian: 0.5
+        hazard: 0.5
+        animal: 0.5
+        unknown: 0.5
+        pointcloud: 0.5
+      side_distance_th:
+        car: 0.0
+        truck: 0.0
+        bus: 0.0
+        trailer: 0.0
+        motorcycle: 1.0
+        bicycle: 1.0
+        pedestrian: 1.0
+        hazard: 0.5
+        animal: 0.5
+        unknown: 0.5
+        pointcloud: 0.5
+      back_distance_th:
+        car: 0.0
+        truck: 0.0
+        bus: 0.0
+        trailer: 0.0
+        motorcycle: 0.5
+        bicycle: 0.5
+        pedestrian: 0.5
+        hazard: 0.5
+        animal: 0.5
+        unknown: 0.5
+        pointcloud: 0.5
+      hysteresis_distance: 0.1 # [m]
+      hysteresis_time: 0.2     # [s]
+      ego_stopped_vel_th: 0.1  # [m/s]
+
+    velocity_smoother:
+      nearest_dist_threshold_m: 1.5
+      nearest_yaw_threshold_deg: 60.0
+      target_pull_out_speed_mps: 0.25
+      target_pull_out_acc_mps2: 0.5
+      max_speed_mps: 13.88
+      max_lateral_accel_mps2: 1.5
+      set_engage_speed: true
+      limit_speed: true
+      limit_lateral_acceleration: false
+      smooth_velocities: true
+      stop_dist_to_prohibit_engage: 0.5
+
+    post_resample:
+      max_trajectory_length: 300.0
+      min_trajectory_length: 30.0
+      resample_time: 10.0
+      dense_resample_dt: 0.1
+      dense_min_interval_distance: 0.1
+      sparse_resample_dt: 0.1
+      sparse_min_interval_distance: 1.0
+
+    debug:
+      enable_path: true
+      enable_shifted_trajectory: true
+      enable_optimizer_trajectory: true
+      enable_modifier_trajectory: true
+      enable_output_trajectory: true

--- a/planning/autoware_minimum_rule_based_planner/config/trajectory_optimizer_plugins/elastic_band_smoother.param.yaml
+++ b/planning/autoware_minimum_rule_based_planner/config/trajectory_optimizer_plugins/elastic_band_smoother.param.yaml
@@ -1,0 +1,47 @@
+/**:
+  ros__parameters:
+    # EBPathSmoother parameters (CommonParam, EgoNearestParam)
+    common:
+      output_delta_arc_length: 0.5
+      output_backward_traj_length: 5.0
+
+    elastic_band:
+      option:
+        enable_warm_start: true
+        enable_optimization_validation: false
+
+      common:
+        num_points: 100
+        delta_arc_length: 1.0
+
+      clearance:
+        num_joint_points: 3
+        clearance_for_fix: 0.0
+        clearance_for_joint: 0.1
+        clearance_for_smooth: 0.1
+
+      weight:
+        smooth_weight: 1.0
+        lat_error_weight: 0.001
+
+      qp:
+        max_iteration: 10000
+        eps_abs: 1.0e-7
+        eps_rel: 1.0e-7
+
+      validation:
+        max_error: 3.0
+
+    # EgoNearestParam for EB smoother
+    ego_nearest_dist_threshold: 3.0
+    ego_nearest_yaw_threshold: 1.046
+
+    # Replan parameters for EB smoother
+    replan:
+      enable: true
+      max_path_shape_around_ego_lat_dist: 2.0
+      max_path_shape_forward_lon_dist: 100.0
+      max_path_shape_forward_lat_dist: 0.2
+      max_ego_moving_dist: 5.0
+      max_goal_moving_dist: 15.0
+      max_delta_time_sec: 0.0

--- a/planning/autoware_minimum_rule_based_planner/config/velocity_smoother/jerk_filtered_smoother.param.yaml
+++ b/planning/autoware_minimum_rule_based_planner/config/velocity_smoother/jerk_filtered_smoother.param.yaml
@@ -1,0 +1,36 @@
+/**:
+  ros__parameters:
+    # SmootherBase parameters (required at top level for JerkFilteredSmoother)
+    normal:
+      max_acc: 1.0
+      min_acc: -1.0
+      max_jerk: 1.6
+      min_jerk: -1.6
+
+    stop_decel: 0.0
+    min_decel_for_lateral_acc_lim_filter: -2.5
+    min_curve_velocity: 2.74
+    decel_distance_before_curve: 3.5
+    decel_distance_after_curve: 2.0
+    resample_ds: 0.1
+    curvature_threshold: 0.02
+    curvature_calculation_distance: 5.0
+
+    lateral_acceleration_limits: [0.8, 0.8, 0.8, 0.8]
+    velocity_thresholds: [0.1, 0.3, 20.0, 30.0]
+    steering_angle_rate_limits: [57.0, 57.0, 57.0, 40.0]
+
+    max_trajectory_length: 200.0
+    min_trajectory_length: 150.0
+    resample_time: 2.0
+    dense_resample_dt: 0.2
+    dense_min_interval_distance: 0.1
+    sparse_resample_dt: 0.5
+    sparse_min_interval_distance: 4.0
+
+    # JerkFilteredSmoother parameters (required at top level)
+    jerk_weight: 10.0
+    over_v_weight: 100000.0
+    over_a_weight: 5000.0
+    over_j_weight: 2000.0
+    jerk_filter_ds: 0.1

--- a/planning/autoware_minimum_rule_based_planner/launch/minimum_rule_based_planner.launch.xml
+++ b/planning/autoware_minimum_rule_based_planner/launch/minimum_rule_based_planner.launch.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<launch>
+  <!-- Common parameter file (provides max_vel, limit.* params) -->
+  <arg name="common_param_path" default="$(find-pkg-share autoware_core_planning)/config/common.param.yaml"/>
+
+  <!-- Main parameter file -->
+  <arg name="minimum_rule_base_planner_param_path" default="$(find-pkg-share autoware_minimum_rule_based_planner)/config/minimum_rule_based_planner.param.yaml"/>
+
+  <!-- Trajectory optimizer plugin parameter files -->
+  <arg
+    name="minimum_rule_base_planner_elastic_band_smoother_param_path"
+    default="$(find-pkg-share autoware_minimum_rule_based_planner)/config/trajectory_optimizer_plugins/elastic_band_smoother.param.yaml"
+  />
+
+  <!-- Velocity smoother parameter file -->
+  <arg name="minimum_rule_base_planner_jerk_filtered_smoother_param_path" default="$(find-pkg-share autoware_minimum_rule_based_planner)/config/velocity_smoother/jerk_filtered_smoother.param.yaml"/>
+
+  <!-- Topic remappings -->
+  <arg name="input_route" default="~/input/route"/>
+  <arg name="input_vector_map" default="~/input/vector_map"/>
+  <arg name="input_odometry" default="~/input/odometry"/>
+  <arg name="input_acceleration" default="~/input/acceleration"/>
+  <arg name="input_objects" default="~/input/objects"/>
+  <arg name="input_pointcloud" default="~/input/pointcloud"/>
+  <arg name="output_candidate_trajectories" default="~/output/candidate_trajectories"/>
+
+  <node pkg="autoware_minimum_rule_based_planner" exec="autoware_minimum_rule_based_planner_node" name="minimum_rule_based_planner_node" output="both">
+    <!-- Load parameter files -->
+    <env name="LD_LIBRARY_PATH" value="/opt/acados/lib:$(env LD_LIBRARY_PATH)"/>
+    <param from="$(var common_param_path)"/>
+    <param from="$(var minimum_rule_base_planner_param_path)" allow_substs="true"/>
+    <param from="$(var minimum_rule_base_planner_elastic_band_smoother_param_path)" allow_substs="true"/>
+    <param from="$(var minimum_rule_base_planner_jerk_filtered_smoother_param_path)" allow_substs="true"/>
+
+    <!-- Topic remappings -->
+    <remap from="~/input/route" to="$(var input_route)"/>
+    <remap from="~/input/vector_map" to="$(var input_vector_map)"/>
+    <remap from="~/input/odometry" to="$(var input_odometry)"/>
+    <remap from="~/input/acceleration" to="$(var input_acceleration)"/>
+    <remap from="~/input/objects" to="$(var input_objects)"/>
+    <remap from="~/input/pointcloud" to="$(var input_pointcloud)"/>
+    <remap from="~/output/candidate_trajectories" to="$(var output_candidate_trajectories)"/>
+  </node>
+</launch>

--- a/planning/autoware_minimum_rule_based_planner/package.xml
+++ b/planning/autoware_minimum_rule_based_planner/package.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>autoware_minimum_rule_based_planner</name>
+  <version>0.48.0</version>
+  <description>The minimum_rule_based_planner package</description>
+
+  <maintainer email="takumi.odashima@tier4.jp">Takumi Odashima</maintainer>
+  <maintainer email="yuki.takagi@tier4.jp">Yuki Takagi</maintainer>
+  <maintainer email="alqudah.mohammad@tier4.jp">Alqudah Mohammad</maintainer>
+  <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>
+
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
+
+  <build_depend>generate_parameter_library</build_depend>
+
+  <depend>autoware_agnocast_wrapper</depend>
+  <depend>autoware_internal_debug_msgs</depend>
+  <depend>autoware_internal_planning_msgs</depend>
+  <depend>autoware_lanelet2_extension</depend>
+  <depend>autoware_map_msgs</depend>
+  <depend>autoware_motion_utils</depend>
+  <depend>autoware_obstacle_proximity_checker</depend>
+  <depend>autoware_perception_msgs</depend>
+  <depend>autoware_planning_factor_interface</depend>
+  <depend>autoware_planning_msgs</depend>
+  <depend>autoware_planning_test_manager</depend>
+  <depend>autoware_qp_interface</depend>
+  <depend>autoware_trajectory</depend>
+  <depend>autoware_trajectory_modifier</depend>
+  <depend>autoware_trajectory_optimizer</depend>
+  <depend>autoware_utils</depend>
+  <depend>autoware_utils_debug</depend>
+  <depend>autoware_utils_uuid</depend>
+  <depend>autoware_vehicle_info_utils</depend>
+  <depend>autoware_vehicle_msgs</depend>
+  <depend>autoware_velocity_smoother</depend>
+  <depend>geometry_msgs</depend>
+  <depend>libboost-dev</depend>
+  <depend>libopencv-dev</depend>
+  <depend>magic_enum</depend>
+  <depend>nav_msgs</depend>
+  <depend>pluginlib</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
+  <depend>sensor_msgs</depend>
+  <depend>tf2</depend>
+  <depend>tf2_eigen</depend>
+  <depend>tf2_geometry_msgs</depend>
+  <depend>tf2_ros</depend>
+  <depend>tier4_planning_msgs</depend>
+  <depend>visualization_msgs</depend>
+
+  <exec_depend>autoware_core_planning</exec_depend>
+
+  <test_depend>ament_cmake_ros</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>autoware_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
+++ b/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
@@ -1,0 +1,452 @@
+minimum_rule_based_planner:
+  planning_frequency_hz:
+    type: double
+    default_value: 10.0
+    validation:
+      gt<>: [0.0]
+  plugin_names:
+    type: string_array
+    default_value:
+      - autoware::minimum_rule_based_planner::plugin::ObstacleStop
+      - autoware::minimum_rule_based_planner::plugin::SurroundObstacleStop
+    description: List of plugin names to load
+    read_only: false
+
+  path_planning:
+    waypoint_group:
+      separation_threshold:
+        type: double
+        default_value: 1.0
+        description: maximum distance between waypoints to belong to same group [m]
+
+      interval_margin_ratio:
+        type: double
+        default_value: 10.0
+        description: ratio to expand interval bound of group according to lateral distance
+
+    smooth_goal_connection:
+      search_radius_range:
+        type: double
+        default_value: 7.5
+        description: search radius range for smooth goal connection [m]
+
+      pre_goal_offset:
+        type: double
+        default_value: 1.0
+        description: offset before goal for smooth connection [m]
+
+    # Parameters for lanelet matching (different from EB smoother's ego_nearest_* params)
+    ego_nearest_lanelet:
+      dist_threshold:
+        type: double
+        default_value: 3.0
+        description: distance threshold for ego nearest lanelet search [m]
+
+      yaw_threshold:
+        type: double
+        default_value: 1.046
+        description: yaw threshold for ego nearest lanelet search [rad]
+
+    path_length:
+      backward:
+        type: double
+        default_value: 5.0
+        validation:
+          gt<>: [0.0]
+
+      forward:
+        type: double
+        default_value: 100.0
+        validation:
+          gt<>: [0.0]
+
+    output:
+      delta_arc_length:
+        type: double
+        default_value: 0.5
+        description: delta arc length for output trajectory [m]
+        validation:
+          gt<>: [0.0]
+
+    # Path Shift to Ego Parameters
+    path_shift:
+      enable:
+        type: bool
+        default_value: true
+        description: enable path shifting from ego position to centerline
+
+      minimum_shift_length:
+        type: double
+        default_value: 0.1
+        description: lateral offset threshold to trigger path shifting [m]
+
+      minimum_shift_yaw:
+        type: double
+        default_value: 0.1
+        description: yaw deviation threshold to trigger path shifting [rad]
+
+      minimum_shift_distance:
+        type: double
+        default_value: 5.0
+        description: floor for shift distance ahead of ego [m]
+
+      min_speed_for_curvature:
+        type: double
+        default_value: 2.77
+        description: lower bound on ego speed used to compute initial curvature kappa0 = yaw_rate / speed [m/s]
+        validation:
+          gt<>: [0.0]
+
+      lateral_accel_limit:
+        type: double
+        default_value: 0.5
+        description: allowed lateral acceleration budget for the shift polynomial (comfort/safety limit) [m/s^2]
+        validation:
+          gt<>: [0.0]
+
+  obstacle_stop:
+    enable:
+      type: bool
+      default_value: true
+      description: enable obstacle stop
+    use_objects:
+      type: bool
+      default_value: true
+      description: use objects for obstacle stop
+    use_pointcloud:
+      type: bool
+      default_value: true
+      description: use pointcloud for obstacle stop
+    enable_stop_for_objects:
+      type: bool
+      default_value: true
+      description: enable stop for objects
+    enable_stop_for_pointcloud:
+      type: bool
+      default_value: false
+      description: enable stop for pointcloud
+    stop_margin:
+      type: double
+      default_value: 6.0
+      description: stop margin for obstacle stop [m]
+    nominal_stopping_decel:
+      type: double
+      default_value: 1.0
+      description: nominal stopping deceleration [m/s^2]
+    maximum_stopping_decel:
+      type: double
+      default_value: 4.0
+      description: maximum stopping deceleration [m/s^2]
+    stopping_jerk:
+      type: double
+      default_value: 3.0
+      description: stopping jerk [m/s^3]
+    on_time_buffer:
+      type: double
+      default_value: 0.5
+      description: time buffer before obstacle stop [s]
+    off_time_buffer:
+      type: double
+      default_value: 1.0
+      description: time buffer after obstacle stop [s]
+    lateral_margin:
+      type: double
+      default_value: 0.2
+      description: lateral margin for obstacle stop [m]
+    arrived_distance_threshold:
+      type: double
+      default_value: 0.5
+      description: threshold to check if the ego vehicle has arrived at the stop point [m]
+      validation:
+        bounds<>: [0.0, 10.0]
+    objects:
+      object_types:
+        type: string_array
+        default_value: [car, truck, bus, trailer, motorcycle, bicycle, pedestrian, hazard]
+        description: object types to consider for obstacle stop
+      max_velocity_th:
+        type: double
+        default_value: 3.0
+        description: maximum velocity threshold for target object [m/s]
+      stopped_velocity_th:
+        type: double
+        default_value: 0.3
+        description: velocity threshold for target object to be considered as stopped [m/s]
+      max_lateral_velocity_th:
+        type: double
+        default_value: 1.0
+        description: maximum lateral velocity threshold for target object to be considered for obstacle stop [m/s]
+        validation:
+          bounds<>: [0.0, 10.0]
+      safety_buffer:
+        type: double
+        default_value: 0.1
+        description: safety buffer to expand object shape [m]
+        validation:
+          bounds<>: [0.0, 10.0]
+    pointcloud:
+      height_buffer:
+        type: double
+        default_value: 0.5
+        description: height buffer to add above ego height [m]
+        validation:
+          bounds<>: [0.0, 10.0]
+      min_height:
+        type: double
+        default_value: 0.2
+        description: minimum height of pointcloud [m]
+        validation:
+          bounds<>: [0.0, 10.0]
+      voxel_grid_filter:
+        x:
+          type: double
+          default_value: 0.2
+          description: x size of voxel grid filter [m]
+          validation:
+            bounds<>: [0.0, 1.0]
+        y:
+          type: double
+          default_value: 0.2
+          description: y size of voxel grid filter [m]
+          validation:
+            bounds<>: [0.0, 1.0]
+        z:
+          type: double
+          default_value: 0.2
+          description: z size of voxel grid filter [m]
+          validation:
+            bounds<>: [0.0, 1.0]
+        min_size:
+          type: int
+          default_value: 3
+          description: minimum size of voxel grid filter
+          validation:
+            bounds<>: [1, 100]
+      clustering:
+        tolerance:
+          type: double
+          default_value: 0.5
+          description: tolerance for clustering [m]
+          validation:
+            bounds<>: [0.0, 1.0]
+        min_height:
+          type: double
+          default_value: 0.5
+          description: minimum height for clustering [m]
+          validation:
+            bounds<>: [0.0, 1.0]
+        min_size:
+          type: int
+          default_value: 10
+          description: minimum size for clustering
+          validation:
+            bounds<>: [1, 100]
+        max_size:
+          type: int
+          default_value: 10000
+          description: maximum size for clustering
+          validation:
+            bounds<>: [1, 10000]
+    rss_params:
+      enable:
+        type: bool
+        default_value: true
+        description: enable the use of RSS parameters for obstacle stop
+      object_decel:
+        car:
+          type: double
+          default_value: 1.5
+          description: deceleration for car type objects [m/s^2]
+          validation:
+            bounds<>: [0.0, 10.0]
+        truck:
+          type: double
+          default_value: 1.5
+          description: deceleration for truck type objects [m/s^2]
+          validation:
+            bounds<>: [0.0, 10.0]
+        bus:
+          type: double
+          default_value: 1.5
+          description: deceleration for bus type objects [m/s^2]
+          validation:
+            bounds<>: [0.0, 10.0]
+        trailer:
+          type: double
+          default_value: 1.5
+          description: deceleration for trailer type objects [m/s^2]
+          validation:
+            bounds<>: [0.0, 10.0]
+        motorcycle:
+          type: double
+          default_value: 2.0
+          description: deceleration for motorcycle type objects [m/s^2]
+          validation:
+            bounds<>: [0.0, 10.0]
+        bicycle:
+          type: double
+          default_value: 3.0
+          description: deceleration for bicycle type objects [m/s^2]
+          validation:
+            bounds<>: [0.0, 10.0]
+        pedestrian:
+          type: double
+          default_value: 5.0
+          description: deceleration for pedestrian type objects [m/s^2]
+          validation:
+            bounds<>: [0.0, 10.0]
+      ego_decel:
+        type: double
+        default_value: 2.5
+        description: deceleration for ego vehicle used in RSS calculation [m/s^2]
+        validation:
+          bounds<>: [0.0, 10.0]
+      reaction_time:
+        type: double
+        default_value: 0.2
+        description: reaction time used in RSS calculation [s]
+        validation:
+          bounds<>: [0.0, 10.0]
+      safety_margin:
+        type: double
+        default_value: 2.0
+        description: safety margin used in RSS calculation [m]
+        validation:
+          bounds<>: [0.0, 10.0]
+      lookahead_horizon:
+        type: double
+        default_value: 1.5
+        description: lookahead horizon used in RSS calculation [s]
+        validation:
+          bounds<>: [0.0, 10.0]
+
+  surround_obstacle_stop:
+    enable:
+      type: bool
+      default_value: true
+      description: enable surround obstacle stop
+      read_only: false
+    use_objects:
+      type: bool
+      default_value: true
+      description: enable the use of objects for surround obstacle stop
+      read_only: false
+    use_pointcloud:
+      type: bool
+      default_value: false
+      description: enable the use of pointcloud for surround obstacle stop
+      read_only: false
+    object_types:
+      type: string_array
+      default_value:
+        [car, truck, bus, trailer, motorcycle, bicycle, pedestrian, hazard, animal, unknown]
+      description: types of objects to consider for surround obstacle stop
+      read_only: false
+    base_distance_th:
+      &distance_th_template {
+        type: double,
+        default_value: 0.5,
+        validation: { bounds<>: [0.0, 10.0] },
+        read_only: false,
+      }
+    base:
+      &base_template {
+        car: *distance_th_template,
+        truck: *distance_th_template,
+        bus: *distance_th_template,
+        trailer: *distance_th_template,
+        motorcycle: *distance_th_template,
+        bicycle: *distance_th_template,
+        pedestrian: *distance_th_template,
+        hazard: *distance_th_template,
+        animal: *distance_th_template,
+        unknown: *distance_th_template,
+        pointcloud: *distance_th_template,
+      }
+    front_distance_th: *base_template
+    side_distance_th: *base_template
+    back_distance_th: *base_template
+    hysteresis_distance:
+      type: double
+      default_value: 0.1
+      description: distance hysteresis threshold for clearing surround stop [m]
+      validation:
+        bounds<>: [0.0, 10.0]
+      read_only: false
+    hysteresis_time:
+      type: double
+      default_value: 0.2
+      description: time hysteresis threshold for clearing surround stop [s]
+      validation:
+        bounds<>: [0.0, 10.0]
+      read_only: false
+    ego_stopped_vel_th:
+      type: double
+      default_value: 0.1
+      description: velocity threshold below which ego vehicle is considered stopped [m/s]
+      validation:
+        bounds<>: [0.0, 10.0]
+      read_only: false
+
+  debug:
+    enable_path:
+      type: bool
+      default_value: true
+      description: publish debug path_with_lane_id
+
+    enable_output_trajectory:
+      type: bool
+      default_value: true
+      description: publish debug final output trajectory
+
+    enable_shifted_trajectory:
+      type: bool
+      default_value: true
+      description: publish debug shifted trajectory
+
+    enable_optimizer_trajectory:
+      type: bool
+      default_value: true
+      description: publish debug optimizer module trajectories
+
+    enable_modifier_trajectory:
+      type: bool
+      default_value: true
+      description: publish debug modifier module trajectories
+
+  # Post-optimization resample parameters
+  post_resample:
+    max_trajectory_length:
+      type: double
+      default_value: 300.0
+      description: max trajectory length for post-optimization resampling [m]
+
+    min_trajectory_length:
+      type: double
+      default_value: 30.0
+      description: min trajectory length for post-optimization resampling [m]
+
+    resample_time:
+      type: double
+      default_value: 10.0
+      description: resample total time for dense sampling after optimization [s]
+
+    dense_resample_dt:
+      type: double
+      default_value: 0.1
+      description: resample time interval for dense sampling after optimization [s]
+
+    dense_min_interval_distance:
+      type: double
+      default_value: 0.1
+      description: minimum points-interval length for dense sampling after optimization [m]
+
+    sparse_resample_dt:
+      type: double
+      default_value: 0.1
+      description: resample time interval for sparse sampling after optimization [s]
+
+    sparse_min_interval_distance:
+      type: double
+      default_value: 1.0
+      description: minimum points-interval length for sparse sampling after optimization [m]

--- a/planning/autoware_minimum_rule_based_planner/plugins.xml
+++ b/planning/autoware_minimum_rule_based_planner/plugins.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<library path="autoware_minimum_rule_based_planner_plugins">
+  <class type="autoware::minimum_rule_based_planner::plugin::ObstacleStop"
+         base_class_type="autoware::minimum_rule_based_planner::plugin::PluginInterface">
+    <description>
+      Obstacle stop plugin for minimum rule based planner
+    </description>
+  </class>
+  <class type="autoware::minimum_rule_based_planner::plugin::SurroundObstacleStop"
+         base_class_type="autoware::minimum_rule_based_planner::plugin::PluginInterface">
+    <description>
+      Surround obstacle stop plugin for minimum rule based planner
+    </description>
+  </class>
+</library>

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
@@ -1,0 +1,455 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "obstacle_stop.hpp"
+
+#include <autoware/planning_factor_interface/planning_factor_interface.hpp>
+#include <autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp>
+#include <autoware/trajectory_modifier/trajectory_modifier_utils/utils.hpp>
+#include <autoware_utils/ros/marker_helper.hpp>
+#include <autoware_utils/transform/transforms.hpp>
+#include <tf2_eigen/tf2_eigen.hpp>
+
+#include <algorithm>
+#include <iomanip>
+#include <limits>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace autoware::minimum_rule_based_planner::plugin
+{
+using autoware::trajectory_modifier::utils::clamp_stop_point_arc_length;
+using autoware::trajectory_modifier::utils::insert_stop_point;
+using autoware::trajectory_modifier::utils::obstacle_stop::get_nearest_object_collision;
+using autoware::trajectory_modifier::utils::obstacle_stop::get_nearest_pcd_collision;
+using autoware::trajectory_modifier::utils::obstacle_stop::get_trajectory_shape;
+using autoware::trajectory_modifier::utils::obstacle_stop::PointCloud;
+
+void ObstacleStop::on_initialize(const MinimumRuleBasedPlannerParams & params)
+{
+  params_ = params.obstacle_stop;
+
+  planning_factor_interface_ =
+    std::make_unique<autoware::planning_factor_interface::PlanningFactorInterface>(
+      get_node_ptr(), "backup_planner_obstacle_stop");
+
+  pointcloud_filter_ =
+    std::make_unique<trajectory_modifier::utils::obstacle_stop::PointCloudFilter>(
+      params_.pointcloud.voxel_grid_filter.x, params_.pointcloud.voxel_grid_filter.y,
+      params_.pointcloud.voxel_grid_filter.z, params_.pointcloud.voxel_grid_filter.min_size,
+      params_.pointcloud.clustering.tolerance, params_.pointcloud.clustering.min_size,
+      params_.pointcloud.clustering.max_size);
+
+  object_filter_ = std::make_unique<trajectory_modifier::utils::obstacle_stop::ObjectFilter>(
+    params_.objects.object_types, params_.objects.max_velocity_th,
+    params_.objects.stopped_velocity_th, params_.objects.max_lateral_velocity_th,
+    params_.objects.safety_buffer);
+
+  pub_clustered_pointcloud_ =
+    get_node_ptr()->create_publisher<PointCloud2>("~/obstacle_stop/debug/cluster_points", 1);
+  debug_viz_pub_ = get_node_ptr()->create_publisher<MarkerArray>("~/obstacle_stop/debug/marker", 1);
+  pub_debug_text_ =
+    get_node_ptr()->create_publisher<StringStamped>("~/obstacle_stop/debug/text", 1);
+
+  update_object_decel_map();
+}
+
+void ObstacleStop::run(TrajectoryPoints & traj_points, const ModifierData & data)
+{
+  if (!params_.enable) return;
+
+  const auto detected = is_obstacle_detected(traj_points, data);
+  publish_debug_string(!detected);
+  publish_debug_data("obstacle_stop", data);
+
+  if (!detected) return;
+  if (!nearest_collision_point_) return;
+
+  set_stop_point(traj_points, data);
+}
+
+bool ObstacleStop::is_obstacle_detected(
+  const TrajectoryPoints & traj_points, const ModifierData & data)
+{
+  debug_data_ = DebugData();
+  safety_factors_ = SafetyFactorArray{};
+  debug_data_.trajectory_shape = get_trajectory_shape(
+    traj_points, data.odometry_ptr->pose.pose, context_->vehicle_info,
+    data.odometry_ptr->twist.twist.linear.x, data.acceleration_ptr->accel.accel.linear.x,
+    params_.nominal_stopping_decel, params_.stopping_jerk, params_.stop_margin,
+    params_.lateral_margin);
+  const auto collision_point_pcd = check_pointcloud(traj_points, data);
+  update_collision_points_buffer(collision_points_buffer_.pcd, traj_points, collision_point_pcd);
+  const auto collision_point_objects = check_predicted_objects(traj_points, data);
+  update_collision_points_buffer(
+    collision_points_buffer_.objects, traj_points, collision_point_objects);
+
+  const auto nearest_pcd_collision_point =
+    get_nearest_collision_point(collision_points_buffer_.pcd);
+  const auto nearest_objects_collision_point =
+    get_nearest_collision_point(collision_points_buffer_.objects);
+
+  const auto make_safety_factor =
+    [](const geometry_msgs::msg::Point & point, const SafetyFactor::_type_type type) {
+      SafetyFactor factor;
+      factor.type = type;
+      factor.points.emplace_back(point);
+      factor.is_safe = false;
+      return factor;
+    };
+  if (nearest_objects_collision_point) {
+    RCLCPP_WARN_THROTTLE(
+      get_node_ptr()->get_logger(), *get_clock(), 500,
+      "[Backup Planner ObstacleStop] Detected collision with object at arc length %f m",
+      nearest_objects_collision_point->arc_length);
+    if (debug_data_.colliding_object) {
+      auto factor = make_safety_factor(
+        debug_data_.colliding_object->kinematics.initial_pose_with_covariance.pose.position,
+        SafetyFactor::OBJECT);
+      factor.object_id = debug_data_.colliding_object->object_id;
+      safety_factors_.factors.push_back(factor);
+    }
+  }
+
+  if (nearest_pcd_collision_point) {
+    RCLCPP_WARN_THROTTLE(
+      get_node_ptr()->get_logger(), *get_clock(), 500,
+      "[Backup Planner ObstacleStop] Detected collision with pointcloud at arc length %f m",
+      nearest_pcd_collision_point->arc_length);
+    safety_factors_.factors.push_back(
+      make_safety_factor(nearest_pcd_collision_point->point, SafetyFactor::POINTCLOUD));
+  }
+
+  nearest_collision_point_ = std::invoke([&]() -> std::optional<CollisionPoint> {
+    const auto is_collision_point_pcd =
+      params_.enable_stop_for_pointcloud && nearest_pcd_collision_point;
+    const auto is_collision_point_objects =
+      params_.enable_stop_for_objects && nearest_objects_collision_point;
+    if (!is_collision_point_pcd && !is_collision_point_objects) return std::nullopt;
+    if (!is_collision_point_pcd) return nearest_objects_collision_point.value();
+    if (!is_collision_point_objects) return nearest_pcd_collision_point.value();
+    return nearest_pcd_collision_point->arc_length < nearest_objects_collision_point->arc_length
+             ? nearest_pcd_collision_point.value()
+             : nearest_objects_collision_point.value();
+  });
+
+  debug_data_.active_collision_point =
+    nearest_collision_point_ ? nearest_collision_point_->point : geometry_msgs::msg::Point();
+
+  return nearest_collision_point_ != std::nullopt;
+}
+
+void ObstacleStop::set_stop_point(TrajectoryPoints & traj_points, const ModifierData & data)
+{
+  const auto stop_margin = params_.stop_margin + context_->vehicle_info.max_longitudinal_offset_m;
+  const auto target_stop_point_arc_length = clamp_stop_point_arc_length(
+    nearest_collision_point_->arc_length - stop_margin,
+    debug_data_.trajectory_shape.trajectory_length, data.odometry_ptr->twist.twist.linear.x,
+    data.acceleration_ptr->accel.accel.linear.x, params_.nominal_stopping_decel,
+    params_.stopping_jerk);
+
+  if (!insert_stop_point(
+        traj_points, target_stop_point_arc_length, debug_data_.trajectory_shape.trajectory_length))
+    return;
+
+  if (
+    target_stop_point_arc_length < params_.arrived_distance_threshold ||
+    !insert_stop_point(
+      traj_points, target_stop_point_arc_length, debug_data_.trajectory_shape.trajectory_length)) {
+    auto p = traj_points.front();
+    traj_points.clear();
+    p.longitudinal_velocity_mps = 0.0;
+    p.acceleration_mps2 = 0.0;
+    p.time_from_start = rclcpp::Duration::from_seconds(0.0);
+    traj_points.push_back(p);
+    p.time_from_start = rclcpp::Duration::from_seconds(0.1);
+    traj_points.push_back(p);
+  }
+
+  const auto & stop_pose = traj_points.back().pose;
+  const auto & ego_pose = data.odometry_ptr->pose.pose;
+  planning_factor_interface_->add(
+    traj_points, ego_pose, stop_pose, PlanningFactor::STOP, safety_factors_);
+
+  RCLCPP_WARN_THROTTLE(
+    get_node_ptr()->get_logger(), *get_clock(), 500,
+    "[Backup Planner ObstacleStop] Inserted stop point at arc length %f m",
+    target_stop_point_arc_length);
+}
+
+std::optional<CollisionPoint> ObstacleStop::check_predicted_objects(
+  const TrajectoryPoints & traj_points, const ModifierData & data)
+{
+  if (!params_.use_objects) return std::nullopt;
+
+  if (!data.predicted_objects_ptr || data.predicted_objects_ptr->objects.empty())
+    return std::nullopt;
+  auto predicted_objects = *data.predicted_objects_ptr;
+
+  object_filter_->filter_objects(predicted_objects);
+  object_filter_->filter_by_target_area(
+    predicted_objects, traj_points, context_->vehicle_info, debug_data_.trajectory_shape.polygon,
+    debug_data_.target_polygons);
+
+  autoware_perception_msgs::msg::PredictedObject colliding_object;
+  auto collision_point = get_nearest_object_collision(
+    traj_points, context_->vehicle_info, predicted_objects, object_decel_map_,
+    params_.rss_params.ego_decel, params_.rss_params.reaction_time,
+    params_.rss_params.safety_margin, params_.objects.stopped_velocity_th,
+    params_.rss_params.lookahead_horizon, colliding_object, params_.rss_params.enable);
+
+  if (collision_point) debug_data_.colliding_object = colliding_object;
+  return collision_point;
+}
+
+std::optional<CollisionPoint> ObstacleStop::check_pointcloud(
+  const TrajectoryPoints & traj_points, const ModifierData & data)
+{
+  if (!params_.use_pointcloud) return std::nullopt;
+
+  if (!data.obstacle_pointcloud_ptr || data.obstacle_pointcloud_ptr->data.empty())
+    return std::nullopt;
+
+  const auto & pointcloud = data.obstacle_pointcloud_ptr;
+
+  PointCloud::Ptr filtered_pointcloud(new PointCloud);
+  pcl::fromROSMsg(*pointcloud, *filtered_pointcloud);
+
+  {
+    const auto & bounding_box = debug_data_.trajectory_shape.bounding_box;
+    const auto rel_min_point = autoware_utils_geometry::inverse_transform_point(
+      bounding_box.min_corner().to_3d(), data.odometry_ptr->pose.pose);
+    const auto rel_max_point = autoware_utils_geometry::inverse_transform_point(
+      bounding_box.max_corner().to_3d(), data.odometry_ptr->pose.pose);
+    const auto min_z = params_.pointcloud.min_height;
+    const auto max_z = context_->vehicle_info.vehicle_height_m + params_.pointcloud.height_buffer;
+    pointcloud_filter_->filter_pointcloud(
+      filtered_pointcloud, rel_min_point.x(), rel_max_point.x(), rel_min_point.y(),
+      rel_max_point.y(), min_z, max_z);
+  }
+
+  PointCloud::Ptr clustered_points(new PointCloud);
+  pointcloud_filter_->cluster_pointcloud(
+    filtered_pointcloud, clustered_points, params_.pointcloud.clustering.min_height);
+
+  {
+    geometry_msgs::msg::TransformStamped transform_stamped;
+    try {
+      transform_stamped = context_->tf_buffer.lookupTransform(
+        "map", pointcloud->header.frame_id, pointcloud->header.stamp,
+        rclcpp::Duration::from_seconds(0.1));
+    } catch (tf2::TransformException & e) {
+      RCLCPP_WARN(get_node_ptr()->get_logger(), "no transform found for pointcloud: %s", e.what());
+    }
+
+    Eigen::Affine3f isometry = tf2::transformToEigen(transform_stamped.transform).cast<float>();
+    autoware_utils::transform_pointcloud(*filtered_pointcloud, *filtered_pointcloud, isometry);
+  }
+
+  {
+    const auto cluster_pointcloud = std::make_shared<sensor_msgs::msg::PointCloud2>();
+    pcl::toROSMsg(*clustered_points, *cluster_pointcloud);
+    cluster_pointcloud->header.stamp = pointcloud->header.stamp;
+    cluster_pointcloud->header.frame_id = "map";
+    debug_data_.cluster_points = cluster_pointcloud;
+  }
+
+  if (data.predicted_objects_ptr && !data.predicted_objects_ptr->objects.empty()) {
+    pointcloud_filter_->filter_pointcloud_by_object(clustered_points, *data.predicted_objects_ptr);
+  }
+
+  return get_nearest_pcd_collision(
+    traj_points, debug_data_.trajectory_shape, clustered_points, debug_data_.target_pcd_points);
+}
+
+void ObstacleStop::update_collision_points_buffer(
+  std::vector<CollisionPoint> & collision_points_buffer, const TrajectoryPoints & traj_points,
+  const std::optional<CollisionPoint> & collision_point)
+{
+  constexpr double close_distance_threshold = 1.0;
+
+  const auto now = get_clock()->now();
+
+  std::optional<double> closest_distance_diff = std::nullopt;
+  collision_points_buffer.erase(
+    std::remove_if(
+      collision_points_buffer.begin(), collision_points_buffer.end(),
+      [&](CollisionPoint & cp) {
+        if (cp.is_active && (now - cp.start_time).seconds() > params_.off_time_buffer) return true;
+
+        if (!collision_point && !cp.is_active) return true;
+
+        cp.arc_length = motion_utils::calcSignedArcLength(traj_points, 0LU, cp.point);
+        const auto distance_diff = collision_point ? collision_point->arc_length - cp.arc_length
+                                                   : std::numeric_limits<double>::max();
+        const bool is_close = abs(distance_diff) < close_distance_threshold;
+
+        if (!cp.is_active && !is_close) return true;
+
+        if (!cp.is_active && (now - cp.start_time).seconds() > params_.on_time_buffer) {
+          cp.is_active = true;
+          cp.start_time = now;
+        }
+
+        if (
+          is_close &&
+          (!closest_distance_diff || abs(distance_diff) < abs(*closest_distance_diff))) {
+          closest_distance_diff = distance_diff;
+        }
+
+        return false;
+      }),
+    collision_points_buffer.end());
+
+  if (!collision_point) return;
+
+  constexpr double eps = 1e-3;
+  if (collision_points_buffer.empty() || !closest_distance_diff) {
+    collision_points_buffer.emplace_back(*collision_point, now, params_.on_time_buffer < eps);
+    return;
+  }
+
+  auto nearest_collision_point_it = std::find_if(
+    collision_points_buffer.begin(), collision_points_buffer.end(), [&](const CollisionPoint & cp) {
+      return abs(cp.arc_length - collision_point->arc_length) < abs(*closest_distance_diff) + eps;
+    });
+
+  if (nearest_collision_point_it == collision_points_buffer.end()) return;
+
+  if (*closest_distance_diff < 0.0) {
+    nearest_collision_point_it->point = collision_point->point;
+    nearest_collision_point_it->arc_length = collision_point->arc_length;
+  }
+
+  if (nearest_collision_point_it->is_active) {
+    nearest_collision_point_it->start_time = now;
+  }
+}
+
+std::optional<CollisionPoint> ObstacleStop::get_nearest_collision_point(
+  const std::vector<CollisionPoint> & collision_points_buffer) const
+{
+  std::optional<CollisionPoint> nearest_collision_point = std::nullopt;
+  if (collision_points_buffer.empty()) return nearest_collision_point;
+
+  auto minimum_arc_length = std::numeric_limits<double>::max();
+  for (const auto & cp : collision_points_buffer) {
+    if (cp.is_active > minimum_arc_length || !cp.is_active) continue;
+    nearest_collision_point = cp;
+    minimum_arc_length = cp.arc_length;
+  }
+
+  return nearest_collision_point;
+}
+
+void ObstacleStop::publish_debug_string(bool is_safe) const
+{
+  const auto cluster_pcd_size =
+    debug_data_.cluster_points ? debug_data_.cluster_points->data.size() : 0;
+  std::ostringstream ss;
+  ss << std::fixed << std::setprecision(2) << std::boolalpha;
+  ss << "OBSTACLE STOP (Backup Planner):" << "\n";
+  ss << "\t\t" << "SAFE: " << is_safe << "\n";
+  ss << "\t\t" << "OBJECTS: " << debug_data_.filtered_objects.objects.size() << " --> "
+     << debug_data_.target_polygons.size() << "\n";
+  ss << "\t\t" << "POINTCLOUD: " << cluster_pcd_size << " --> "
+     << debug_data_.target_pcd_points.size() << "\n";
+  if (nearest_collision_point_) {
+    ss << "\t\t" << "DISTANCE TO COLLISION: " << nearest_collision_point_->arc_length << " m"
+       << "\n";
+  }
+
+  StringStamped string_stamp;
+  string_stamp.stamp = get_clock()->now();
+  string_stamp.data = ss.str();
+  pub_debug_text_->publish(string_stamp);
+}
+
+void ObstacleStop::publish_debug_data(const std::string & ns, const ModifierData & data) const
+{
+  if (debug_data_.cluster_points) pub_clustered_pointcloud_->publish(*debug_data_.cluster_points);
+
+  MarkerArray marker_array;
+  const auto ego_z = data.odometry_ptr->pose.pose.position.z;
+  const auto white = autoware_utils::create_marker_color(1.0, 1.0, 1.0, 1.0);
+  const auto yellow = autoware_utils::create_marker_color(1.0, 1.0, 0.0, 1.0);
+  const auto magenta = autoware_utils::create_marker_color(1.0, 0.0, 1.0, 1.0);
+
+  auto add_point_marker = [&](
+                            const geometry_msgs::msg::Point & point, const std::string & marker_ns,
+                            const int id, const std_msgs::msg::ColorRGBA & color,
+                            const double scale = 0.1) {
+    Marker marker = autoware_utils::create_default_marker(
+      "map", get_clock()->now(), marker_ns, id, Marker::SPHERE,
+      autoware_utils::create_marker_scale(scale, scale, scale), color);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.2);
+    marker.pose.position = point;
+    marker_array.markers.push_back(marker);
+  };
+
+  auto add_polygon_marker = [&](
+                              const Polygon2d & polygon, const std::string & marker_ns,
+                              const int id, const std_msgs::msg::ColorRGBA & color) {
+    Marker marker = autoware_utils::create_default_marker(
+      "map", get_clock()->now(), marker_ns, id, Marker::LINE_STRIP,
+      autoware_utils::create_marker_scale(0.1, 0.1, 0.1), color);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.2);
+
+    for (const auto & p : polygon.outer()) {
+      marker.points.push_back(autoware_utils_geometry::create_point(p.x(), p.y(), ego_z));
+    }
+    if (!marker.points.empty()) {
+      marker.points.push_back(marker.points.front());
+    }
+    marker_array.markers.push_back(marker);
+  };
+
+  int id = 0;
+  for (const auto & traj_polygon : debug_data_.trajectory_shape.polygon) {
+    add_polygon_marker(traj_polygon, ns + "/traj_polygon", id, yellow);
+    id++;
+  }
+
+  {
+    const auto & bounding_box = debug_data_.trajectory_shape.bounding_box;
+    Polygon2d polygon;
+    polygon.outer().emplace_back(bounding_box.min_corner());
+    polygon.outer().emplace_back(bounding_box.min_corner().x(), bounding_box.max_corner().y());
+    polygon.outer().emplace_back(bounding_box.max_corner());
+    polygon.outer().emplace_back(bounding_box.max_corner().x(), bounding_box.min_corner().y());
+    add_polygon_marker(polygon, ns + "/traj_bounding_box", id, white);
+    id++;
+  }
+
+  for (const auto & target_polygon : debug_data_.target_polygons) {
+    add_polygon_marker(target_polygon, ns + "/target_objects", id, magenta);
+    id++;
+  }
+
+  for (const auto & target_pcd_point : debug_data_.target_pcd_points) {
+    add_point_marker(target_pcd_point, ns + "/target_pcd", id, magenta, 0.25);
+    id++;
+  }
+
+  debug_viz_pub_->publish(marker_array);
+}
+
+}  // namespace autoware::minimum_rule_based_planner::plugin
+
+#include <pluginlib/class_list_macros.hpp>
+PLUGINLIB_EXPORT_CLASS(
+  autoware::minimum_rule_based_planner::plugin::ObstacleStop,
+  autoware::minimum_rule_based_planner::plugin::PluginInterface)

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
@@ -205,11 +205,18 @@ std::optional<CollisionPoint> ObstacleStop::check_predicted_objects(
     debug_data_.target_polygons);
 
   autoware_perception_msgs::msg::PredictedObject colliding_object;
-  auto collision_point = get_nearest_object_collision(
-    traj_points, context_->vehicle_info, predicted_objects, object_decel_map_,
-    params_.rss_params.ego_decel, params_.rss_params.reaction_time,
-    params_.rss_params.safety_margin, params_.objects.stopped_velocity_th,
-    params_.rss_params.lookahead_horizon, colliding_object, params_.rss_params.enable);
+  // TODO(Quda): Port the latest modifier logic
+  std::optional<CollisionPoint> collision_point;
+  if (params_.rss_params.enable) {
+    collision_point = get_nearest_object_collision(
+      traj_points, context_->vehicle_info, predicted_objects, object_decel_map_,
+      params_.rss_params.ego_decel, params_.rss_params.reaction_time,
+      params_.rss_params.safety_margin, params_.objects.stopped_velocity_th,
+      params_.rss_params.lookahead_horizon, colliding_object);
+  } else {
+    collision_point =
+      get_nearest_object_collision(traj_points, predicted_objects, colliding_object);
+  }
 
   if (collision_point) debug_data_.colliding_object = colliding_object;
   return collision_point;

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.hpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.hpp
@@ -1,0 +1,143 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef PLANNING__AUTOWARE_MINIMUM_RULE_BASED_PLANNER__PLUGINS__OBSTACLE_STOP_HPP_
+#define PLANNING__AUTOWARE_MINIMUM_RULE_BASED_PLANNER__PLUGINS__OBSTACLE_STOP_HPP_
+
+#include "autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp"
+#include "plugin_interface.hpp"
+
+#include <autoware_utils_rclcpp/polling_subscriber.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <autoware_internal_debug_msgs/msg/string_stamped.hpp>
+#include <visualization_msgs/msg/marker_array.hpp>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace autoware::minimum_rule_based_planner::plugin
+{
+using autoware_internal_debug_msgs::msg::StringStamped;
+using autoware_internal_planning_msgs::msg::SafetyFactor;
+using autoware_internal_planning_msgs::msg::SafetyFactorArray;
+using autoware_planning_msgs::msg::TrajectoryPoint;
+using autoware_utils_geometry::MultiPolygon2d;
+using autoware_utils_geometry::Polygon2d;
+using trajectory_modifier::utils::obstacle_stop::CollisionPoint;
+using trajectory_modifier::utils::obstacle_stop::DebugData;
+using trajectory_modifier::utils::obstacle_stop::ObjectDecelMap;
+using trajectory_modifier::utils::obstacle_stop::ObjectType;
+using visualization_msgs::msg::Marker;
+using visualization_msgs::msg::MarkerArray;
+using TrajectoryPoints = std::vector<TrajectoryPoint>;
+using trajectory_modifier::utils::obstacle_stop::PointCloud2;
+
+class ObstacleStop : public PluginInterface
+{
+public:
+  ObstacleStop() = default;
+
+  void run(TrajectoryPoints & traj_points, const ModifierData & data) override;
+
+  void update_params(const MinimumRuleBasedPlannerParams & params) override
+  {
+    params_ = params.obstacle_stop;
+
+    {
+      const auto & p = params_.objects;
+      object_filter_->set_params(
+        p.object_types, p.max_velocity_th, p.stopped_velocity_th, p.max_lateral_velocity_th,
+        p.safety_buffer);
+    }
+
+    {
+      const auto & p = params_.pointcloud;
+      pointcloud_filter_->set_params(
+        p.voxel_grid_filter.x, p.voxel_grid_filter.y, p.voxel_grid_filter.z,
+        p.voxel_grid_filter.min_size, p.clustering.tolerance, p.clustering.min_size,
+        p.clustering.max_size);
+    }
+
+    update_object_decel_map();
+  }
+  const MinimumRuleBasedPlannerParams::ObstacleStop & get_params() const { return params_; }
+
+protected:
+  void on_initialize(const MinimumRuleBasedPlannerParams & params) override;
+
+private:
+  MinimumRuleBasedPlannerParams::ObstacleStop params_;
+
+  struct CollisionPointBuffer
+  {
+    std::vector<CollisionPoint> pcd;
+    std::vector<CollisionPoint> objects;
+
+    bool empty() const { return pcd.empty() && objects.empty(); }
+  } collision_points_buffer_;
+
+  std::optional<CollisionPoint> nearest_collision_point_;
+
+  SafetyFactorArray safety_factors_;
+
+  DebugData debug_data_;
+
+  std::unique_ptr<trajectory_modifier::utils::obstacle_stop::PointCloudFilter> pointcloud_filter_;
+
+  std::unique_ptr<trajectory_modifier::utils::obstacle_stop::ObjectFilter> object_filter_;
+
+  ObjectDecelMap object_decel_map_;
+
+  rclcpp::Publisher<MarkerArray>::SharedPtr debug_viz_pub_;
+  rclcpp::Publisher<PointCloud2>::SharedPtr pub_clustered_pointcloud_;
+  rclcpp::Publisher<StringStamped>::SharedPtr pub_debug_text_;
+
+  void update_object_decel_map()
+  {
+    const auto & p = params_.rss_params;
+    object_decel_map_ = {
+      {ObjectType::CAR, p.object_decel.car},
+      {ObjectType::TRUCK, p.object_decel.truck},
+      {ObjectType::BUS, p.object_decel.bus},
+      {ObjectType::TRAILER, p.object_decel.trailer},
+      {ObjectType::MOTORCYCLE, p.object_decel.motorcycle},
+      {ObjectType::BICYCLE, p.object_decel.bicycle},
+      {ObjectType::PEDESTRIAN, p.object_decel.pedestrian}};
+  }
+
+  bool is_obstacle_detected(const TrajectoryPoints & traj_points, const ModifierData & data);
+
+  std::optional<CollisionPoint> check_predicted_objects(
+    const TrajectoryPoints & traj_points, const ModifierData & data);
+  std::optional<CollisionPoint> check_pointcloud(
+    const TrajectoryPoints & traj_points, const ModifierData & data);
+
+  void update_collision_points_buffer(
+    std::vector<CollisionPoint> & collision_points_buffer, const TrajectoryPoints & traj_points,
+    const std::optional<CollisionPoint> & collision_point);
+
+  std::optional<CollisionPoint> get_nearest_collision_point(
+    const std::vector<CollisionPoint> & collision_points_buffer) const;
+
+  void set_stop_point(TrajectoryPoints & traj_points, const ModifierData & data);
+
+  void publish_debug_string(bool is_safe) const;
+  void publish_debug_data(const std::string & ns, const ModifierData & data) const;
+};
+
+}  // namespace autoware::minimum_rule_based_planner::plugin
+
+#endif  // PLANNING__AUTOWARE_MINIMUM_RULE_BASED_PLANNER__PLUGINS__OBSTACLE_STOP_HPP_

--- a/planning/autoware_minimum_rule_based_planner/plugins/plugin_interface.hpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/plugin_interface.hpp
@@ -123,7 +123,7 @@ protected:
 
 private:
   std::string name_;
-  rclcpp::Node * node_ptr_;
+  rclcpp::Node * node_ptr_{nullptr};
   mutable std::shared_ptr<autoware_utils_debug::TimeKeeper> time_keeper_{nullptr};
 };
 }  // namespace autoware::minimum_rule_based_planner::plugin

--- a/planning/autoware_minimum_rule_based_planner/plugins/plugin_interface.hpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/plugin_interface.hpp
@@ -1,0 +1,132 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOLINTNEXTLINE
+#ifndef PLANNING__AUTOWARE_MINIMUM_RULE_BASED_PLANNER__PLUGINS__PLUGIN_INTERFACE_HPP_
+// NOLINTNEXTLINE
+#define PLANNING__AUTOWARE_MINIMUM_RULE_BASED_PLANNER__PLUGINS__PLUGIN_INTERFACE_HPP_
+
+#include <autoware/planning_factor_interface/planning_factor_interface.hpp>
+#include <autoware/vehicle_info_utils/vehicle_info.hpp>
+#include <autoware/vehicle_info_utils/vehicle_info_utils.hpp>
+#include <autoware_minimum_rule_based_planner/minimum_rule_based_planner_parameters.hpp>
+#include <autoware_utils_debug/time_keeper.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <autoware_perception_msgs/msg/predicted_objects.hpp>
+#include <autoware_planning_msgs/msg/trajectory.hpp>
+#include <autoware_planning_msgs/msg/trajectory_point.hpp>
+#include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
+
+#include <iostream>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace autoware::minimum_rule_based_planner::plugin
+{
+using autoware::vehicle_info_utils::VehicleInfo;
+using autoware_internal_planning_msgs::msg::PlanningFactor;
+using autoware_perception_msgs::msg::PredictedObjects;
+using autoware_planning_msgs::msg::TrajectoryPoint;
+using geometry_msgs::msg::AccelWithCovarianceStamped;
+using nav_msgs::msg::Odometry;
+using sensor_msgs::msg::PointCloud2;
+using TrajectoryPoints = std::vector<TrajectoryPoint>;
+using MinimumRuleBasedPlannerParams = ::minimum_rule_based_planner::Params;
+
+struct ModifierData
+{
+  Odometry::ConstSharedPtr odometry_ptr;
+  AccelWithCovarianceStamped::ConstSharedPtr acceleration_ptr;
+  PointCloud2::ConstSharedPtr obstacle_pointcloud_ptr;
+  PredictedObjects::ConstSharedPtr predicted_objects_ptr;
+};
+
+struct ModifierContext
+{
+  explicit ModifierContext(rclcpp::Node * node)
+  : vehicle_info(autoware::vehicle_info_utils::VehicleInfoUtils(*node).getVehicleInfo()),
+    tf_buffer{node->get_clock()},
+    tf_listener{tf_buffer}
+  {
+  }
+
+  VehicleInfo vehicle_info;
+  tf2_ros::Buffer tf_buffer;
+  tf2_ros::TransformListener tf_listener;
+};
+
+class PluginInterface
+{
+public:
+  PluginInterface() = default;
+
+  void initialize(
+    std::string name, rclcpp::Node * node_ptr,
+    const std::shared_ptr<autoware_utils_debug::TimeKeeper> time_keeper,
+    const std::shared_ptr<ModifierContext> & context, const MinimumRuleBasedPlannerParams & params)
+  {
+    name_ = std::move(name);
+    node_ptr_ = node_ptr;
+    time_keeper_ = time_keeper;
+    context_ = context;
+    RCLCPP_DEBUG(node_ptr_->get_logger(), "instantiated PluginInterface: %s", name_.c_str());
+    on_initialize(params);
+  }
+
+  virtual ~PluginInterface() = default;
+  virtual void run(TrajectoryPoints & traj_points, const ModifierData & modifier_data) = 0;
+  std::string get_name() const { return name_; }
+  rclcpp::Node * get_node_ptr() const { return node_ptr_; }
+  std::shared_ptr<autoware_utils_debug::TimeKeeper> get_time_keeper() const { return time_keeper_; }
+  virtual void update_params(const MinimumRuleBasedPlannerParams & params) = 0;
+
+  virtual void publish_planning_factor()
+  {
+    if (planning_factor_interface_) {
+      planning_factor_interface_->publish();
+    }
+  }
+  std::vector<PlanningFactor> get_planning_factors() const
+  {
+    if (planning_factor_interface_ != nullptr) {
+      return planning_factor_interface_->get_factors();
+    }
+    return {};
+  }
+
+protected:
+  virtual void on_initialize(const MinimumRuleBasedPlannerParams & params) = 0;
+  std::unique_ptr<autoware::planning_factor_interface::PlanningFactorInterface>
+    planning_factor_interface_;
+  std::shared_ptr<ModifierContext> context_;
+
+  rclcpp::Clock::SharedPtr get_clock() const { return node_ptr_->get_clock(); }
+
+private:
+  std::string name_;
+  rclcpp::Node * node_ptr_;
+  mutable std::shared_ptr<autoware_utils_debug::TimeKeeper> time_keeper_{nullptr};
+};
+}  // namespace autoware::minimum_rule_based_planner::plugin
+
+// NOLINTNEXTLINE
+#endif  // PLANNING__AUTOWARE_MINIMUM_RULE_BASED_PLANNER__PLUGINS__PLUGIN_INTERFACE_HPP_

--- a/planning/autoware_minimum_rule_based_planner/plugins/surround_obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/surround_obstacle_stop.cpp
@@ -1,0 +1,294 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "surround_obstacle_stop.hpp"
+
+#include "autoware/trajectory_modifier/trajectory_modifier_utils/utils.hpp"
+
+#include <autoware/motion_utils/trajectory/trajectory.hpp>
+#include <autoware_utils/transform/transforms.hpp>
+#include <tf2_eigen/tf2_eigen.hpp>
+
+#include <pcl/point_cloud.h>
+#include <pcl_conversions/pcl_conversions.h>
+
+#include <iomanip>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <unordered_set>
+
+namespace
+{
+using autoware::obstacle_proximity_checker::ObstacleTypeParameters;
+using autoware::obstacle_proximity_checker::Parameters;
+using SurroundObstacleStopParams =
+  autoware::minimum_rule_based_planner::plugin::MinimumRuleBasedPlannerParams::SurroundObstacleStop;
+
+ObstacleTypeParameters to_obstacle_type_parameters(
+  const double front_distance, const double side_distance, const double back_distance)
+{
+  ObstacleTypeParameters parameters;
+  parameters.surround_check_front_distance = front_distance;
+  parameters.surround_check_side_distance = side_distance;
+  parameters.surround_check_back_distance = back_distance;
+  return parameters;
+}
+
+Parameters to_proximity_checker_parameters(const SurroundObstacleStopParams & params)
+{
+  Parameters parameters;
+  parameters.pointcloud_enable_check = params.use_pointcloud;
+
+  const std::unordered_set<std::string> enabled_object_types(
+    params.object_types.begin(), params.object_types.end());
+
+  const auto set_object_enable = [&](const std::string & label) {
+    parameters.object_type_enable_check[label] = enabled_object_types.count(label) > 0;
+  };
+  set_object_enable("unknown");
+  set_object_enable("car");
+  set_object_enable("truck");
+  set_object_enable("bus");
+  set_object_enable("trailer");
+  set_object_enable("motorcycle");
+  set_object_enable("bicycle");
+  set_object_enable("pedestrian");
+  set_object_enable("hazard");
+  set_object_enable("animal");
+
+  const auto & front = params.front_distance_th;
+  const auto & side = params.side_distance_th;
+  const auto & back = params.back_distance_th;
+
+  parameters.obstacle_types_map["pointcloud"] =
+    to_obstacle_type_parameters(front.pointcloud, side.pointcloud, back.pointcloud);
+  parameters.obstacle_types_map["unknown"] =
+    to_obstacle_type_parameters(front.unknown, side.unknown, back.unknown);
+  parameters.obstacle_types_map["car"] = to_obstacle_type_parameters(front.car, side.car, back.car);
+  parameters.obstacle_types_map["truck"] =
+    to_obstacle_type_parameters(front.truck, side.truck, back.truck);
+  parameters.obstacle_types_map["bus"] = to_obstacle_type_parameters(front.bus, side.bus, back.bus);
+  parameters.obstacle_types_map["trailer"] =
+    to_obstacle_type_parameters(front.trailer, side.trailer, back.trailer);
+  parameters.obstacle_types_map["motorcycle"] =
+    to_obstacle_type_parameters(front.motorcycle, side.motorcycle, back.motorcycle);
+  parameters.obstacle_types_map["bicycle"] =
+    to_obstacle_type_parameters(front.bicycle, side.bicycle, back.bicycle);
+  parameters.obstacle_types_map["pedestrian"] =
+    to_obstacle_type_parameters(front.pedestrian, side.pedestrian, back.pedestrian);
+  parameters.obstacle_types_map["hazard"] =
+    to_obstacle_type_parameters(front.hazard, side.hazard, back.hazard);
+  parameters.obstacle_types_map["animal"] =
+    to_obstacle_type_parameters(front.animal, side.animal, back.animal);
+
+  return parameters;
+}
+}  // namespace
+
+namespace autoware::minimum_rule_based_planner::plugin
+{
+namespace utils = autoware::trajectory_modifier::utils;
+
+void SurroundObstacleStop::on_initialize(const MinimumRuleBasedPlannerParams & params)
+{
+  params_ = params.surround_obstacle_stop;
+
+  planning_factor_interface_ =
+    std::make_unique<autoware::planning_factor_interface::PlanningFactorInterface>(
+      get_node_ptr(), "backup_planner_surround_obstacle_stop");
+
+  pub_debug_text_ =
+    get_node_ptr()->create_publisher<StringStamped>("~/surround_obstacle_stop/debug/text", 1);
+
+  proximity_checker_ = std::make_unique<obstacle_proximity_checker::ProximityChecker>(
+    to_proximity_checker_parameters(params_), context_->vehicle_info);
+}
+
+void SurroundObstacleStop::update_params(const MinimumRuleBasedPlannerParams & params)
+{
+  params_ = params.surround_obstacle_stop;
+  proximity_checker_->update_parameters(to_proximity_checker_parameters(params_));
+}
+
+void SurroundObstacleStop::run(TrajectoryPoints & traj_points, const ModifierData & data)
+{
+  proximity_check_result_ = std::nullopt;
+
+  if (!is_stop_required(traj_points, data)) {
+    publish_debug_string(false);
+    return;
+  }
+
+  set_stop_point(traj_points, data);
+  publish_debug_string(true);
+}
+
+bool SurroundObstacleStop::check_inputs(const ModifierData & data) const
+{
+  if (!data.odometry_ptr) {
+    return false;
+  }
+
+  if (!params_.use_pointcloud && !params_.use_objects) {
+    return false;
+  }
+
+  const bool has_pointcloud = params_.use_pointcloud && data.obstacle_pointcloud_ptr;
+  const bool has_objects = params_.use_objects && data.predicted_objects_ptr;
+
+  return has_pointcloud || has_objects;
+}
+
+obstacle_proximity_checker::Inputs SurroundObstacleStop::to_proximity_checker_inputs(
+  const ModifierData & data) const
+{
+  obstacle_proximity_checker::Inputs checker_inputs;
+  checker_inputs.ego_pose = data.odometry_ptr->pose.pose;
+  checker_inputs.objects = data.predicted_objects_ptr;
+
+  if (!data.obstacle_pointcloud_ptr || data.obstacle_pointcloud_ptr->data.empty()) {
+    return checker_inputs;
+  }
+
+  const auto transform_stamped = get_transform(
+    "base_link", data.obstacle_pointcloud_ptr->header.frame_id,
+    data.obstacle_pointcloud_ptr->header.stamp, 0.5);
+
+  if (!transform_stamped.has_value()) return checker_inputs;
+
+  Eigen::Affine3f isometry =
+    tf2::transformToEigen(transform_stamped.value().transform).cast<float>();
+  pcl::PointCloud<pcl::PointXYZ> transformed_pointcloud;
+  pcl::fromROSMsg(*data.obstacle_pointcloud_ptr, transformed_pointcloud);
+  autoware_utils::transform_pointcloud(transformed_pointcloud, transformed_pointcloud, isometry);
+
+  checker_inputs.pointcloud_in_base_link = transformed_pointcloud.makeShared();
+
+  return checker_inputs;
+}
+
+std::optional<geometry_msgs::msg::TransformStamped> SurroundObstacleStop::get_transform(
+  const std::string & target, const std::string & source, const rclcpp::Time & stamp,
+  double duration_sec) const
+{
+  geometry_msgs::msg::TransformStamped transform_stamped;
+
+  try {
+    transform_stamped = context_->tf_buffer.lookupTransform(
+      target, source, stamp, tf2::durationFromSec(duration_sec));
+  } catch (const tf2::TransformException & ex) {
+    RCLCPP_WARN_THROTTLE(
+      get_node_ptr()->get_logger(), *get_clock(), 1000, "no transform found for pointcloud: %s",
+      ex.what());
+    return {};
+  }
+
+  return transform_stamped;
+}
+
+bool SurroundObstacleStop::is_obstacle_nearby(const ModifierData & data)
+{
+  const double contact_distance_threshold = is_stop_active_ ? params_.hysteresis_distance : 1e-3;
+
+  if (!proximity_check_result_.has_value()) {
+    proximity_check_result_ =
+      proximity_checker_->check(to_proximity_checker_inputs(data), contact_distance_threshold);
+  }
+
+  const auto & result = proximity_check_result_.value();
+  if (result.is_obstacle_found) {
+    last_obstacle_found_time_ = get_clock()->now();
+    is_stop_active_ = true;
+    return true;
+  }
+
+  if (is_stop_active_ && last_obstacle_found_time_.has_value()) {
+    const auto elapsed_time = get_clock()->now() - last_obstacle_found_time_.value();
+    if (elapsed_time.seconds() <= params_.hysteresis_time) {
+      return true;
+    }
+  }
+
+  is_stop_active_ = false;
+  last_obstacle_found_time_ = std::nullopt;
+  return false;
+}
+
+bool SurroundObstacleStop::is_stop_required(
+  const TrajectoryPoints & traj_points, const ModifierData & data)
+{
+  if (!params_.enable || !check_inputs(data)) {
+    return false;
+  }
+
+  if (
+    utils::is_stop_trajectory(traj_points, params_.ego_stopped_vel_th) ||
+    utils::is_ego_vehicle_moving(data.odometry_ptr->twist.twist, params_.ego_stopped_vel_th)) {
+    is_stop_active_ = false;
+    last_obstacle_found_time_ = std::nullopt;
+    return false;
+  }
+
+  return is_obstacle_nearby(data);
+}
+
+void SurroundObstacleStop::set_stop_point(TrajectoryPoints & traj_points, const ModifierData & data)
+{
+  if (traj_points.empty()) return;
+
+  const auto & ego_pose = data.odometry_ptr->pose.pose;
+
+  // Insert a zero-velocity stop point at the ego pose while keeping the trajectory shape.
+  const auto stop_index = motion_utils::insertStopPoint(ego_pose, 0.0, traj_points);
+  if (!stop_index) {
+    // Fall back to stopping from the front of the trajectory when insertion at ego fails.
+    for (auto & point : traj_points) {
+      point.longitudinal_velocity_mps = 0.0;
+      point.acceleration_mps2 = 0.0;
+    }
+  }
+
+  const auto & stop_pose = stop_index ? traj_points.at(stop_index.value()).pose : ego_pose;
+
+  planning_factor_interface_->add(
+    traj_points, ego_pose, stop_pose, PlanningFactor::STOP,
+    autoware_internal_planning_msgs::msg::SafetyFactorArray{});
+
+  RCLCPP_WARN_THROTTLE(
+    get_node_ptr()->get_logger(), *get_clock(), 1000,
+    "[Backup Planner SurroundObstacleStop] Inserted stop point at ego pose due to nearby "
+    "obstacle.");
+}
+
+void SurroundObstacleStop::publish_debug_string(const bool is_active) const
+{
+  std::ostringstream ss;
+  ss << std::fixed << std::setprecision(2) << std::boolalpha;
+  ss << "SURROUND OBSTACLE STOP (Backup Planner):" << "\n";
+  ss << "\t\t" << "ACTIVE: " << is_active << "\n";
+  ss << "\t\t" << "STOP_ACTIVE: " << is_stop_active_ << "\n";
+
+  StringStamped string_stamp;
+  string_stamp.stamp = get_clock()->now();
+  string_stamp.data = ss.str();
+  pub_debug_text_->publish(string_stamp);
+}
+
+}  // namespace autoware::minimum_rule_based_planner::plugin
+
+#include <pluginlib/class_list_macros.hpp>
+PLUGINLIB_EXPORT_CLASS(
+  autoware::minimum_rule_based_planner::plugin::SurroundObstacleStop,
+  autoware::minimum_rule_based_planner::plugin::PluginInterface)

--- a/planning/autoware_minimum_rule_based_planner/plugins/surround_obstacle_stop.hpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/surround_obstacle_stop.hpp
@@ -1,0 +1,84 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef PLANNING__AUTOWARE_MINIMUM_RULE_BASED_PLANNER__PLUGINS__SURROUND_OBSTACLE_STOP_HPP_
+#define PLANNING__AUTOWARE_MINIMUM_RULE_BASED_PLANNER__PLUGINS__SURROUND_OBSTACLE_STOP_HPP_
+
+#include "autoware/obstacle_proximity_checker/obstacle_proximity_checker.hpp"
+#include "plugin_interface.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <autoware_internal_debug_msgs/msg/string_stamped.hpp>
+#include <geometry_msgs/msg/transform_stamped.hpp>
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace autoware::minimum_rule_based_planner::plugin
+{
+using autoware_internal_debug_msgs::msg::StringStamped;
+using autoware_planning_msgs::msg::TrajectoryPoint;
+using TrajectoryPoints = std::vector<TrajectoryPoint>;
+
+class SurroundObstacleStop : public PluginInterface
+{
+public:
+  SurroundObstacleStop() = default;
+
+  void run(TrajectoryPoints & traj_points, const ModifierData & data) override;
+
+  void update_params(const MinimumRuleBasedPlannerParams & params) override;
+
+  const MinimumRuleBasedPlannerParams::SurroundObstacleStop & get_params() const { return params_; }
+
+protected:
+  void on_initialize(const MinimumRuleBasedPlannerParams & params) override;
+
+private:
+  MinimumRuleBasedPlannerParams::SurroundObstacleStop params_;
+
+  std::unique_ptr<obstacle_proximity_checker::ProximityChecker> proximity_checker_;
+
+  std::optional<obstacle_proximity_checker::CheckResult> proximity_check_result_;
+
+  bool is_stop_active_{false};
+  std::optional<rclcpp::Time> last_obstacle_found_time_;
+
+  rclcpp::Publisher<StringStamped>::SharedPtr pub_debug_text_;
+
+  [[nodiscard]] bool check_inputs(const ModifierData & data) const;
+
+  [[nodiscard]] obstacle_proximity_checker::Inputs to_proximity_checker_inputs(
+    const ModifierData & data) const;
+
+  [[nodiscard]] bool is_obstacle_nearby(const ModifierData & data);
+
+  [[nodiscard]] bool is_stop_required(
+    const TrajectoryPoints & traj_points, const ModifierData & data);
+
+  std::optional<geometry_msgs::msg::TransformStamped> get_transform(
+    const std::string & target, const std::string & source, const rclcpp::Time & stamp,
+    double duration_sec) const;
+
+  void set_stop_point(TrajectoryPoints & traj_points, const ModifierData & data);
+
+  void publish_debug_string(bool is_active) const;
+};
+
+}  // namespace autoware::minimum_rule_based_planner::plugin
+
+#endif  // PLANNING__AUTOWARE_MINIMUM_RULE_BASED_PLANNER__PLUGINS__SURROUND_OBSTACLE_STOP_HPP_

--- a/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
+++ b/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
@@ -1,0 +1,949 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Parameters for Minimum Rule Based Planner",
+  "type": "object",
+  "definitions": {
+    "minimum_rule_based_planner": {
+      "type": "object",
+      "properties": {
+        "planning_frequency_hz": {
+          "type": "number",
+          "description": "Planning loop frequency [Hz]",
+          "default": 10.0,
+          "minimum": 0.0
+        },
+        "plugin_names": {
+          "type": "array",
+          "description": "List of plugins to load",
+          "default": [
+            "autoware::minimum_rule_based_planner::plugin::ObstacleStop",
+            "autoware::minimum_rule_based_planner::plugin::SurroundObstacleStop"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "path_planning": {
+          "type": "object",
+          "properties": {
+            "path_length": {
+              "type": "object",
+              "properties": {
+                "backward": {
+                  "type": "number",
+                  "description": "Path length behind ego [m]",
+                  "default": 5.0,
+                  "minimum": 0.0
+                },
+                "forward": {
+                  "type": "number",
+                  "description": "Path length ahead of ego [m]",
+                  "default": 300.0,
+                  "minimum": 0.0
+                }
+              },
+              "required": [],
+              "additionalProperties": false
+            },
+            "smooth_goal_connection": {
+              "type": "object",
+              "properties": {
+                "search_radius_range": {
+                  "type": "number",
+                  "description": "Search radius for goal connection [m]",
+                  "default": 7.5,
+                  "minimum": 0.0
+                },
+                "pre_goal_offset": {
+                  "type": "number",
+                  "description": "Offset before goal for smooth connection [m]",
+                  "default": 1.0,
+                  "minimum": 0.0
+                }
+              },
+              "required": [],
+              "additionalProperties": false
+            },
+            "ego_nearest_lanelet": {
+              "type": "object",
+              "properties": {
+                "dist_threshold": {
+                  "type": "number",
+                  "description": "Distance threshold for ego nearest lanelet [m]",
+                  "default": 3.0,
+                  "minimum": 0.0
+                },
+                "yaw_threshold": {
+                  "type": "number",
+                  "description": "Yaw threshold for ego nearest lanelet [rad]",
+                  "default": 0.174533,
+                  "minimum": 0.0
+                }
+              },
+              "required": [],
+              "additionalProperties": false
+            },
+            "path_shift": {
+              "type": "object",
+              "properties": {
+                "enable": {
+                  "type": "boolean",
+                  "description": "Enable path shifting to ego pose",
+                  "default": true
+                },
+                "minimum_shift_length": {
+                  "type": "number",
+                  "description": "Lateral offset threshold to trigger shift [m]",
+                  "default": 0.5,
+                  "minimum": 0.0
+                },
+                "minimum_shift_yaw": {
+                  "type": "number",
+                  "description": "Yaw deviation threshold to trigger shift [rad]",
+                  "default": 0.349,
+                  "minimum": 0.0
+                },
+                "minimum_shift_distance": {
+                  "type": "number",
+                  "description": "Floor for shift distance [m]",
+                  "default": 5.0,
+                  "minimum": 0.0
+                },
+                "min_speed_for_curvature": {
+                  "type": "number",
+                  "description": "Lower bound on speed for curvature computation [m/s]",
+                  "default": 2.77,
+                  "minimum": 0.0
+                },
+                "lateral_accel_limit": {
+                  "type": "number",
+                  "description": "Lateral acceleration limit for shift [m/s^2]",
+                  "default": 1.0,
+                  "minimum": 0.0
+                }
+              },
+              "required": [],
+              "additionalProperties": false
+            },
+            "waypoint_group": {
+              "type": "object",
+              "properties": {
+                "separation_threshold": {
+                  "type": "number",
+                  "description": "Max distance between waypoints in same group [m]",
+                  "default": 1.0,
+                  "minimum": 0.0
+                },
+                "interval_margin_ratio": {
+                  "type": "number",
+                  "description": "IRatio to expand group interval by lateral distance",
+                  "default": 10.0,
+                  "minimum": 0.0
+                }
+              },
+              "required": [],
+              "additionalProperties": false
+            },
+            "output": {
+              "type": "object",
+              "properties": {
+                "delta_arc_length": {
+                  "type": "number",
+                  "description": "Resampling interval for path-to-trajectory conversion [m]",
+                  "default": 0.5,
+                  "minimum": 0.0
+                }
+              },
+              "required": [],
+              "additionalProperties": false
+            }
+          },
+          "required": [],
+          "additionalProperties": false
+        },
+        "obstacle_stop": {
+          "type": "object",
+          "properties": {
+            "enable": {
+              "type": "boolean",
+              "description": "Enable obstacle stop [m]",
+              "default": true
+            },
+            "use_objects": {
+              "type": "boolean",
+              "description": "Enable object detection [m]",
+              "default": true
+            },
+            "use_pointcloud": {
+              "type": "boolean",
+              "description": "Enable pointcloud detection [m]",
+              "default": true
+            },
+            "enable_stop_for_objects": {
+              "type": "boolean",
+              "description": "Enable stop for objects",
+              "default": true
+            },
+            "enable_stop_for_pointcloud": {
+              "type": "boolean",
+              "description": "Enable stop for pointcloud",
+              "default": false
+            },
+            "stop_margin": {
+              "type": "number",
+              "description": "Stop margin [m]",
+              "default": 6.0,
+              "minimum": 0.0
+            },
+            "nominal_stopping_decel": {
+              "type": "number",
+              "description": "Nominal stopping deceleration [m/s^2]",
+              "default": 1.0,
+              "minimum": 0.0
+            },
+            "maximum_stopping_decel": {
+              "type": "number",
+              "description": "Maximum stopping deceleration [m/s^2]",
+              "default": 4.0,
+              "minimum": 0.0
+            },
+            "stopping_jerk": {
+              "type": "number",
+              "description": "Stopping jerk [m/s^3]",
+              "default": 3.0,
+              "minimum": 0.0
+            },
+            "on_time_buffer": {
+              "type": "number",
+              "description": "On time buffer [s]",
+              "default": 0.5,
+              "minimum": 0.0
+            },
+            "off_time_buffer": {
+              "type": "number",
+              "description": "Off time buffer [s]",
+              "default": 1.0,
+              "minimum": 0.0
+            },
+            "lateral_margin": {
+              "type": "number",
+              "description": "Lateral margin [m]",
+              "default": 0.5,
+              "minimum": 0.0
+            },
+            "arrived_distance_threshold": {
+              "type": "number",
+              "description": "Threshold to check if the ego vehicle has arrived at the stop point [m]",
+              "default": 0.5,
+              "minimum": 0.0
+            },
+            "objects": {
+              "type": "object",
+              "properties": {
+                "object_types": {
+                  "type": "array",
+                  "description": "Object types",
+                  "default": [
+                    "car",
+                    "truck",
+                    "bus",
+                    "trailer",
+                    "motorcycle",
+                    "bicycle",
+                    "pedestrian",
+                    "hazard"
+                  ],
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "max_velocity_th": {
+                  "type": "number",
+                  "description": "Max velocity threshold [m/s]",
+                  "default": 1.0,
+                  "minimum": 0.0
+                },
+                "stopped_velocity_th": {
+                  "type": "number",
+                  "description": "Velocity threshold for target object to be considered as stopped [m/s]",
+                  "default": 0.25,
+                  "minimum": 0.0
+                },
+                "max_lateral_velocity_th": {
+                  "type": "number",
+                  "description": "Maximum lateral velocity threshold for target object [m/s]",
+                  "default": 1.0,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "safety_buffer": {
+                  "type": "number",
+                  "description": "Safety buffer to expand object shape [m]",
+                  "default": 0.0,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                }
+              },
+              "required": [],
+              "additionalProperties": false
+            },
+            "pointcloud": {
+              "type": "object",
+              "properties": {
+                "height_buffer": {
+                  "type": "number",
+                  "description": "Height buffer [m]",
+                  "default": 0.5,
+                  "minimum": 0.0
+                },
+                "min_height": {
+                  "type": "number",
+                  "description": "Min height [m]",
+                  "default": 0.2,
+                  "minimum": 0.0
+                },
+                "detection_range": {
+                  "type": "number",
+                  "description": "Detection range [m]",
+                  "default": 100.0,
+                  "minimum": 0.0
+                },
+                "voxel_grid_filter": {
+                  "type": "object",
+                  "properties": {
+                    "x": {
+                      "type": "number",
+                      "description": "X [m]",
+                      "default": 0.2,
+                      "minimum": 0.0
+                    },
+                    "y": {
+                      "type": "number",
+                      "description": "Y [m]",
+                      "default": 0.2,
+                      "minimum": 0.0
+                    },
+                    "z": {
+                      "type": "number",
+                      "description": "Z [m]",
+                      "default": 0.2,
+                      "minimum": 0.0
+                    },
+                    "min_size": {
+                      "type": "number",
+                      "description": "Min size",
+                      "default": 3,
+                      "minimum": 0.0
+                    }
+                  },
+                  "required": [],
+                  "additionalProperties": false
+                },
+                "clustering": {
+                  "type": "object",
+                  "properties": {
+                    "tolerance": {
+                      "type": "number",
+                      "description": "Tolerance [m]",
+                      "default": 0.5,
+                      "minimum": 0.0
+                    },
+                    "min_height": {
+                      "type": "number",
+                      "description": "Min height [m]",
+                      "default": 0.5,
+                      "minimum": 0.0
+                    },
+                    "min_size": {
+                      "type": "number",
+                      "description": "Min size",
+                      "default": 10,
+                      "minimum": 0.0
+                    },
+                    "max_size": {
+                      "type": "number",
+                      "description": "Max size",
+                      "default": 10000,
+                      "minimum": 0.0
+                    }
+                  },
+                  "required": [],
+                  "additionalProperties": false
+                }
+              },
+              "required": [],
+              "additionalProperties": false
+            },
+            "rss_params": {
+              "type": "object",
+              "properties": {
+                "enable": {
+                  "type": "boolean",
+                  "description": "Enable RSS-based stop logic",
+                  "default": true
+                },
+                "object_decel": {
+                  "type": "object",
+                  "properties": {
+                    "car": {
+                      "type": "number",
+                      "description": "Deceleration for car type objects [m/s^2]",
+                      "default": 1.5,
+                      "minimum": 0.0
+                    },
+                    "truck": {
+                      "type": "number",
+                      "description": "Deceleration for truck type objects [m/s^2]",
+                      "default": 1.5,
+                      "minimum": 0.0
+                    },
+                    "bus": {
+                      "type": "number",
+                      "description": "Deceleration for bus type objects [m/s^2]",
+                      "default": 1.5,
+                      "minimum": 0.0
+                    },
+                    "trailer": {
+                      "type": "number",
+                      "description": "Deceleration for trailer type objects [m/s^2]",
+                      "default": 1.5,
+                      "minimum": 0.0
+                    },
+                    "motorcycle": {
+                      "type": "number",
+                      "description": "Deceleration for motorcycle type objects [m/s^2]",
+                      "default": 3.0,
+                      "minimum": 0.0
+                    },
+                    "bicycle": {
+                      "type": "number",
+                      "description": "Deceleration for bicycle type objects [m/s^2]",
+                      "default": 5.0,
+                      "minimum": 0.0
+                    },
+                    "pedestrian": {
+                      "type": "number",
+                      "description": "Deceleration for pedestrian type objects [m/s^2]",
+                      "default": 5.0,
+                      "minimum": 0.0
+                    }
+                  },
+                  "required": [],
+                  "additionalProperties": false
+                },
+                "ego_decel": {
+                  "type": "number",
+                  "description": "Deceleration for ego vehicle used in RSS calculation [m/s^2]",
+                  "default": 4.0,
+                  "minimum": 0.0
+                },
+                "reaction_time": {
+                  "type": "number",
+                  "description": "Reaction time used in RSS calculation [s]",
+                  "default": 0.2,
+                  "minimum": 0.0
+                },
+                "safety_margin": {
+                  "type": "number",
+                  "description": "Safety margin used in RSS calculation [m]",
+                  "default": 2.0,
+                  "minimum": 0.0
+                },
+                "lookahead_horizon": {
+                  "type": "number",
+                  "description": "Lookahead horizon used in RSS calculation [s]",
+                  "default": 1.5,
+                  "minimum": 0.0
+                }
+              },
+              "required": [],
+              "additionalProperties": false
+            }
+          },
+          "required": [],
+          "additionalProperties": false
+        },
+        "surround_obstacle_stop": {
+          "type": "object",
+          "properties": {
+            "enable": {
+              "type": "boolean",
+              "description": "Enable surround obstacle stop",
+              "default": true
+            },
+            "use_objects": {
+              "type": "boolean",
+              "description": "Enable the use of objects for surround obstacle stop",
+              "default": true
+            },
+            "use_pointcloud": {
+              "type": "boolean",
+              "description": "Enable the use of pointcloud for surround obstacle stop",
+              "default": false
+            },
+            "object_types": {
+              "type": "array",
+              "description": "Types of objects to consider for surround obstacle stop",
+              "default": [
+                "car",
+                "truck",
+                "bus",
+                "trailer",
+                "motorcycle",
+                "bicycle",
+                "pedestrian",
+                "hazard",
+                "animal",
+                "unknown"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
+            "front_distance_th": {
+              "type": "object",
+              "properties": {
+                "car": {
+                  "type": "number",
+                  "description": "Front surround check distance for car [m]",
+                  "default": 0.5,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "truck": {
+                  "type": "number",
+                  "description": "Front surround check distance for truck [m]",
+                  "default": 0.5,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "bus": {
+                  "type": "number",
+                  "description": "Front surround check distance for bus [m]",
+                  "default": 0.5,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "trailer": {
+                  "type": "number",
+                  "description": "Front surround check distance for trailer [m]",
+                  "default": 0.5,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "motorcycle": {
+                  "type": "number",
+                  "description": "Front surround check distance for motorcycle [m]",
+                  "default": 0.5,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "bicycle": {
+                  "type": "number",
+                  "description": "Front surround check distance for bicycle [m]",
+                  "default": 0.5,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "pedestrian": {
+                  "type": "number",
+                  "description": "Front surround check distance for pedestrian [m]",
+                  "default": 0.5,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "hazard": {
+                  "type": "number",
+                  "description": "Front surround check distance for hazard [m]",
+                  "default": 0.5,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "animal": {
+                  "type": "number",
+                  "description": "Front surround check distance for animal [m]",
+                  "default": 0.5,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "unknown": {
+                  "type": "number",
+                  "description": "Front surround check distance for unknown [m]",
+                  "default": 0.5,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "pointcloud": {
+                  "type": "number",
+                  "description": "Front surround check distance for pointcloud [m]",
+                  "default": 0.5,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                }
+              },
+              "required": [],
+              "additionalProperties": false
+            },
+            "side_distance_th": {
+              "type": "object",
+              "properties": {
+                "car": {
+                  "type": "number",
+                  "description": "Side surround check distance for car [m]",
+                  "default": 0.0,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "truck": {
+                  "type": "number",
+                  "description": "Side surround check distance for truck [m]",
+                  "default": 0.0,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "bus": {
+                  "type": "number",
+                  "description": "Side surround check distance for bus [m]",
+                  "default": 0.0,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "trailer": {
+                  "type": "number",
+                  "description": "Side surround check distance for trailer [m]",
+                  "default": 0.0,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "motorcycle": {
+                  "type": "number",
+                  "description": "Side surround check distance for motorcycle [m]",
+                  "default": 1.0,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "bicycle": {
+                  "type": "number",
+                  "description": "Side surround check distance for bicycle [m]",
+                  "default": 1.0,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "pedestrian": {
+                  "type": "number",
+                  "description": "Side surround check distance for pedestrian [m]",
+                  "default": 1.0,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "hazard": {
+                  "type": "number",
+                  "description": "Side surround check distance for hazard [m]",
+                  "default": 0.5,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "animal": {
+                  "type": "number",
+                  "description": "Side surround check distance for animal [m]",
+                  "default": 0.5,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "unknown": {
+                  "type": "number",
+                  "description": "Side surround check distance for unknown [m]",
+                  "default": 0.5,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "pointcloud": {
+                  "type": "number",
+                  "description": "Side surround check distance for pointcloud [m]",
+                  "default": 0.5,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                }
+              },
+              "required": [],
+              "additionalProperties": false
+            },
+            "back_distance_th": {
+              "type": "object",
+              "properties": {
+                "car": {
+                  "type": "number",
+                  "description": "Back surround check distance for car [m]",
+                  "default": 0.0,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "truck": {
+                  "type": "number",
+                  "description": "Back surround check distance for truck [m]",
+                  "default": 0.0,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "bus": {
+                  "type": "number",
+                  "description": "Back surround check distance for bus [m]",
+                  "default": 0.0,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "trailer": {
+                  "type": "number",
+                  "description": "Back surround check distance for trailer [m]",
+                  "default": 0.0,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "motorcycle": {
+                  "type": "number",
+                  "description": "Back surround check distance for motorcycle [m]",
+                  "default": 0.5,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "bicycle": {
+                  "type": "number",
+                  "description": "Back surround check distance for bicycle [m]",
+                  "default": 0.5,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "pedestrian": {
+                  "type": "number",
+                  "description": "Back surround check distance for pedestrian [m]",
+                  "default": 0.5,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "hazard": {
+                  "type": "number",
+                  "description": "Back surround check distance for hazard [m]",
+                  "default": 0.5,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "animal": {
+                  "type": "number",
+                  "description": "Back surround check distance for animal [m]",
+                  "default": 0.5,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "unknown": {
+                  "type": "number",
+                  "description": "Back surround check distance for unknown [m]",
+                  "default": 0.5,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "pointcloud": {
+                  "type": "number",
+                  "description": "Back surround check distance for pointcloud [m]",
+                  "default": 0.5,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                }
+              },
+              "required": [],
+              "additionalProperties": false
+            },
+            "hysteresis_distance": {
+              "type": "number",
+              "description": "Distance hysteresis threshold for clearing surround stop [m]",
+              "default": 0.1,
+              "minimum": 0.0,
+              "maximum": 10.0
+            },
+            "hysteresis_time": {
+              "type": "number",
+              "description": "Time hysteresis threshold for clearing surround stop [s]",
+              "default": 0.2,
+              "minimum": 0.0,
+              "maximum": 10.0
+            },
+            "ego_stopped_vel_th": {
+              "type": "number",
+              "description": "Velocity threshold below which ego vehicle is considered stopped [m/s]",
+              "default": 0.1,
+              "minimum": 0.0,
+              "maximum": 10.0
+            }
+          },
+          "required": [],
+          "additionalProperties": false
+        },
+        "velocity_smoother": {
+          "type": "object",
+          "properties": {
+            "nearest_dist_threshold_m": {
+              "type": "number",
+              "description": "Nearest distance threshold [m]",
+              "default": 1.5,
+              "minimum": 0.0
+            },
+            "nearest_yaw_threshold_deg": {
+              "type": "number",
+              "description": "Nearest yaw threshold [deg]",
+              "default": 60.0,
+              "minimum": 0.0
+            },
+            "target_pull_out_speed_mps": {
+              "type": "number",
+              "description": "Target pull out speed [m/s]",
+              "default": 0.25,
+              "minimum": 0.0
+            },
+            "target_pull_out_acc_mps2": {
+              "type": "number",
+              "description": "Target pull out acceleration [m/s^2]",
+              "default": 0.5,
+              "minimum": 0.0
+            },
+            "max_speed_mps": {
+              "type": "number",
+              "description": "Max speed [m/s]",
+              "default": 13.88,
+              "minimum": 0.0
+            },
+            "max_lateral_accel_mps2": {
+              "type": "number",
+              "description": "Max lateral acceleration [m/s^2]",
+              "default": 1.5,
+              "minimum": 0.0
+            },
+            "set_engage_speed": {
+              "type": "boolean",
+              "description": "Set engage speed at start",
+              "default": true
+            },
+            "limit_speed": {
+              "type": "boolean",
+              "description": "Apply max speed limit",
+              "default": true
+            },
+            "limit_lateral_acceleration": {
+              "type": "boolean",
+              "description": "Apply max lateral acceleration limit",
+              "default": false
+            },
+            "smooth_velocities": {
+              "type": "boolean",
+              "description": "Apply jerk-filtered velocity smoothing",
+              "default": true
+            },
+            "stop_dist_to_prohibit_engage": {
+              "type": "number",
+              "description": "Stop distance to prohibit engage [m]",
+              "default": 0.5,
+              "minimum": 0.0
+            }
+          },
+          "required": [],
+          "additionalProperties": false
+        },
+        "post_resample": {
+          "type": "object",
+          "properties": {
+            "max_trajectory_length": {
+              "type": "number",
+              "description": "Max trajectory length for post-optimization resampling [m]",
+              "default": 300.0,
+              "minimum": 0.0
+            },
+            "min_trajectory_length": {
+              "type": "number",
+              "description": "Minimum trajectory length for post-optimization resampling [m]",
+              "default": 30.0,
+              "minimum": 0.0
+            },
+            "resample_time": {
+              "type": "number",
+              "description": "Resample total time [s]",
+              "default": 10.0,
+              "minimum": 0.0
+            },
+            "dense_resample_dt": {
+              "type": "number",
+              "description": "Dense sampling time interval [s]",
+              "default": 0.1,
+              "minimum": 0.0
+            },
+            "dense_min_interval_distance": {
+              "type": "number",
+              "description": "Dense sampling min interval [m]",
+              "default": 0.1,
+              "minimum": 0.0
+            },
+            "sparse_resample_dt": {
+              "type": "number",
+              "description": "Sparse sampling time interval [s]",
+              "default": 0.1,
+              "minimum": 0.0
+            },
+            "sparse_min_interval_distance": {
+              "type": "number",
+              "description": "Sparse sampling min interval [m]",
+              "default": 1.0,
+              "minimum": 0.0
+            }
+          },
+          "required": [],
+          "additionalProperties": false
+        },
+        "debug": {
+          "type": "object",
+          "properties": {
+            "enable_path": {
+              "type": "boolean",
+              "description": "Enable path debugging",
+              "default": true
+            },
+            "enable_shifted_trajectory": {
+              "type": "boolean",
+              "description": "Enable shifted trajectory debugging",
+              "default": true
+            },
+            "enable_optimizer_trajectory": {
+              "type": "boolean",
+              "description": "Enable optimizer trajectory debugging",
+              "default": true
+            },
+            "enable_modifier_trajectory": {
+              "type": "boolean",
+              "description": "Enable modifier trajectory debugging",
+              "default": true
+            },
+            "enable_output_trajectory": {
+              "type": "boolean",
+              "description": "Enable output trajectory debugging",
+              "default": true
+            }
+          },
+          "required": [],
+          "additionalProperties": false
+        }
+      },
+      "required": [],
+      "additionalProperties": false
+    }
+  },
+  "properties": {
+    "/**": {
+      "type": "object",
+      "properties": {
+        "ros__parameters": {
+          "$ref": "#/definitions/minimum_rule_based_planner"
+        }
+      },
+      "required": ["ros__parameters"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["/**"],
+  "additionalProperties": false
+}

--- a/planning/autoware_minimum_rule_based_planner/src/minimum_rule_based_planner.cpp
+++ b/planning/autoware_minimum_rule_based_planner/src/minimum_rule_based_planner.cpp
@@ -1,0 +1,536 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "minimum_rule_based_planner.hpp"
+
+#include <autoware/motion_utils/resample/resample.hpp>
+#include <autoware/motion_utils/trajectory/conversion.hpp>
+#include <autoware/motion_utils/trajectory/trajectory.hpp>
+#include <autoware/trajectory/utils/pretty_build.hpp>
+#include <autoware/velocity_smoother/resample.hpp>
+#include <autoware_utils/geometry/geometry.hpp>
+
+#include <algorithm>
+#include <limits>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace autoware::minimum_rule_based_planner
+{
+
+namespace
+{
+trajectory_optimizer::TrajectoryOptimizerData make_optimizer_data(
+  const MinimumRuleBasedPlannerNode::InputData & input_data)
+{
+  trajectory_optimizer::TrajectoryOptimizerData data;
+  data.current_odometry = *input_data.odometry_ptr;
+  if (input_data.acceleration_ptr) {
+    data.current_acceleration = *input_data.acceleration_ptr;
+  }
+  return data;
+}
+
+minimum_rule_based_planner::plugin::ModifierData make_modifier_data(
+  const MinimumRuleBasedPlannerNode::InputData & input_data)
+{
+  minimum_rule_based_planner::plugin::ModifierData data;
+  data.odometry_ptr = input_data.odometry_ptr;
+  data.acceleration_ptr = input_data.acceleration_ptr;
+  data.predicted_objects_ptr = input_data.predicted_objects_ptr;
+  data.obstacle_pointcloud_ptr = input_data.obstacle_pointcloud_ptr;
+  return data;
+}
+}  // namespace
+
+MinimumRuleBasedPlannerNode::MinimumRuleBasedPlannerNode(const rclcpp::NodeOptions & options)
+: rclcpp::Node("minimum_rule_based_planner_node", options),
+  generator_uuid_(autoware_utils_uuid::generate_uuid()),
+  vehicle_info_(vehicle_info_utils::VehicleInfoUtils(*this).getVehicleInfo()),
+  modifier_plugin_loader_(
+    "autoware_minimum_rule_based_planner",
+    "autoware::minimum_rule_based_planner::plugin::PluginInterface"),
+  modifier_context_(std::make_shared<plugin::ModifierContext>(this))
+{
+  param_listener_ =
+    std::make_shared<::minimum_rule_based_planner::ParamListener>(get_node_parameters_interface());
+
+  pub_trajectories_ =
+    this->create_publisher<CandidateTrajectories>("~/output/candidate_trajectories", 1);
+  pub_debug_path_ = this->create_publisher<PathWithLaneId>("~/debug/path_with_lane_id", 1);
+  pub_debug_trajectory_ = this->create_publisher<Trajectory>("~/debug/trajectory", 1);
+  pub_debug_shifted_trajectory_ =
+    this->create_publisher<Trajectory>("~/debug/shifted_trajectory", 1);
+  debug_processing_time_detail_pub_ =
+    this->create_publisher<autoware_utils_debug::ProcessingTimeDetail>(
+      "~/debug/processing_time_detail_ms", 1);
+  debug_processing_time_pub_ =
+    this->create_publisher<autoware_internal_debug_msgs::msg::Float64Stamped>(
+      "~/debug/processing_time_ms", 1);
+  time_keeper_ =
+    std::make_shared<autoware_utils_debug::TimeKeeper>(debug_processing_time_detail_pub_);
+
+  params_ = param_listener_->get_params();
+
+  load_optimizer_plugins();
+  load_modifier_plugins();
+
+  path_planner_ =
+    std::make_unique<PathPlanner>(get_logger(), get_clock(), time_keeper_, params_, vehicle_info_);
+  timer_ = rclcpp::create_timer(
+    this, get_clock(), rclcpp::Rate(params_.planning_frequency_hz).period(),
+    std::bind(&MinimumRuleBasedPlannerNode::on_timer, this));
+
+  RCLCPP_INFO(get_logger(), "Minimum Rule Based Planner Node has been started.");
+}
+
+void MinimumRuleBasedPlannerNode::load_optimizer_plugins()
+{
+  // Create plugin loader for autoware_trajectory_optimizer
+  plugin_loader_ = std::make_unique<OptimizerPluginLoader>(
+    "autoware_trajectory_optimizer",
+    "autoware::trajectory_optimizer::plugin::TrajectoryOptimizerPluginBase");
+
+  auto try_load_optimizer_plugin = [&](const std::string & plugin_path, const std::string & name)
+    -> std::shared_ptr<OptimizerPluginInterface> {
+    try {
+      auto plugin = plugin_loader_->createSharedInstance(plugin_path);
+      plugin->initialize(name, this, time_keeper_);
+      pub_debug_optimizer_module_trajectories_[plugin->get_name()] =
+        this->create_publisher<Trajectory>(
+          "~/debug/optimizer/" + plugin->get_name() + "/trajectory", 1);
+      RCLCPP_INFO(get_logger(), "Loaded trajectory %s plugin", name.c_str());
+      return plugin;
+    } catch (const pluginlib::PluginlibException & ex) {
+      RCLCPP_ERROR(
+        get_logger(), "Failed to load trajectory %s plugin: %s", name.c_str(), ex.what());
+      return nullptr;
+    }
+  };
+
+  path_smoother_ = try_load_optimizer_plugin(
+    "autoware::trajectory_optimizer::plugin::TrajectoryEBSmootherOptimizer", "eb_smoother");
+
+  // Set up velocity optimizer
+  // NOTE(odashima):
+  // The velocity_optimizer modifier plugin used in diffusion_planner has different processing,
+  // so a separate implementation is provided here.
+  {
+    VelocitySmootherParams vel_params;
+    vel_params.nearest_dist_threshold_m =
+      declare_parameter<double>("velocity_smoother.nearest_dist_threshold_m");
+    vel_params.nearest_yaw_threshold_deg =
+      declare_parameter<double>("velocity_smoother.nearest_yaw_threshold_deg");
+    vel_params.target_pull_out_speed_mps =
+      declare_parameter<double>("velocity_smoother.target_pull_out_speed_mps");
+    vel_params.target_pull_out_acc_mps2 =
+      declare_parameter<double>("velocity_smoother.target_pull_out_acc_mps2");
+    vel_params.max_speed_mps = declare_parameter<double>("velocity_smoother.max_speed_mps");
+    vel_params.max_lateral_accel_mps2 =
+      declare_parameter<double>("velocity_smoother.max_lateral_accel_mps2");
+    vel_params.stop_dist_to_prohibit_engage =
+      declare_parameter<double>("velocity_smoother.stop_dist_to_prohibit_engage");
+    vel_params.set_engage_speed = declare_parameter<bool>("velocity_smoother.set_engage_speed");
+    vel_params.limit_speed = declare_parameter<bool>("velocity_smoother.limit_speed");
+    vel_params.limit_lateral_acceleration =
+      declare_parameter<bool>("velocity_smoother.limit_lateral_acceleration");
+    vel_params.smooth_velocities = declare_parameter<bool>("velocity_smoother.smooth_velocities");
+
+    const auto vehicle_info =
+      autoware::vehicle_info_utils::VehicleInfoUtils(*this).getVehicleInfo();
+    auto jerk_filtered_smoother =
+      std::make_shared<autoware::velocity_smoother::JerkFilteredSmoother>(*this, time_keeper_);
+
+    velocity_smoother_ = std::make_unique<VelocitySmoother>(
+      vel_params, get_logger(), get_clock(), vehicle_info, std::move(jerk_filtered_smoother));
+  }
+}
+
+void MinimumRuleBasedPlannerNode::load_modifier_plugins()
+{
+  for (const auto & name : params_.plugin_names) {
+    if (name.empty()) continue;
+    load_plugin(name);
+  }
+
+  initialized_modifiers_ = true;
+  RCLCPP_INFO(
+    get_logger(), "Trajectory modifier plugins initialized: %zu plugins", modifier_plugins_.size());
+}
+
+void MinimumRuleBasedPlannerNode::load_plugin(const std::string & name)
+{
+  // Check if the plugin is already instantiated
+  auto it = std::find_if(modifier_plugins_.begin(), modifier_plugins_.end(), [&](const auto & p) {
+    return p->get_name() == name;
+  });
+  if (it != modifier_plugins_.end()) {
+    RCLCPP_WARN(
+      this->get_logger(), "The plugin '%s' is already in the plugins list.", name.c_str());
+    return;
+  }
+
+  if (modifier_plugin_loader_.isClassAvailable(name)) {
+    const auto plugin = modifier_plugin_loader_.createSharedInstance(name);
+    plugin->initialize(name, this, time_keeper_, modifier_context_, params_);
+
+    // Convert "autoware::...::ObstacleStop" to "obstacle_stop"
+    const auto short_name = [](const std::string & plugin_name) {
+      const std::string class_name = plugin_name.find("::") != std::string::npos
+                                       ? plugin_name.substr(plugin_name.rfind("::") + 2)
+                                       : plugin_name;
+      std::string short_name;
+      for (size_t i = 0; i < class_name.size(); ++i) {
+        if (std::isupper(class_name[i])) {
+          if (i > 0) short_name += '_';
+          short_name += static_cast<char>(std::tolower(class_name[i]));
+        } else {
+          short_name += class_name[i];
+        }
+      }
+
+      return short_name;
+    }(name);
+
+    pub_debug_modifier_module_trajectories_[plugin->get_name()] =
+      this->create_publisher<Trajectory>("~/debug/modifier/" + short_name + "/trajectory", 1);
+    modifier_plugins_.push_back(plugin);
+    RCLCPP_DEBUG(this->get_logger(), "The plugin '%s' has been loaded", name.c_str());
+  } else {
+    RCLCPP_ERROR(this->get_logger(), "The plugin '%s' is not available", name.c_str());
+  }
+}
+
+void MinimumRuleBasedPlannerNode::unload_plugin(const std::string & name)
+{
+  auto it = std::remove_if(
+    modifier_plugins_.begin(), modifier_plugins_.end(),
+    [&](const auto plugin) { return plugin->get_name() == name; });
+
+  if (it == modifier_plugins_.end()) {
+    RCLCPP_WARN(
+      this->get_logger(), "The plugin '%s' is not in the registered modules", name.c_str());
+  } else {
+    modifier_plugins_.erase(it, modifier_plugins_.end());
+    RCLCPP_INFO(this->get_logger(), "The scene plugin '%s' has been unloaded", name.c_str());
+  }
+}
+
+void MinimumRuleBasedPlannerNode::publish_debug_trajectory(
+  const std::string & plugin_name, const TrajectoryPoints & traj_points) const
+{
+  Trajectory traj;
+  traj.points = traj_points;
+  pub_debug_modifier_module_trajectories_.at(plugin_name)->publish(traj);
+}
+
+void MinimumRuleBasedPlannerNode::on_timer()
+{
+  autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
+  stop_watch_ptr_ = std::make_unique<autoware_utils_system::StopWatch<std::chrono::milliseconds>>();
+  stop_watch_ptr_->tic("processing_time");
+
+  // 1. Check data availability
+  const auto input_data = take_data();
+  path_planner_->set_planner_data(input_data.lanelet_map_bin_ptr, input_data.route_ptr);
+  if (!is_data_ready(input_data)) {
+    RCLCPP_WARN_THROTTLE(
+      this->get_logger(), *this->get_clock(), 5000,
+      "Waiting for necessary data to plan trajectories.");
+    return;
+  }
+
+  if (param_listener_->is_old(params_)) {
+    update_params();
+  }
+
+  // 2. Get path
+  const auto path = plan_path(input_data);
+
+  if (!path) {
+    RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 5000, "Failed to plan path.");
+    return;
+  }
+
+  // 3. Convert path to trajectory
+  auto traj_from_path =
+    path_planner_->convert_path_to_trajectory(*path, params_.path_planning.output.delta_arc_length);
+  traj_from_path.header = path->header;
+
+  // 4. Shift trajectory to ego position
+  const auto shifted_trajectory = shift_trajectory_to_ego(traj_from_path, input_data);
+
+  // 5. Smooth path
+  auto smoothed_trajectory = smooth_trajectory(shifted_trajectory, input_data);
+
+  // 6. Apply trajectory modifiers
+  apply_modifiers(smoothed_trajectory, input_data);
+
+  // 7. Velocity optimization
+  const auto trajectory = optimize_velocity(smoothed_trajectory, input_data);
+
+  // 8. Create and publish CandidateTrajectories message
+  publish_candidate_trajectories(trajectory);
+
+  // 9. Publish debug information if enabled
+  if (params_.debug.enable_path) {
+    pub_debug_path_->publish(*path);
+  }
+  if (params_.debug.enable_output_trajectory) {
+    pub_debug_trajectory_->publish(trajectory);
+  }
+
+  // Publish processing time
+  autoware_internal_debug_msgs::msg::Float64Stamped processing_time_msg;
+  processing_time_msg.stamp = get_clock()->now();
+  processing_time_msg.data = stop_watch_ptr_->toc("processing_time", true);
+  debug_processing_time_pub_->publish(processing_time_msg);
+}
+
+std::optional<PathWithLaneId> MinimumRuleBasedPlannerNode::plan_path(const InputData & input_data)
+{
+  autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
+  if (input_data.test_path_with_lane_id_ptr) {
+    return *input_data.test_path_with_lane_id_ptr;
+  }
+  return path_planner_->plan_path(
+    input_data.odometry_ptr->pose.pose, input_data.odometry_ptr->twist.twist.linear.x);
+}
+
+Trajectory MinimumRuleBasedPlannerNode::shift_trajectory_to_ego(
+  const Trajectory & trajectory, const InputData & input_data) const
+{
+  autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
+
+  if (!params_.path_planning.path_shift.enable) return trajectory;
+
+  TrajectoryShiftParams shift_params;
+  shift_params.minimum_shift_length = params_.path_planning.path_shift.minimum_shift_length;
+  shift_params.minimum_shift_yaw = params_.path_planning.path_shift.minimum_shift_yaw;
+  shift_params.minimum_shift_distance = params_.path_planning.path_shift.minimum_shift_distance;
+  shift_params.min_speed_for_curvature = params_.path_planning.path_shift.min_speed_for_curvature;
+  shift_params.lateral_accel_limit = params_.path_planning.path_shift.lateral_accel_limit;
+
+  const double ego_velocity = input_data.odometry_ptr->twist.twist.linear.x;
+  const double ego_yaw_rate = input_data.odometry_ptr->twist.twist.angular.z;
+  const auto shifted_trajectory = path_planner_->shift_trajectory_to_ego(
+    trajectory, input_data.odometry_ptr->pose.pose, ego_velocity, ego_yaw_rate, shift_params,
+    params_.path_planning.output.delta_arc_length);
+
+  if (params_.debug.enable_shifted_trajectory) {
+    Trajectory shifted_traj;
+    shifted_traj.header = trajectory.header;
+    shifted_traj.points = shifted_trajectory.points;
+    pub_debug_shifted_trajectory_->publish(shifted_traj);
+  }
+  return shifted_trajectory;
+}
+
+Trajectory MinimumRuleBasedPlannerNode::smooth_trajectory(
+  const Trajectory & trajectory, const InputData & input_data) const
+{
+  autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
+  auto optimizer_data = make_optimizer_data(input_data);
+
+  trajectory_optimizer::TrajectoryOptimizerParams optimizer_params;
+  optimizer_params.use_eb_smoother = true;
+
+  auto trajectory_points = trajectory.points;
+  if (path_smoother_) {
+    autoware_utils_debug::ScopedTimeTrack st_path_smoother(
+      path_smoother_->get_name(), *time_keeper_);
+    path_smoother_->optimize_trajectory(trajectory_points, optimizer_params, optimizer_data);
+    if (params_.debug.enable_optimizer_trajectory) {
+      publish_debug_trajectory(path_smoother_->get_name(), trajectory_points);
+    }
+  }
+
+  Trajectory traj;
+  traj.header = trajectory.header;
+  traj.points = trajectory_points;
+  return traj;
+}
+
+void MinimumRuleBasedPlannerNode::apply_modifiers(
+  Trajectory & trajectory, const InputData & input_data) const
+{
+  autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
+  const auto modifier_data = make_modifier_data(input_data);
+  for (auto & modifier : modifier_plugins_) {
+    autoware_utils_debug::ScopedTimeTrack st_modifier(modifier->get_name(), *time_keeper_);
+    modifier->run(trajectory.points, modifier_data);
+    modifier->publish_planning_factor();
+    if (params_.debug.enable_modifier_trajectory) {
+      publish_debug_trajectory(modifier->get_name(), trajectory.points);
+    }
+  }
+}
+
+Trajectory MinimumRuleBasedPlannerNode::optimize_velocity(
+  const Trajectory & trajectory, const InputData & input_data) const
+{
+  autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
+
+  auto trajectory_points = trajectory.points;
+
+  velocity_smoother_->optimize(
+    trajectory_points, *input_data.odometry_ptr, input_data.acceleration_ptr->accel.accel.linear.x);
+
+  // Post-optimization resample
+  {
+    autoware::velocity_smoother::resampling::ResampleParam post_resample_param;
+    post_resample_param.max_trajectory_length = params_.post_resample.max_trajectory_length;
+    post_resample_param.min_trajectory_length = params_.post_resample.min_trajectory_length;
+    post_resample_param.resample_time = params_.post_resample.resample_time;
+    post_resample_param.dense_resample_dt = params_.post_resample.dense_resample_dt;
+    post_resample_param.dense_min_interval_distance =
+      params_.post_resample.dense_min_interval_distance;
+    post_resample_param.sparse_resample_dt = params_.post_resample.sparse_resample_dt;
+    post_resample_param.sparse_min_interval_distance =
+      params_.post_resample.sparse_min_interval_distance;
+
+    const auto & ego_pose = input_data.odometry_ptr->pose.pose;
+    const double v_current = input_data.odometry_ptr->twist.twist.linear.x;
+
+    trajectory_points = autoware::velocity_smoother::resampling::resampleTrajectory(
+      trajectory_points, v_current, ego_pose,
+      params_.path_planning.ego_nearest_lanelet.dist_threshold,
+      params_.path_planning.ego_nearest_lanelet.yaw_threshold, post_resample_param, false);
+
+    if (!trajectory_points.empty()) {
+      trajectory_points.back().longitudinal_velocity_mps = 0.0;
+    }
+  }
+
+  autoware::motion_utils::calculate_time_from_start(
+    trajectory_points, input_data.odometry_ptr->pose.pose.position);
+
+  Trajectory traj;
+  traj.header = trajectory.header;
+  traj.points = trajectory_points;
+  return traj;
+}
+
+void MinimumRuleBasedPlannerNode::publish_candidate_trajectories(
+  const Trajectory & trajectory) const
+{
+  autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
+
+  autoware_internal_planning_msgs::msg::CandidateTrajectory candidate_traj;
+  candidate_traj.header = trajectory.header;
+  candidate_traj.generator_id = generator_uuid_;
+  candidate_traj.points = trajectory.points;
+
+  CandidateTrajectories msg;
+  msg.candidate_trajectories.push_back(candidate_traj);
+
+  autoware_internal_planning_msgs::msg::GeneratorInfo generator_info;
+  generator_info.generator_id = generator_uuid_;
+  generator_info.generator_name.data = "MinimumRuleBasedPlanner";
+  msg.generator_info.push_back(generator_info);
+
+  pub_trajectories_->publish(msg);
+}
+
+MinimumRuleBasedPlannerNode::InputData MinimumRuleBasedPlannerNode::take_data()
+{
+  autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
+  InputData input_data;
+
+  if (const auto msg = route_subscriber_.take_data()) {
+    if (!msg->segments.empty()) {
+      route_ptr_ = msg;
+    } else {
+      RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 5000, "input route is empty, ignoring...");
+    }
+  }
+  input_data.route_ptr = route_ptr_;
+
+  if (const auto msg = vector_map_subscriber_.take_data()) {
+    lanelet_map_bin_ptr_ = msg;
+  }
+  input_data.lanelet_map_bin_ptr = lanelet_map_bin_ptr_;
+
+  if (const auto msg = odometry_subscriber_.take_data()) {
+    odometry_ptr_ = msg;
+  }
+  input_data.odometry_ptr = odometry_ptr_;
+
+  if (const auto msg = acceleration_subscriber_.take_data()) {
+    acceleration_ptr_ = msg;
+  }
+  input_data.acceleration_ptr = acceleration_ptr_;
+
+  if (const auto msg = objects_subscriber_.take_data()) {
+    predicted_objects_ptr_ = msg;
+  }
+  input_data.predicted_objects_ptr = predicted_objects_ptr_;
+
+  if (const auto msg = pointcloud_subscriber_.take_data()) {
+    obstacle_pointcloud_ptr_ = msg;
+  }
+  input_data.obstacle_pointcloud_ptr = obstacle_pointcloud_ptr_;
+
+  if (const auto msg = test_path_with_lane_id_subscriber_.take_data()) {
+    test_path_with_lane_id_ptr = msg;
+  }
+  input_data.test_path_with_lane_id_ptr = test_path_with_lane_id_ptr;
+
+  return input_data;
+}
+
+bool MinimumRuleBasedPlannerNode::is_data_ready(const InputData & input_data)
+{
+  autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
+  const auto notify_waiting = [this](const std::string & name) {
+    RCLCPP_INFO_SKIPFIRST_THROTTLE(
+      get_logger(), *get_clock(), 5000, "waiting for %s", name.c_str());
+  };
+
+  // NOTE(odashima): on test mode, minimum rule based planner receives path_with_lane_id topic
+  if (!input_data.route_ptr && !input_data.test_path_with_lane_id_ptr) {
+    notify_waiting("route");
+    return false;
+  }
+  if (!input_data.lanelet_map_bin_ptr) {
+    notify_waiting("lanelet map");
+    return false;
+  }
+  if (!input_data.odometry_ptr) {
+    notify_waiting("odometry");
+    return false;
+  }
+  if (!input_data.acceleration_ptr) {
+    notify_waiting("acceleration");
+    return false;
+  }
+  return true;
+}
+
+void MinimumRuleBasedPlannerNode::update_params()
+{
+  params_ = param_listener_->get_params();
+  path_planner_->update_params(params_);
+
+  for (auto & modifier : modifier_plugins_) {
+    modifier->update_params(params_);
+  }
+}
+
+}  // namespace autoware::minimum_rule_based_planner
+
+#include "rclcpp_components/register_node_macro.hpp"
+RCLCPP_COMPONENTS_REGISTER_NODE(autoware::minimum_rule_based_planner::MinimumRuleBasedPlannerNode)

--- a/planning/autoware_minimum_rule_based_planner/src/minimum_rule_based_planner.hpp
+++ b/planning/autoware_minimum_rule_based_planner/src/minimum_rule_based_planner.hpp
@@ -1,0 +1,190 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MINIMUM_RULE_BASED_PLANNER_HPP_
+#define MINIMUM_RULE_BASED_PLANNER_HPP_
+
+#include "autoware/trajectory_optimizer/trajectory_optimizer_structs.hpp"
+#include "path_planner.hpp"
+#include "velocity_smoother.hpp"
+
+#include <autoware_trajectory_modifier/trajectory_modifier_param.hpp>
+#include <autoware_utils/ros/polling_subscriber.hpp>
+#include <autoware_utils_debug/time_keeper.hpp>
+#include <autoware_utils_system/stop_watch.hpp>
+#include <autoware_utils_uuid/uuid_helper.hpp>
+#include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
+
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace autoware::minimum_rule_based_planner
+{
+class MinimumRuleBasedPlannerNode : public rclcpp::Node
+{
+public:
+  explicit MinimumRuleBasedPlannerNode(const rclcpp::NodeOptions & options);
+
+  /**
+   * @brief aggregated input data consumed each planning cycle
+   */
+  struct InputData
+  {
+    LaneletRoute::ConstSharedPtr route_ptr;
+    LaneletMapBin::ConstSharedPtr lanelet_map_bin_ptr;
+    Odometry::ConstSharedPtr odometry_ptr;
+    AccelWithCovarianceStamped::ConstSharedPtr acceleration_ptr;
+    PredictedObjects::ConstSharedPtr predicted_objects_ptr;
+    PointCloud2::ConstSharedPtr obstacle_pointcloud_ptr;
+    PathWithLaneId::ConstSharedPtr test_path_with_lane_id_ptr;
+  };
+
+private:
+  /**
+   ***********************************************************
+   * @defgroup core pipeline
+   * on_timer() is the main entry point, called at planning_frequency_hz.
+   * @{
+   */
+  void on_timer();
+  InputData take_data();
+  bool is_data_ready(const InputData & input_data);
+  void update_params();
+
+  std::optional<PathWithLaneId> plan_path(const InputData & input_data);
+  Trajectory shift_trajectory_to_ego(
+    const Trajectory & trajectory, const InputData & input_data) const;
+  Trajectory smooth_trajectory(const Trajectory & trajectory, const InputData & input_data) const;
+  void apply_modifiers(Trajectory & trajectory, const InputData & input_data) const;
+  Trajectory optimize_velocity(const Trajectory & trajectory, const InputData & input_data) const;
+
+  void publish_candidate_trajectories(const Trajectory & trajectory) const;
+
+  void publish_debug_trajectory(
+    const std::string & plugin_name, const TrajectoryPoints & traj_points) const;
+
+  rclcpp::TimerBase::SharedPtr timer_;
+  std::shared_ptr<::minimum_rule_based_planner::ParamListener> param_listener_;
+  const UUID generator_uuid_;
+  const VehicleInfo vehicle_info_;
+  std::shared_ptr<autoware_utils_debug::TimeKeeper> time_keeper_;
+  rclcpp::Publisher<autoware_utils_debug::ProcessingTimeDetail>::SharedPtr
+    debug_processing_time_detail_pub_;
+  rclcpp::Publisher<autoware_internal_debug_msgs::msg::Float64Stamped>::SharedPtr
+    debug_processing_time_pub_;
+  std::unique_ptr<autoware_utils_system::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_;
+  minimum_rule_based_planner::Params params_;
+  /** @} */
+
+private:
+  /**
+   ***********************************************************
+   * @defgroup path planning
+   * PathPlanner handles route/map initialisation, path planning,
+   * trajectory shifting, and conversion.
+   * @{
+   */
+  //! PathPlanner encapsulates path planning, trajectory shifting, and conversion
+  std::unique_ptr<PathPlanner> path_planner_;
+  /** @} */
+
+private:
+  /**
+   ***********************************************************
+   * @defgroup optimizer-plugins trajectory optimizer plugins
+   * @{
+   */
+  void load_optimizer_plugins();
+
+  std::unique_ptr<OptimizerPluginLoader> plugin_loader_;
+  std::shared_ptr<OptimizerPluginInterface> path_smoother_;
+  std::unique_ptr<VelocitySmoother> velocity_smoother_;
+  std::map<std::string, rclcpp::Publisher<Trajectory>::SharedPtr>
+    pub_debug_optimizer_module_trajectories_;
+  /** @} */
+
+private:
+  /**
+   ***********************************************************
+   * @defgroup modifier-plugins trajectory modifier plugins
+   * @{
+   */
+  void load_modifier_plugins();
+
+  void load_plugin(const std::string & name);
+  void unload_plugin(const std::string & name);
+
+  bool initialized_modifiers_{false};
+  ModifierPluginLoader modifier_plugin_loader_;
+  std::vector<std::shared_ptr<plugin::PluginInterface>> modifier_plugins_;
+  std::map<std::string, rclcpp::Publisher<Trajectory>::SharedPtr>
+    pub_debug_modifier_module_trajectories_;
+
+  std::shared_ptr<plugin::ModifierContext> modifier_context_;
+  /** @} */
+
+private:
+  /**
+   ***********************************************************
+   * @defgroup subscribers and publishers
+   * @{
+   */
+  autoware_utils::InterProcessPollingSubscriber<
+    LaneletRoute, autoware_utils::polling_policy::Newest>
+    route_subscriber_{this, "~/input/route", rclcpp::QoS{1}.transient_local()};
+  LaneletRoute::ConstSharedPtr route_ptr_;
+
+  autoware_utils::InterProcessPollingSubscriber<
+    LaneletMapBin, autoware_utils::polling_policy::Newest>
+    vector_map_subscriber_{this, "~/input/vector_map", rclcpp::QoS{1}.transient_local()};
+  LaneletMapBin::ConstSharedPtr lanelet_map_bin_ptr_;
+
+  autoware_utils::InterProcessPollingSubscriber<Odometry> odometry_subscriber_{
+    this, "~/input/odometry"};
+  Odometry::ConstSharedPtr odometry_ptr_;
+
+  autoware_utils::InterProcessPollingSubscriber<AccelWithCovarianceStamped>
+    acceleration_subscriber_{this, "~/input/acceleration"};
+  AccelWithCovarianceStamped::ConstSharedPtr acceleration_ptr_;
+
+  autoware_utils::InterProcessPollingSubscriber<PredictedObjects> objects_subscriber_{
+    this, "~/input/objects"};
+  PredictedObjects::ConstSharedPtr predicted_objects_ptr_;
+
+  autoware_utils_rclcpp::InterProcessPollingSubscriber<PointCloud2> pointcloud_subscriber_{
+    this, "~/input/pointcloud", autoware_utils::single_depth_sensor_qos()};
+  PointCloud2::ConstSharedPtr obstacle_pointcloud_ptr_;
+
+  //! test input: bypasses path planning when provided
+  autoware_utils::InterProcessPollingSubscriber<
+    PathWithLaneId, autoware_utils::polling_policy::Newest>
+    test_path_with_lane_id_subscriber_{this, "~/input/test/path_with_lane_id"};
+  PathWithLaneId::ConstSharedPtr test_path_with_lane_id_ptr;
+
+  rclcpp::Publisher<CandidateTrajectories>::SharedPtr pub_trajectories_;
+  rclcpp::Publisher<PathWithLaneId>::SharedPtr pub_debug_path_;
+  rclcpp::Publisher<Trajectory>::SharedPtr pub_debug_trajectory_;
+  rclcpp::Publisher<Trajectory>::SharedPtr pub_debug_shifted_trajectory_;
+  /** @} */
+};
+
+}  // namespace autoware::minimum_rule_based_planner
+
+#endif  // MINIMUM_RULE_BASED_PLANNER_HPP_

--- a/planning/autoware_minimum_rule_based_planner/src/path_planner.cpp
+++ b/planning/autoware_minimum_rule_based_planner/src/path_planner.cpp
@@ -1,0 +1,1768 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "path_planner.hpp"
+
+#include <autoware/motion_utils/resample/resample.hpp>
+#include <autoware/motion_utils/trajectory/conversion.hpp>
+#include <autoware/motion_utils/trajectory/trajectory.hpp>
+#include <autoware/trajectory/interpolator/linear.hpp>
+#include <autoware/trajectory/path_point_with_lane_id.hpp>
+#include <autoware/trajectory/utils/closest.hpp>
+#include <autoware/trajectory/utils/crop.hpp>
+#include <autoware/trajectory/utils/find_intervals.hpp>
+#include <autoware/trajectory/utils/pretty_build.hpp>
+#include <autoware_lanelet2_extension/utility/message_conversion.hpp>
+#include <autoware_lanelet2_extension/utility/query.hpp>
+#include <autoware_lanelet2_extension/utility/utilities.hpp>
+#include <autoware_utils/geometry/geometry.hpp>
+#include <autoware_utils/math/normalization.hpp>
+
+#include <lanelet2_core/geometry/Lanelet.h>
+#include <tf2/utils.h>
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace autoware::minimum_rule_based_planner
+{
+
+// ===========================================================================
+// PathPlanner class implementation
+// ===========================================================================
+
+PathPlanner::PathPlanner(
+  const rclcpp::Logger & logger, rclcpp::Clock::SharedPtr clock,
+  std::shared_ptr<autoware_utils_debug::TimeKeeper> time_keeper, const Params & params,
+  const VehicleInfo & vehicle_info)
+: logger_(logger),
+  clock_(std::move(clock)),
+  time_keeper_(std::move(time_keeper)),
+  params_(params),
+  vehicle_info_(vehicle_info)
+{
+}
+
+void PathPlanner::set_planner_data(
+  const LaneletMapBin::ConstSharedPtr & lanelet_map_bin_ptr,
+  const LaneletRoute::ConstSharedPtr & route_ptr)
+{
+  autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
+  if (lanelet_map_bin_ptr && !route_context_.lanelet_map_ptr) {
+    route_context_.lanelet_map_ptr = std::make_shared<lanelet::LaneletMap>();
+    lanelet::utils::conversion::fromBinMsg(
+      *lanelet_map_bin_ptr, route_context_.lanelet_map_ptr, &route_context_.traffic_rules_ptr,
+      &route_context_.routing_graph_ptr);
+  }
+
+  if (route_ptr) {
+    set_route(route_ptr);
+  }
+}
+
+void PathPlanner::set_route(const LaneletRoute::ConstSharedPtr & route_ptr)
+{
+  autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
+  route_context_.route_frame_id = route_ptr->header.frame_id;
+  route_context_.goal_pose = route_ptr->goal_pose;
+
+  route_context_.route_lanelets.clear();
+  route_context_.preferred_lanelets.clear();
+  route_context_.start_lanelets.clear();
+  route_context_.goal_lanelets.clear();
+
+  size_t primitives_num = 0;
+  for (const auto & route_section : route_ptr->segments) {
+    primitives_num += route_section.primitives.size();
+  }
+  route_context_.route_lanelets.reserve(primitives_num);
+
+  for (const auto & route_section : route_ptr->segments) {
+    for (const auto & primitive : route_section.primitives) {
+      const auto id = primitive.id;
+      const auto & lanelet = route_context_.lanelet_map_ptr->laneletLayer.get(id);
+      route_context_.route_lanelets.push_back(lanelet);
+      if (id == route_section.preferred_primitive.id) {
+        route_context_.preferred_lanelets.push_back(lanelet);
+      }
+    }
+  }
+
+  const auto set_lanelets_from_segment =
+    [&](
+      const autoware_planning_msgs::msg::LaneletSegment & segment,
+      lanelet::ConstLanelets & lanelets) {
+      lanelets.reserve(segment.primitives.size());
+      for (const auto & primitive : segment.primitives) {
+        const auto & lanelet = route_context_.lanelet_map_ptr->laneletLayer.get(primitive.id);
+        lanelets.push_back(lanelet);
+      }
+    };
+  set_lanelets_from_segment(route_ptr->segments.front(), route_context_.start_lanelets);
+  set_lanelets_from_segment(route_ptr->segments.back(), route_context_.goal_lanelets);
+}
+
+void PathPlanner::set_route_context(const RouteContext & route_context)
+{
+  route_context_ = route_context;
+}
+
+RouteContext & PathPlanner::route_context()
+{
+  return route_context_;
+}
+
+const RouteContext & PathPlanner::route_context() const
+{
+  return route_context_;
+}
+
+void PathPlanner::update_params(const Params & params)
+{
+  params_ = params;
+}
+
+Trajectory PathPlanner::convert_path_to_trajectory(
+  const PathWithLaneId & path, double resample_interval)
+{
+  std::vector<autoware_planning_msgs::msg::TrajectoryPoint> traj_points;
+  traj_points.reserve(path.points.size());
+  for (const auto & path_point : path.points) {
+    autoware_planning_msgs::msg::TrajectoryPoint traj_point;
+    traj_point.pose = path_point.point.pose;
+    traj_point.longitudinal_velocity_mps = path_point.point.longitudinal_velocity_mps;
+    traj_point.lateral_velocity_mps = path_point.point.lateral_velocity_mps;
+    traj_point.heading_rate_rps = path_point.point.heading_rate_rps;
+    traj_points.push_back(traj_point);
+  }
+
+  const auto traj_msg = autoware::motion_utils::convertToTrajectory(traj_points, path.header);
+  return autoware::motion_utils::resampleTrajectory(
+    traj_msg, resample_interval, false, true, true, true);
+}
+
+// ===========================================================================
+// Utility functions
+// ===========================================================================
+namespace utils
+{
+namespace
+{
+template <typename T>
+bool exists(const std::vector<T> & vec, const T & item)
+{
+  return std::find(vec.begin(), vec.end(), item) != vec.end();
+}
+
+template <typename const_iterator>
+std::vector<geometry_msgs::msg::Point> to_geometry_msgs_points(
+  const const_iterator begin, const const_iterator end)
+{
+  std::vector<geometry_msgs::msg::Point> geometry_msgs_points{};
+  geometry_msgs_points.reserve(std::distance(begin, end));
+  std::transform(begin, end, std::back_inserter(geometry_msgs_points), [](const auto & point) {
+    return lanelet::utils::conversion::toGeomMsgPt(point);
+  });
+  return geometry_msgs_points;
+}
+
+lanelet::BasicPoints3d to_lanelet_points(
+  const std::vector<geometry_msgs::msg::Point> & geometry_msgs_points)
+{
+  lanelet::BasicPoints3d lanelet_points{};
+  lanelet_points.reserve(geometry_msgs_points.size());
+  std::transform(
+    geometry_msgs_points.begin(), geometry_msgs_points.end(), std::back_inserter(lanelet_points),
+    [](const auto & point) { return lanelet::utils::conversion::toLaneletPoint(point); });
+  return lanelet_points;
+}
+}  // namespace
+
+std::optional<lanelet::ConstLanelets> get_lanelets_within_route_up_to(
+  const lanelet::ConstLanelet & lanelet, const RouteContext & planner_data, const double distance)
+{
+  if (!exists(planner_data.route_lanelets, lanelet)) {
+    return std::nullopt;
+  }
+
+  lanelet::ConstLanelets lanelets{};
+  auto current_lanelet = lanelet;
+  auto length = 0.;
+
+  while (length < distance) {
+    const auto prev_lanelet = get_previous_lanelet_within_route(current_lanelet, planner_data);
+    if (!prev_lanelet) {
+      break;
+    }
+
+    lanelets.push_back(*prev_lanelet);
+    current_lanelet = *prev_lanelet;
+    length += lanelet::utils::getLaneletLength2d(*prev_lanelet);
+  }
+
+  std::reverse(lanelets.begin(), lanelets.end());
+  return lanelets;
+}
+
+std::optional<lanelet::ConstLanelets> get_lanelets_within_route_after(
+  const lanelet::ConstLanelet & lanelet, const RouteContext & planner_data, const double distance)
+{
+  if (!exists(planner_data.route_lanelets, lanelet)) {
+    return std::nullopt;
+  }
+
+  lanelet::ConstLanelets lanelets{};
+  auto current_lanelet = lanelet;
+  auto length = 0.;
+
+  while (length < distance) {
+    const auto next_lanelet = get_next_lanelet_within_route(current_lanelet, planner_data);
+    if (!next_lanelet) {
+      break;
+    }
+
+    lanelets.push_back(*next_lanelet);
+    current_lanelet = *next_lanelet;
+    length += lanelet::utils::getLaneletLength2d(*next_lanelet);
+  }
+
+  return lanelets;
+}
+
+std::optional<lanelet::ConstLanelet> get_previous_lanelet_within_route(
+  const lanelet::ConstLanelet & lanelet, const RouteContext & planner_data)
+{
+  if (exists(planner_data.start_lanelets, lanelet)) {
+    return std::nullopt;
+  }
+
+  const auto prev_lanelets = planner_data.routing_graph_ptr->previous(lanelet);
+  if (prev_lanelets.empty()) {
+    return std::nullopt;
+  }
+
+  const auto prev_lanelet_itr = std::find_if(
+    prev_lanelets.cbegin(), prev_lanelets.cend(),
+    [&](const lanelet::ConstLanelet & l) { return exists(planner_data.route_lanelets, l); });
+  if (prev_lanelet_itr == prev_lanelets.cend()) {
+    return std::nullopt;
+  }
+  return *prev_lanelet_itr;
+}
+
+std::optional<lanelet::ConstLanelet> get_next_lanelet_within_route(
+  const lanelet::ConstLanelet & lanelet, const RouteContext & planner_data)
+{
+  if (planner_data.preferred_lanelets.empty()) {
+    return std::nullopt;
+  }
+
+  if (exists(planner_data.goal_lanelets, lanelet)) {
+    return std::nullopt;
+  }
+
+  const auto next_lanelets = planner_data.routing_graph_ptr->following(lanelet);
+  if (
+    next_lanelets.empty() ||
+    next_lanelets.front().id() == planner_data.preferred_lanelets.front().id()) {
+    return std::nullopt;
+  }
+
+  // Fallback: any route lanelet
+  const auto next_lanelet_itr = std::find_if(
+    next_lanelets.cbegin(), next_lanelets.cend(),
+    [&](const lanelet::ConstLanelet & l) { return exists(planner_data.route_lanelets, l); });
+  if (next_lanelet_itr == next_lanelets.cend()) {
+    return std::nullopt;
+  }
+  return *next_lanelet_itr;
+}
+
+std::vector<WaypointGroup> get_waypoint_groups(
+  const lanelet::LaneletSequence & lanelet_sequence, const lanelet::LaneletMap & lanelet_map,
+  const double group_separation_threshold, const double interval_margin_ratio)
+{
+  std::vector<WaypointGroup> waypoint_groups{};
+
+  const auto get_interval_bound =
+    [&](const lanelet::ConstPoint3d & point, const double lateral_distance_factor) {
+      const auto arc_coordinates = lanelet::geometry::toArcCoordinates(
+        lanelet_sequence.centerline2d(), lanelet::utils::to2D(point));
+      return arc_coordinates.length + lateral_distance_factor * std::abs(arc_coordinates.distance);
+    };
+
+  for (const auto & lanelet : lanelet_sequence) {
+    if (!lanelet.hasAttribute("waypoints")) {
+      continue;
+    }
+
+    const auto waypoints_id = lanelet.attribute("waypoints").asId().value();
+    const auto & waypoints = lanelet_map.lineStringLayer.get(waypoints_id);
+
+    if (
+      waypoint_groups.empty() || lanelet::geometry::distance2d(
+                                   waypoint_groups.back().waypoints.back().point,
+                                   waypoints.front()) > group_separation_threshold) {
+      waypoint_groups.emplace_back().interval.start =
+        get_interval_bound(waypoints.front(), -interval_margin_ratio);
+    }
+    waypoint_groups.back().interval.end =
+      get_interval_bound(waypoints.back(), interval_margin_ratio);
+
+    std::transform(
+      waypoints.begin(), waypoints.end(), std::back_inserter(waypoint_groups.back().waypoints),
+      [&](const lanelet::ConstPoint3d & waypoint) {
+        return WaypointGroup::Waypoint{waypoint, lanelet.id()};
+      });
+  }
+
+  return waypoint_groups;
+}
+
+std::optional<double> get_first_intersection_arc_length(
+  const lanelet::LaneletSequence & lanelet_sequence, const double s_start, const double s_end,
+  const double vehicle_length)
+{
+  if (lanelet_sequence.empty()) {
+    return std::nullopt;
+  }
+
+  std::optional<double> s_intersection;
+
+  const auto s_start_on_bounds = get_arc_length_on_bounds(lanelet_sequence, s_start);
+  const auto s_end_on_bounds = get_arc_length_on_bounds(lanelet_sequence, s_end);
+
+  const auto crop_and_convert = [](const auto & line, double s0, double s1) {
+    return lanelet::utils::to2D(to_lanelet_points(
+      crop_line_string(to_geometry_msgs_points(line.begin(), line.end()), s0, s1)));
+  };
+
+  const auto cropped_centerline = crop_and_convert(lanelet_sequence.centerline2d(), s_start, s_end);
+  const auto cropped_left_bound =
+    crop_and_convert(lanelet_sequence.leftBound2d(), s_start_on_bounds.left, s_end_on_bounds.left);
+  const auto cropped_right_bound = crop_and_convert(
+    lanelet_sequence.rightBound2d(), s_start_on_bounds.right, s_end_on_bounds.right);
+
+  if (cropped_centerline.empty() || cropped_left_bound.empty() || cropped_right_bound.empty()) {
+    return std::nullopt;
+  }
+
+  const lanelet::BasicLineString2d start_edge{
+    cropped_left_bound.front(), cropped_right_bound.front()};
+
+  // Helper: offset an optional arc length by a base value
+  auto offset_optional = [](std::optional<double> s, double base) -> std::optional<double> {
+    if (s) *s += base;
+    return s;
+  };
+
+  // Self intersection of bounds
+  {
+    const auto s_left_bound = offset_optional(
+      get_first_self_intersection_arc_length(cropped_left_bound), s_start_on_bounds.left);
+    const auto s_right_bound = offset_optional(
+      get_first_self_intersection_arc_length(cropped_right_bound), s_start_on_bounds.right);
+
+    const auto [s_left, s_right] =
+      get_arc_length_on_centerline(lanelet_sequence, s_left_bound, s_right_bound);
+
+    if (s_left && s_right) {
+      s_intersection = std::min(s_left, s_right);
+    } else {
+      s_intersection = s_left ? s_left : s_right;
+    }
+  }
+
+  // intersection between left and right bounds
+  {
+    lanelet::BasicPoints2d intersections;
+    boost::geometry::intersection(cropped_left_bound, cropped_right_bound, intersections);
+    for (const auto & intersection : intersections) {
+      const auto s_on_centerline = get_arc_length_on_centerline(
+        lanelet_sequence,
+        s_start_on_bounds.left +
+          lanelet::geometry::toArcCoordinates(cropped_left_bound, intersection).length,
+        s_start_on_bounds.right +
+          lanelet::geometry::toArcCoordinates(cropped_right_bound, intersection).length);
+      const auto s_mutual = [&]() -> std::optional<double> {
+        if (s_on_centerline.left && s_on_centerline.right) {
+          return std::max(s_on_centerline.left, s_on_centerline.right);
+        }
+        return s_on_centerline.left ? s_on_centerline.left : s_on_centerline.right;
+      }();
+      if (s_intersection && s_mutual) {
+        s_intersection = std::min(s_intersection, s_mutual);
+      } else if (s_mutual) {
+        s_intersection = s_mutual;
+      }
+    }
+  }
+
+  // intersection between start edge of drivable area and left / right bound
+  {
+    const auto get_start_edge_intersection_arc_length =
+      [&](const lanelet::BasicLineString2d & bound) {
+        std::optional<double> s_start_edge = std::nullopt;
+        if (bound.size() <= 2) {
+          return s_start_edge;
+        }
+        lanelet::BasicPoints2d start_edge_intersections;
+        boost::geometry::intersection(start_edge, bound, start_edge_intersections);
+        for (const auto & intersection : start_edge_intersections) {
+          if (boost::geometry::equals(intersection, bound.front())) {
+            continue;
+          }
+          const auto s = lanelet::geometry::toArcCoordinates(bound, intersection).length;
+          s_start_edge = s_start_edge ? std::min(*s_start_edge, s) : s;
+        }
+        return s_start_edge;
+      };
+    const auto s_left_bound = [&]() {
+      auto s = get_start_edge_intersection_arc_length(cropped_left_bound);
+      if (s) {
+        *s += s_start_on_bounds.left;
+      }
+      return s;
+    }();
+    const auto s_right_bound = [&]() {
+      auto s = get_start_edge_intersection_arc_length(cropped_right_bound);
+      if (s) {
+        *s += s_start_on_bounds.right;
+      }
+      return s;
+    }();
+
+    const auto s_on_centerline =
+      get_arc_length_on_centerline(lanelet_sequence, s_left_bound, s_right_bound);
+
+    const auto s_start_edge = [&]() {
+      if (s_on_centerline.left && s_on_centerline.right) {
+        return std::min(s_on_centerline.left, s_on_centerline.right);
+      }
+      return s_on_centerline.left ? s_on_centerline.left : s_on_centerline.right;
+    }();
+    if (s_intersection && s_start_edge) {
+      s_intersection = std::min(s_intersection, s_start_edge);
+    } else if (s_start_edge) {
+      s_intersection = s_start_edge;
+    }
+  }
+
+  // intersection between start edge of drivable area and center line
+  {
+    std::optional<double> s_start_edge;
+    lanelet::BasicPoints2d start_edge_intersections;
+    boost::geometry::intersection(start_edge, cropped_centerline, start_edge_intersections);
+    for (const auto & intersection : start_edge_intersections) {
+      auto s = lanelet::geometry::toArcCoordinates(cropped_centerline, intersection).length;
+      // Ignore intersections near the beginning of the centerline.
+      // It is impossible to make a turn shorter than the vehicle_length, so use it as a threshold.
+      if (s < vehicle_length) continue;
+      s += s_start;
+      s_start_edge = s_start_edge ? std::min(*s_start_edge, s) : s;
+    }
+    if (s_intersection && s_start_edge) {
+      s_intersection = std::min(s_intersection, s_start_edge);
+    } else if (s_start_edge) {
+      s_intersection = s_start_edge;
+    }
+  }
+
+  return s_intersection;
+}
+
+std::optional<double> get_first_self_intersection_arc_length(
+  const lanelet::BasicLineString2d & line_string)
+{
+  if (line_string.size() < 3) {
+    return std::nullopt;
+  }
+
+  std::optional<size_t> first_self_intersection_index;
+  std::optional<double> intersection_arc_length_on_latter_segment;
+  double s = 0.;
+
+  for (size_t i = 0; i < line_string.size() - 1; ++i) {
+    if (
+      first_self_intersection_index && i == first_self_intersection_index &&
+      intersection_arc_length_on_latter_segment) {
+      return s + *intersection_arc_length_on_latter_segment;
+    }
+
+    const auto current_segment = lanelet::BasicSegment2d{line_string.at(i), line_string.at(i + 1)};
+    s += lanelet::geometry::length(current_segment);
+
+    lanelet::BasicPoints2d self_intersections{};
+    for (size_t j = i + 1; j < line_string.size() - 1; ++j) {
+      const auto segment = lanelet::BasicSegment2d{line_string.at(j), line_string.at(j + 1)};
+      if (
+        segment.first == current_segment.second || segment.second == current_segment.first ||
+        segment.first == current_segment.first) {
+        continue;
+      }
+      boost::geometry::intersection(current_segment, segment, self_intersections);
+      if (self_intersections.empty()) {
+        continue;
+      }
+      first_self_intersection_index = j;
+      intersection_arc_length_on_latter_segment =
+        (self_intersections.front() - segment.first).norm();
+      break;
+    }
+  }
+
+  return std::nullopt;
+}
+
+double get_arc_length_on_path(
+  const lanelet::LaneletSequence & lanelet_sequence, const std::vector<PathPointWithLaneId> & path,
+  const double s_centerline)
+{
+  std::optional<lanelet::Id> target_lanelet_id;
+  std::optional<lanelet::BasicPoint2d> point_on_centerline;
+
+  if (lanelet_sequence.empty() || path.empty()) {
+    RCLCPP_WARN(
+      rclcpp::get_logger("minimum_rule_based_planner").get_child("utils").get_child(__func__),
+      "Input lanelet sequence or path is empty, returning 0.");
+    return 0.;
+  }
+
+  if (s_centerline < 0.) {
+    RCLCPP_WARN(
+      rclcpp::get_logger("minimum_rule_based_planner").get_child("utils").get_child(__func__),
+      "Input arc length is negative, returning 0.");
+    return 0.;
+  }
+
+  for (auto [it, s] = std::make_tuple(lanelet_sequence.begin(), 0.); it != lanelet_sequence.end();
+       ++it) {
+    const double centerline_length = lanelet::geometry::length(it->centerline2d());
+    if (s + centerline_length < s_centerline) {
+      s += centerline_length;
+      continue;
+    }
+
+    target_lanelet_id = it->id();
+    point_on_centerline =
+      lanelet::geometry::interpolatedPointAtDistance(it->centerline2d(), s_centerline - s);
+    break;
+  }
+
+  if (!target_lanelet_id || !point_on_centerline) {
+    // lanelet_sequence is too short, thus we return input arc length as is.
+    return s_centerline;
+  }
+
+  auto s_path = 0.;
+  lanelet::BasicLineString2d target_path_segment;
+
+  for (auto it = path.begin(); it != path.end(); ++it) {
+    if (
+      std::find(it->lane_ids.begin(), it->lane_ids.end(), *target_lanelet_id) ==
+      it->lane_ids.end()) {
+      if (target_path_segment.empty() && it != std::prev(path.end())) {
+        s_path += autoware_utils::calc_distance2d(*it, *std::next(it));
+        continue;
+      }
+      break;
+    }
+    target_path_segment.push_back(
+      lanelet::utils::conversion::toLaneletPoint(it->point.pose.position).basicPoint2d());
+  }
+
+  // guard: toArcCoordinates requires at least 2 points in the line string,
+  // otherwise closestSegment() dereferences a null pointer.
+  if (target_path_segment.size() < 2) {
+    RCLCPP_WARN(
+      rclcpp::get_logger("minimum_rule_based_planner").get_child("utils").get_child(__func__),
+      "target_path_segment has insufficient points (%zu), "
+      "falling back to closest point search on path",
+      target_path_segment.size());
+    // fallback: find the closest point on the entire path to point_on_centerline
+    double min_dist_sq = std::numeric_limits<double>::max();
+    double s_closest = 0.;
+    double s_acc = 0.;
+    for (size_t i = 0; i < path.size(); ++i) {
+      const auto & pos = path[i].point.pose.position;
+      const double dx = pos.x - point_on_centerline->x();
+      const double dy = pos.y - point_on_centerline->y();
+      const double dist_sq = dx * dx + dy * dy;
+      if (dist_sq < min_dist_sq) {
+        min_dist_sq = dist_sq;
+        s_closest = s_acc;
+      }
+      if (i + 1 < path.size()) {
+        s_acc += autoware_utils::calc_distance2d(path[i], path[i + 1]);
+      }
+    }
+    return s_closest;
+  }
+
+  s_path += lanelet::geometry::toArcCoordinates(target_path_segment, *point_on_centerline).length;
+
+  return s_path;
+}
+
+PathRange<std::vector<geometry_msgs::msg::Point>> get_path_bounds(
+  const lanelet::LaneletSequence & lanelet_sequence, const double s_start, const double s_end)
+{
+  if (lanelet_sequence.empty()) {
+    return {};
+  }
+
+  const auto [s_left_start, s_right_start] = get_arc_length_on_bounds(lanelet_sequence, s_start);
+  const auto [s_left_end, s_right_end] = get_arc_length_on_bounds(lanelet_sequence, s_end);
+
+  return {
+    crop_line_string(
+      to_geometry_msgs_points(
+        lanelet_sequence.leftBound().begin(), lanelet_sequence.leftBound().end()),
+      s_left_start, s_left_end),
+    crop_line_string(
+      to_geometry_msgs_points(
+        lanelet_sequence.rightBound().begin(), lanelet_sequence.rightBound().end()),
+      s_right_start, s_right_end)};
+}
+
+std::vector<geometry_msgs::msg::Point> crop_line_string(
+  const std::vector<geometry_msgs::msg::Point> & line_string, const double s_start,
+  const double s_end)
+{
+  if (s_start < 0.) {
+    RCLCPP_WARN(
+      rclcpp::get_logger("minimum_rule_based_planner").get_child("utils").get_child(__func__),
+      "Start of crop range is negative, returning input as is");
+    return line_string;
+  }
+
+  if (s_start > s_end) {
+    RCLCPP_WARN(
+      rclcpp::get_logger("minimum_rule_based_planner").get_child("utils").get_child(__func__),
+      "Start of crop range is larger than end, returning input as is");
+    return line_string;
+  }
+
+  auto trajectory =
+    autoware::experimental::trajectory::Trajectory<geometry_msgs::msg::Point>::Builder()
+      .set_xy_interpolator<autoware::experimental::trajectory::interpolator::Linear>()
+      .build(line_string);
+  if (!trajectory) {
+    return {};
+  }
+
+  trajectory->crop(s_start, s_end - s_start);
+  if (trajectory->length() < 1e-6) {
+    return {};
+  }
+  return trajectory->restore();
+}
+
+PathRange<double> get_arc_length_on_bounds(
+  const lanelet::LaneletSequence & lanelet_sequence, const double s_centerline)
+{
+  if (s_centerline < 0.) {
+    RCLCPP_WARN(
+      rclcpp::get_logger("minimum_rule_based_planner").get_child("utils").get_child(__func__),
+      "Input arc length is negative, returning 0.");
+    return {0., 0.};
+  }
+
+  auto s = 0.;
+  auto s_left = 0.;
+  auto s_right = 0.;
+
+  for (auto it = lanelet_sequence.begin(); it != lanelet_sequence.end(); ++it) {
+    const double centerline_length = lanelet::geometry::length(it->centerline2d());
+    const double left_bound_length = lanelet::geometry::length(it->leftBound2d());
+    const double right_bound_length = lanelet::geometry::length(it->rightBound2d());
+
+    if (s + centerline_length < s_centerline) {
+      s += centerline_length;
+      s_left += left_bound_length;
+      s_right += right_bound_length;
+      continue;
+    }
+
+    const auto point_on_centerline =
+      lanelet::geometry::interpolatedPointAtDistance(it->centerline2d(), s_centerline - s);
+    s_left += lanelet::geometry::toArcCoordinates(it->leftBound2d(), point_on_centerline).length;
+    s_right += lanelet::geometry::toArcCoordinates(it->rightBound2d(), point_on_centerline).length;
+
+    return {s_left, s_right};
+  }
+
+  // If the loop ends without returning, it means that the lanelet_sequence is too short.
+  // In this case, we return the original arc length on the centerline.
+  return {s_centerline, s_centerline};
+}
+
+PathRange<std::optional<double>> get_arc_length_on_centerline(
+  const lanelet::LaneletSequence & lanelet_sequence, const std::optional<double> & s_left_bound,
+  const std::optional<double> & s_right_bound)
+{
+  std::optional<double> s_left_centerline;
+  std::optional<double> s_right_centerline;
+
+  if (s_left_bound && *s_left_bound < 0.) {
+    RCLCPP_WARN(
+      rclcpp::get_logger("minimum_rule_based_planner").get_child("utils").get_child(__func__),
+      "Input left arc length is negative, returning 0.");
+    s_left_centerline = 0.;
+  }
+  if (s_right_bound && *s_right_bound < 0.) {
+    RCLCPP_WARN(
+      rclcpp::get_logger("minimum_rule_based_planner").get_child("utils").get_child(__func__),
+      "Input right arc length is negative, returning 0.");
+    s_right_centerline = 0.;
+  }
+
+  auto s = 0.;
+  auto s_left = 0.;
+  auto s_right = 0.;
+
+  for (auto it = lanelet_sequence.begin(); it != lanelet_sequence.end(); ++it) {
+    const auto is_left_done = !s_left_bound || s_left_centerline;
+    const auto is_right_done = !s_right_bound || s_right_centerline;
+    if (is_left_done && is_right_done) {
+      break;
+    }
+
+    const double centerline_length = lanelet::utils::getLaneletLength2d(*it);
+    const double left_bound_length = lanelet::geometry::length(it->leftBound2d());
+    const double right_bound_length = lanelet::geometry::length(it->rightBound2d());
+
+    if (!is_left_done && s_left + left_bound_length > s_left_bound) {
+      s_left_centerline = s + lanelet::geometry::toArcCoordinates(
+                                it->centerline2d(), lanelet::geometry::interpolatedPointAtDistance(
+                                                      it->leftBound2d(), *s_left_bound - s_left))
+                                .length;
+    }
+    if (!is_right_done && s_right + right_bound_length > s_right_bound) {
+      s_right_centerline =
+        s + lanelet::geometry::toArcCoordinates(
+              it->centerline2d(), lanelet::geometry::interpolatedPointAtDistance(
+                                    it->rightBound2d(), *s_right_bound - s_right))
+              .length;
+    }
+
+    s += centerline_length;
+    s_left += left_bound_length;
+    s_right += right_bound_length;
+  }
+
+  return {
+    s_left_centerline ? s_left_centerline : s_left_bound,
+    s_right_centerline ? s_right_centerline : s_right_bound};
+}
+
+PathPointTrajectory refine_path_for_goal(
+  const PathPointTrajectory & input, const geometry_msgs::msg::Pose & goal_pose,
+  const lanelet::Id goal_lane_id, const double search_radius_range, const double pre_goal_offset)
+{
+  auto contain_goal_lane_id = [&](const PathPointWithLaneId & point) {
+    const auto & ids = point.lane_ids;
+    return std::find(ids.begin(), ids.end(), goal_lane_id) != ids.end();
+  };
+
+  auto outside_circle = [&](const PathPointWithLaneId & point) {
+    return autoware_utils::calc_distance2d(point.point.pose, goal_pose) > search_radius_range;
+  };
+
+  auto closest_to_goal = autoware::experimental::trajectory::closest_with_constraint(
+    input, goal_pose, contain_goal_lane_id);
+
+  // If no point with the goal lane ID exists in the trajectory (e.g. goal is on an adjacent lane),
+  // fall back to the geometrically closest point so the goal connection still applies.
+  if (!closest_to_goal) {
+    closest_to_goal = autoware::experimental::trajectory::closest(input, goal_pose);
+  }
+
+  auto cropped_path = autoware::experimental::trajectory::crop(input, 0, *closest_to_goal);
+
+  auto intervals =
+    autoware::experimental::trajectory::find_intervals(cropped_path, outside_circle, 10);
+
+  std::vector<PathPointWithLaneId> goal_connected_trajectory_points;
+
+  if (!intervals.empty()) {
+    auto cropped = autoware::experimental::trajectory::crop(cropped_path, 0, intervals.back().end);
+    goal_connected_trajectory_points = cropped.restore();
+  } else if (cropped_path.length() > pre_goal_offset) {
+    // If distance from start to goal is smaller than refine_goal_search_radius_range and start is
+    // farther from goal than pre_goal, we just connect start, pre_goal, and goal.
+    goal_connected_trajectory_points = {cropped_path.compute(0)};
+  }
+
+  auto goal = input.compute(autoware::experimental::trajectory::closest(input, goal_pose));
+  goal.point.pose = goal_pose;
+  goal.point.longitudinal_velocity_mps = 0.0;
+
+  const auto pre_goal_pose =
+    autoware_utils::calc_offset_pose(goal_pose, -pre_goal_offset, 0.0, 0.0);
+  auto pre_goal = input.compute(autoware::experimental::trajectory::closest(input, pre_goal_pose));
+  pre_goal.point.pose = pre_goal_pose;
+
+  goal_connected_trajectory_points.push_back(pre_goal);
+  goal_connected_trajectory_points.push_back(goal);
+
+  if (
+    const auto output =
+      autoware::experimental::trajectory::pretty_build(goal_connected_trajectory_points)) {
+    return *output;
+  }
+  return input;
+}
+
+lanelet::ConstLanelets extract_lanelets_from_trajectory(
+  const PathPointTrajectory & trajectory, const RouteContext & planner_data)
+{
+  lanelet::ConstLanelets lanelets{};
+  const auto lane_ids = trajectory.get_contained_lane_ids();
+  const auto lane_ids_set = std::set(lane_ids.begin(), lane_ids.end());
+  for (const auto & lane_id : lane_ids_set) {
+    const auto lanelet = planner_data.lanelet_map_ptr->laneletLayer.get(lane_id);
+    lanelets.push_back(lanelet);
+  }
+  return lanelets;
+}
+
+bool is_in_lanelets(const geometry_msgs::msg::Pose & pose, const lanelet::ConstLanelets & lanes)
+{
+  return std::any_of(lanes.begin(), lanes.end(), [&](const auto & lane) {
+    return lanelet::utils::isInLanelet(pose, lane);
+  });
+}
+
+bool is_trajectory_inside_lanelets(
+  const PathPointTrajectory & refined_path, const lanelet::ConstLanelets & lanelets)
+{
+  const auto points = refined_path.restore();
+  return std::none_of(points.begin(), points.end(), [&](const auto & point) {
+    return !is_in_lanelets(point.point.pose, lanelets);
+  });
+}
+
+std::optional<PathPointTrajectory> modify_path_for_smooth_goal_connection(
+  const PathPointTrajectory & trajectory, const RouteContext & planner_data,
+  const double search_radius_range, const double pre_goal_offset)
+{
+  if (planner_data.preferred_lanelets.empty()) {
+    return std::nullopt;
+  }
+  // Build the set of lanelets valid for the refined path.
+  // Include goal lanelets so that a path connecting to an adjacent goal lane passes validation.
+  auto lanelets = extract_lanelets_from_trajectory(trajectory, planner_data);
+  for (const auto & goal_ll : planner_data.goal_lanelets) {
+    if (std::find(lanelets.begin(), lanelets.end(), goal_ll) == lanelets.end()) {
+      lanelets.push_back(goal_ll);
+    }
+  }
+
+  // Include lanelets that contain the goal pose (e.g., shoulder lanelets) so that
+  // the trajectory connecting to an off-lane goal passes the inside-lanelets check.
+  const auto goal_point_2d =
+    lanelet::BasicPoint2d(planner_data.goal_pose.position.x, planner_data.goal_pose.position.y);
+  const auto nearest_lanelets =
+    lanelet::geometry::findNearest(planner_data.lanelet_map_ptr->laneletLayer, goal_point_2d, 5);
+  for (const auto & [dist, ll] : nearest_lanelets) {
+    if (
+      lanelet::geometry::inside(ll, goal_point_2d) &&
+      std::find(lanelets.begin(), lanelets.end(), ll) == lanelets.end()) {
+      lanelets.push_back(ll);
+    }
+  }
+
+  // This process is to fit the trajectory inside the lanelets. By reducing
+  // refine_goal_search_radius_range, we can fit the trajectory inside lanelets even if the
+  // trajectory has a high curvature.
+  for (double s = search_radius_range; s > 0; s -= 0.1) {
+    const auto refined_trajectory = refine_path_for_goal(
+      trajectory, planner_data.goal_pose, planner_data.preferred_lanelets.back().id(), s,
+      pre_goal_offset);
+    if (is_trajectory_inside_lanelets(refined_trajectory, lanelets)) {
+      return refined_trajectory;
+    }
+  }
+  return std::nullopt;
+}
+
+}  // namespace utils
+
+// ===========================================================================
+// File-local helpers
+// ===========================================================================
+
+namespace
+{
+// Peak curvature multiplier of the symmetric quintic shift: kappa_max = quintic_kappa_coeff*|d|/L^2
+constexpr double quintic_kappa_coeff = 5.773502691896258;  // 10*sqrt(3)/3
+constexpr double yaw_diff_clamp_rad = M_PI / 4.0;
+constexpr double lane_end_match_tolerance_sq = 4.0;  // [m^2] 2m tolerance squared
+constexpr double yaw_step = 0.1;  // [m] finite-difference step for centerline yaw
+
+struct QuinticShiftCoeffs
+{
+  double a0, a1, a2, a3, a4, a5;
+};
+
+// Closed-form coefficients of y(s) = a0 + a1 s + a2 s^2 + a3 s^3 + a4 s^4 + a5 s^5
+// solved from 6 boundary conditions:
+//   s=0: y=d, y'=q, y''=kappa0   ->   a0 = d, a1 = q, a2 = kappa0/2
+//   s=L: y=0, y'=0, y''=0        ->   solve the 3x3 system for (a3, a4, a5),
+//                                     yielding linear combinations of d, qL, kappa0 L^2.
+QuinticShiftCoeffs compute_quintic_shift_coeffs(
+  const double d, const double yaw_diff, const double kappa0, const double L)
+{
+  // Initial slope y'(0) for the quintic shift polynomial.
+  const double q = std::tan(std::clamp(yaw_diff, -yaw_diff_clamp_rad, yaw_diff_clamp_rad));
+  const double L2 = L * L;
+  const double L3 = L2 * L;
+  return {
+    d,
+    q,
+    kappa0 / 2.0,
+    -(20.0 * d + 12.0 * q * L + 3.0 * kappa0 * L2) / (2.0 * L3),
+    (30.0 * d + 16.0 * q * L + 3.0 * kappa0 * L2) / (2.0 * L3 * L),
+    -(12.0 * d + 6.0 * q * L + kappa0 * L2) / (2.0 * L3 * L2),
+  };
+}
+
+double evaluate_quintic(const QuinticShiftCoeffs & c, const double s)
+{
+  const double s2 = s * s;
+  const double s3 = s2 * s;
+  return c.a0 + c.a1 * s + c.a2 * s2 + c.a3 * s3 + c.a4 * s3 * s + c.a5 * s3 * s2;
+}
+
+double evaluate_quintic_derivative(const QuinticShiftCoeffs & c, const double s)
+{
+  const double s2 = s * s;
+  const double s3 = s2 * s;
+  return c.a1 + 2.0 * c.a2 * s + 3.0 * c.a3 * s2 + 4.0 * c.a4 * s3 + 5.0 * c.a5 * s3 * s;
+}
+
+double compute_shift_length_from_lateral_accel(
+  const double abs_d, const double velocity, const double lateral_accel_limit,
+  const double min_length)
+{
+  return std::max(
+    min_length, velocity * std::sqrt(quintic_kappa_coeff * abs_d / lateral_accel_limit));
+}
+
+double signed_curvature_3pt(
+  const lanelet::BasicPoint2d & p0, const lanelet::BasicPoint2d & p1,
+  const lanelet::BasicPoint2d & p2)
+{
+  const double v1x = p1.x() - p0.x();
+  const double v1y = p1.y() - p0.y();
+  const double v2x = p2.x() - p1.x();
+  const double v2y = p2.y() - p1.y();
+  const double cross = v1x * v2y - v1y * v2x;
+  const double l1 = std::hypot(v1x, v1y);
+  const double l2 = std::hypot(v2x, v2y);
+  const double l3 = std::hypot(p2.x() - p0.x(), p2.y() - p0.y());
+  const double denom = l1 * l2 * l3;
+  if (denom < 1e-9) {
+    return 0.0;
+  }
+  return 2.0 * cross / denom;
+}
+
+lanelet::ConstLanelet select_route_preferred_lanelet(
+  const lanelet::ConstLanelets & candidates, const RouteContext & route_context)
+{
+  const auto it =
+    std::find_if(candidates.begin(), candidates.end(), [&](const lanelet::ConstLanelet & ll) {
+      return std::any_of(
+        route_context.route_lanelets.begin(), route_context.route_lanelets.end(),
+        [&](const auto & rl) { return rl.id() == ll.id(); });
+    });
+  return it != candidates.end() ? *it : candidates.front();
+}
+
+// ---------------------------------------------------------------------------
+// Lane-change interpolation helpers
+// ---------------------------------------------------------------------------
+
+struct LaneChangeBoundaryInfo
+{
+  double lateral_offset;
+  double abs_lateral_offset;
+  double yaw_diff;
+  double start_curvature;
+  double s_projection;
+  double next_centerline_length;
+  geometry_msgs::msg::Point prev_end_geom;
+};
+
+std::optional<size_t> find_lane_change_boundary(
+  const lanelet::ConstLanelets & lanelets, const double min_shift_length)
+{
+  for (size_t li = 0; li + 1 < lanelets.size(); ++li) {
+    const auto & prev_centerline = lanelets[li].centerline();
+    const auto & next_centerline = lanelets[li + 1].centerline();
+    if (prev_centerline.size() < 2 || next_centerline.size() < 2) {
+      continue;
+    }
+    const double gap = lanelet::geometry::distance2d(
+      lanelet::utils::to2D(prev_centerline.back()), lanelet::utils::to2D(next_centerline.front()));
+    if (gap >= min_shift_length) {
+      return li;
+    }
+  }
+  return std::nullopt;
+}
+
+LaneChangeBoundaryInfo compute_lane_change_boundary_info(
+  const lanelet::ConstLanelet & lanelet_prev, const lanelet::ConstLanelet & lanelet_next)
+{
+  const auto & prev_centerline = lanelet_prev.centerline();
+  const auto & prev_end_pt = prev_centerline.back();
+
+  const auto arc_on_next = lanelet::geometry::toArcCoordinates(
+    lanelet_next.centerline2d(), lanelet::utils::to2D(prev_end_pt));
+
+  const auto & next_centerline = lanelet_next.centerline();
+  const double prev_yaw = std::atan2(
+    prev_end_pt.y() - (prev_centerline.end() - 2)->y(),
+    prev_end_pt.x() - (prev_centerline.end() - 2)->x());
+  const double next_yaw = std::atan2(
+    (next_centerline.begin() + 1)->y() - next_centerline.front().y(),
+    (next_centerline.begin() + 1)->x() - next_centerline.front().x());
+
+  const double kappa0 = [&]() {
+    if (prev_centerline.size() < 3) {
+      return 0.0;
+    }
+    const auto & p0 = *(prev_centerline.end() - 3);
+    const auto & p1 = *(prev_centerline.end() - 2);
+    const auto & p2 = *(prev_centerline.end() - 1);
+    return signed_curvature_3pt(
+      lanelet::utils::to2D(p0).basicPoint(), lanelet::utils::to2D(p1).basicPoint(),
+      lanelet::utils::to2D(p2).basicPoint());
+  }();
+
+  return {
+    arc_on_next.distance,
+    std::abs(arc_on_next.distance),
+    autoware_utils::normalize_radian(prev_yaw - next_yaw),
+    kappa0,
+    std::max(0.0, arc_on_next.length),
+    static_cast<double>(lanelet::geometry::length(lanelet_next.centerline2d())),
+    lanelet::utils::conversion::toGeomMsgPt(prev_end_pt),
+  };
+}
+
+std::optional<size_t> find_closest_path_index(
+  const std::vector<PathPointWithLaneId> & path_points, const lanelet::Id lanelet_id,
+  const geometry_msgs::msg::Point & target_point)
+{
+  std::optional<size_t> closest_idx;
+  double min_dist_sq = std::numeric_limits<double>::max();
+  for (size_t pi = 0; pi < path_points.size(); ++pi) {
+    const auto & ids = path_points[pi].lane_ids;
+    if (std::find(ids.begin(), ids.end(), lanelet_id) == ids.end()) {
+      continue;
+    }
+    const auto & pp = path_points[pi].point.pose.position;
+    const double dx = pp.x - target_point.x;
+    const double dy = pp.y - target_point.y;
+    const double d2 = dx * dx + dy * dy;
+    if (d2 < min_dist_sq) {
+      min_dist_sq = d2;
+      closest_idx = pi;
+    }
+  }
+  if (!closest_idx || min_dist_sq > lane_end_match_tolerance_sq) {
+    return std::nullopt;
+  }
+  return closest_idx;
+}
+
+std::vector<PathPointWithLaneId> generate_shift_points(
+  const LaneChangeBoundaryInfo & info, const QuinticShiftCoeffs & coeffs, const double L,
+  const double delta_arc_length, const double speed_limit,
+  const lanelet::ConstLanelet & lanelet_next, const lanelet::Id lanelet_prev_id)
+{
+  std::vector<PathPointWithLaneId> interp_points;
+  for (double s = 0.0; s <= L + 1e-6; s += delta_arc_length) {
+    const double sc = std::min(s, L);
+    const double y_s = evaluate_quintic(coeffs, sc);
+    const double yp_s = evaluate_quintic_derivative(coeffs, sc);
+
+    const double s_on_next = info.s_projection + sc;
+    if (s_on_next > info.next_centerline_length) {
+      break;
+    }
+
+    const auto base_2d =
+      lanelet::geometry::interpolatedPointAtDistance(lanelet_next.centerline2d(), s_on_next);
+    const auto base_3d =
+      lanelet::geometry::interpolatedPointAtDistance(lanelet_next.centerline(), s_on_next);
+
+    const double ds = std::min(yaw_step, info.next_centerline_length - s_on_next);
+    double base_yaw;
+    if (ds > 1e-6) {
+      const auto fwd =
+        lanelet::geometry::interpolatedPointAtDistance(lanelet_next.centerline2d(), s_on_next + ds);
+      base_yaw = std::atan2(fwd.y() - base_2d.y(), fwd.x() - base_2d.x());
+    } else {
+      const auto bwd = lanelet::geometry::interpolatedPointAtDistance(
+        lanelet_next.centerline2d(), std::max(0.0, s_on_next - yaw_step));
+      base_yaw = std::atan2(base_2d.y() - bwd.y(), base_2d.x() - bwd.x());
+    }
+
+    PathPointWithLaneId pp;
+    pp.point.pose.position.x = base_2d.x() + y_s * (-std::sin(base_yaw));
+    pp.point.pose.position.y = base_2d.y() + y_s * std::cos(base_yaw);
+    pp.point.pose.position.z = base_3d.z();
+    pp.point.pose.orientation =
+      autoware_utils::create_quaternion_from_yaw(base_yaw + std::atan2(yp_s, 1.0));
+    pp.point.longitudinal_velocity_mps = speed_limit;
+    pp.lane_ids = {lanelet_next.id()};
+    if (sc < L / 2.0) {
+      pp.lane_ids.push_back(lanelet_prev_id);
+    }
+    interp_points.push_back(pp);
+  }
+  return interp_points;
+}
+
+void splice_shift_points(
+  std::vector<PathPointWithLaneId> & path_points, const size_t prev_end_idx,
+  const std::vector<PathPointWithLaneId> & interp_points,
+  const lanelet::ConstLanelet & lanelet_next, const double merge_s_on_next)
+{
+  size_t merge_idx = path_points.size();
+  std::optional<size_t> last_next_idx;
+  for (size_t pi = prev_end_idx + 1; pi < path_points.size(); ++pi) {
+    const auto & ids = path_points[pi].lane_ids;
+    if (std::find(ids.begin(), ids.end(), lanelet_next.id()) == ids.end()) {
+      continue;
+    }
+    last_next_idx = pi;
+    const auto pp_2d = lanelet::BasicPoint2d(
+      path_points[pi].point.pose.position.x, path_points[pi].point.pose.position.y);
+    const auto pp_arc = lanelet::geometry::toArcCoordinates(lanelet_next.centerline2d(), pp_2d);
+    if (pp_arc.length >= merge_s_on_next) {
+      merge_idx = pi;
+      break;
+    }
+  }
+  if (merge_idx == path_points.size() && last_next_idx) {
+    merge_idx = *last_next_idx + 1;
+  }
+
+  const size_t erase_begin = prev_end_idx;
+  const size_t erase_end = std::min(merge_idx, path_points.size());
+  path_points.erase(path_points.begin() + erase_begin, path_points.begin() + erase_end);
+  path_points.insert(path_points.begin() + erase_begin, interp_points.begin(), interp_points.end());
+}
+
+}  // namespace
+
+// ===========================================================================
+// PathPlanner member functions
+// ===========================================================================
+
+bool PathPlanner::update_current_lanelet(const geometry_msgs::msg::Pose & current_pose)
+{
+  if (!current_lanelet_) {
+    lanelet::ConstLanelet closest;
+    if (lanelet::utils::query::getClosestLanelet(
+          route_context_.route_lanelets, current_pose, &closest)) {
+      current_lanelet_ = closest;
+      return true;
+    }
+    return false;
+  }
+
+  lanelet::ConstLanelets candidates;
+  if (
+    const auto previous_lanelet =
+      utils::get_previous_lanelet_within_route(*current_lanelet_, route_context_)) {
+    candidates.push_back(*previous_lanelet);
+  }
+  candidates.push_back(*current_lanelet_);
+  if (
+    const auto next_lanelet =
+      utils::get_next_lanelet_within_route(*current_lanelet_, route_context_)) {
+    candidates.push_back(*next_lanelet);
+  }
+
+  // Include adjacent route lanelets so that ego transitions to the correct lane
+  // during lane changes (e.g., 2->4) instead of being picked up by a longitudinally
+  // adjacent lanelet on the wrong lane (e.g., 3)
+  for (const auto & beside : route_context_.routing_graph_ptr->besides(*current_lanelet_)) {
+    if (
+      beside.id() != current_lanelet_->id() &&
+      std::any_of(
+        route_context_.route_lanelets.begin(), route_context_.route_lanelets.end(),
+        [&](const auto & rl) { return rl.id() == beside.id(); })) {
+      candidates.push_back(beside);
+    }
+  }
+
+  if (lanelet::utils::query::getClosestLaneletWithConstrains(
+        candidates, current_pose, &*current_lanelet_,
+        params_.path_planning.ego_nearest_lanelet.dist_threshold,
+        params_.path_planning.ego_nearest_lanelet.yaw_threshold)) {
+    return true;
+  }
+
+  if (lanelet::utils::query::getClosestLanelet(
+        route_context_.route_lanelets, current_pose, &*current_lanelet_)) {
+    return true;
+  }
+
+  return false;
+}
+
+std::optional<PathWithLaneId> PathPlanner::plan_path(
+  const geometry_msgs::msg::Pose & current_pose, const double ego_velocity)
+{
+  const auto path_length_backward = params_.path_planning.path_length.backward;
+  const auto path_length_forward = params_.path_planning.path_length.forward;
+
+  if (!update_current_lanelet(current_pose)) {
+    RCLCPP_ERROR_THROTTLE(logger_, *clock_, 5000, "Failed to update current lanelet");
+    return std::nullopt;
+  }
+
+  // No transition needed: use existing logic with closest preferred lanelet
+  const auto & base_lanelet = [&]() -> const lanelet::ConstLanelet & {
+    if (route_context_.preferred_lanelets.empty()) {
+      return *current_lanelet_;
+    }
+    lanelet::ConstLanelet closest;
+    if (lanelet::utils::query::getClosestLanelet(
+          route_context_.preferred_lanelets, current_pose, &closest)) {
+      route_context_.closest_preferred_lanelet = closest;
+      return *route_context_.closest_preferred_lanelet;
+    }
+    return *current_lanelet_;
+  }();
+
+  lanelet::ConstLanelets lanelets{base_lanelet};
+  const auto s_on_current_lanelet =
+    lanelet::utils::getArcCoordinates({base_lanelet}, current_pose).length;
+
+  const auto backward_length = std::max(
+    0., path_length_backward + vehicle_info_.max_longitudinal_offset_m - s_on_current_lanelet);
+  const auto backward_lanelets_within_route =
+    utils::get_lanelets_within_route_up_to(base_lanelet, route_context_, backward_length);
+  if (!backward_lanelets_within_route) {
+    RCLCPP_ERROR(
+      logger_, "Failed to get backward lanelets within route for current lanelet (id: %ld)",
+      base_lanelet.id());
+    return std::nullopt;
+  }
+  lanelets.insert(
+    lanelets.begin(), backward_lanelets_within_route->begin(),
+    backward_lanelets_within_route->end());
+
+  //  Extend lanelets by backward_length even outside planned route to ensure
+  //  ego footprint is inside lanelets if ego is at the beginning of start lane
+  auto backward_lanelets_length =
+    lanelet::utils::getLaneletLength2d(*backward_lanelets_within_route);
+  while (backward_lanelets_length < backward_length) {
+    const auto prev_lanelets = route_context_.routing_graph_ptr->previous(lanelets.front());
+    if (prev_lanelets.empty()) {
+      break;
+    }
+    // Prefer a lanelet that is in the route at branch points
+    const auto selected = select_route_preferred_lanelet(prev_lanelets, route_context_);
+    lanelets.insert(lanelets.begin(), selected);
+    backward_lanelets_length += lanelet::geometry::length2d(selected);
+  }
+
+  const auto forward_length = std::max(
+    0., path_length_forward + vehicle_info_.max_longitudinal_offset_m -
+          (lanelet::geometry::length2d(base_lanelet) - s_on_current_lanelet));
+  const auto forward_lanelets_within_route =
+    utils::get_lanelets_within_route_after(base_lanelet, route_context_, forward_length);
+  if (!forward_lanelets_within_route) {
+    RCLCPP_ERROR(
+      logger_, "Failed to get forward lanelets within route for current lanelet (id: %ld)",
+      base_lanelet.id());
+    return std::nullopt;
+  }
+  lanelets.insert(
+    lanelets.end(), forward_lanelets_within_route->begin(), forward_lanelets_within_route->end());
+
+  // If the next preferred lanelet is a lateral neighbor of the last one we collected, extend
+  // across the lane change. `s_before_lc` holds the arc length at the discontinuity within
+  // `lanelets` and serves as the intersection-check cutoff for that case.
+  std::optional<double> s_before_lc = [&]() -> std::optional<double> {
+    const auto & preferred = route_context_.preferred_lanelets;
+    auto pref_it = preferred.end();
+    for (auto it = lanelets.rbegin(); it != lanelets.rend(); ++it) {
+      pref_it = std::find_if(
+        preferred.begin(), preferred.end(), [&](const auto & ll) { return ll.id() == it->id(); });
+      if (pref_it != preferred.end()) {
+        break;
+      }
+    }
+    if (pref_it == preferred.end() || std::next(pref_it) == preferred.end()) {
+      return std::nullopt;
+    }
+    const auto & next_preferred = *std::next(pref_it);
+    const auto following = route_context_.routing_graph_ptr->following(*pref_it);
+    const bool is_longitudinal_successor = std::any_of(
+      following.begin(), following.end(),
+      [&](const auto & ll) { return ll.id() == next_preferred.id(); });
+    if (is_longitudinal_successor) {
+      return std::nullopt;
+    }
+
+    while (lanelets.back().id() != pref_it->id()) {
+      lanelets.pop_back();
+    }
+    const double s_boundary = lanelet::utils::getLaneletLength2d(lanelets);
+    lanelets.push_back(next_preferred);
+    const auto forward_from_next =
+      utils::get_lanelets_within_route_after(next_preferred, route_context_, forward_length);
+    if (forward_from_next) {
+      lanelets.insert(lanelets.end(), forward_from_next->begin(), forward_from_next->end());
+    }
+    return s_boundary;
+  }();
+
+  if (!s_before_lc) {
+    auto forward_lanelets_length =
+      lanelet::utils::getLaneletLength2d(*forward_lanelets_within_route);
+    while (forward_lanelets_length < forward_length) {
+      const auto next_lanelets = route_context_.routing_graph_ptr->following(lanelets.back());
+      if (next_lanelets.empty()) {
+        break;
+      }
+      // Prefer a lanelet that is in the route at branch points
+      const auto selected = select_route_preferred_lanelet(next_lanelets, route_context_);
+      lanelets.insert(lanelets.end(), selected);
+      forward_lanelets_length += lanelet::geometry::length2d(selected);
+    }
+  }
+
+  const auto s = s_on_current_lanelet + backward_lanelets_length;
+  const auto s_start = std::max(0., s - path_length_backward);
+  const auto s_end = [&]() {
+    auto s_end_val = s + path_length_forward;
+
+    if (!utils::get_next_lanelet_within_route(lanelets.back(), route_context_)) {
+      s_end_val = std::min(s_end_val, lanelet::utils::getLaneletLength2d(lanelets));
+    }
+
+    auto is_goal_lanelet = [&](const lanelet::ConstLanelet & ll) {
+      return std::any_of(
+        route_context_.goal_lanelets.begin(), route_context_.goal_lanelets.end(),
+        [&](const auto & goal_ll) { return ll.id() == goal_ll.id(); });
+    };
+
+    for (auto [it, goal_arc_length] = std::make_tuple(lanelets.begin(), 0.); it != lanelets.end();
+         ++it) {
+      if (is_goal_lanelet(*it)) {
+        goal_arc_length +=
+          lanelet::utils::getArcCoordinates({*it}, route_context_.goal_pose).length;
+        s_end_val = std::min(s_end_val, goal_arc_length);
+        break;
+      }
+      goal_arc_length += lanelet::geometry::length2d(*it);
+    }
+
+    // Limit the intersection check to the pre-lane-change range to avoid false positives from
+    // the centerline/bound discontinuity at the lane-change boundary.
+    const double s_check_end =
+      s_before_lc ? std::min(s_end_val + vehicle_info_.max_longitudinal_offset_m, *s_before_lc)
+                  : s_end_val + vehicle_info_.max_longitudinal_offset_m;
+    const lanelet::LaneletSequence lanelet_seq(lanelets);
+    if (
+      const auto s_intersection = utils::get_first_intersection_arc_length(
+        lanelet_seq, std::max(0., s_start - vehicle_info_.max_longitudinal_offset_m), s_check_end,
+        vehicle_info_.vehicle_length_m)) {
+      s_end_val = std::min(
+        s_end_val, std::max(0., *s_intersection - vehicle_info_.max_longitudinal_offset_m));
+    }
+
+    return s_end_val;
+  }();
+
+  if (s_end <= s_start) {
+    RCLCPP_WARN_THROTTLE(
+      logger_, *clock_, 5000, "s_end (%.2f) <= s_start (%.2f), cannot generate path", s_end,
+      s_start);
+    return std::nullopt;
+  }
+
+  return generate_path(lanelets, s_start, s_end, ego_velocity);
+}
+
+std::optional<PathWithLaneId> PathPlanner::generate_path(
+  const lanelet::LaneletSequence & lanelet_sequence, const double s_start, const double s_end,
+  const double ego_velocity)
+{
+  if (lanelet_sequence.empty()) {
+    RCLCPP_ERROR(logger_, "Lanelet sequence is empty");
+    return std::nullopt;
+  }
+
+  std::vector<PathPointWithLaneId> path_points_with_lane_id{};
+
+  const auto waypoint_groups = utils::get_waypoint_groups(
+    lanelet_sequence, *route_context_.lanelet_map_ptr,
+    params_.path_planning.waypoint_group.separation_threshold,
+    params_.path_planning.waypoint_group.interval_margin_ratio);
+
+  auto extended_lanelets = lanelet_sequence.lanelets();
+  auto extended_arc_length = 0.;
+  for (const auto & [waypoints, interval] : waypoint_groups) {
+    while (interval.start + extended_arc_length < 0.) {
+      const auto prev_lanelets =
+        route_context_.routing_graph_ptr->previous(extended_lanelets.front());
+      if (prev_lanelets.empty()) {
+        break;
+      }
+      extended_lanelets.insert(extended_lanelets.begin(), prev_lanelets.front());
+      extended_arc_length += lanelet::utils::getLaneletLength2d(prev_lanelets.front());
+    }
+  }
+
+  const auto add_path_point =
+    [&](const lanelet::ConstPoint3d & path_point, const lanelet::Id & lane_id) {
+      PathPointWithLaneId path_point_with_lane_id{};
+      path_point_with_lane_id.lane_ids.push_back(lane_id);
+      path_point_with_lane_id.point.pose.position =
+        lanelet::utils::conversion::toGeomMsgPt(path_point);
+      path_point_with_lane_id.point.longitudinal_velocity_mps =
+        route_context_.traffic_rules_ptr
+          ->speedLimit(route_context_.lanelet_map_ptr->laneletLayer.get(lane_id))
+          .speedLimit.value();
+      path_points_with_lane_id.push_back(std::move(path_point_with_lane_id));
+    };
+
+  const lanelet::LaneletSequence extended_lanelet_sequence(extended_lanelets);
+  std::optional<size_t> overlapping_waypoint_group_index;
+
+  for (auto [lanelet_it, s] = std::make_tuple(extended_lanelet_sequence.begin(), 0.);
+       lanelet_it != extended_lanelet_sequence.end(); ++lanelet_it) {
+    const auto & centerline = lanelet_it->centerline();
+
+    for (auto point_it = centerline.begin(); point_it != centerline.end(); ++point_it) {
+      if (point_it != centerline.begin()) {
+        s += lanelet::geometry::distance2d(*std::prev(point_it), *point_it);
+      } else if (lanelet_it != extended_lanelet_sequence.begin()) {
+        continue;
+      }
+
+      if (overlapping_waypoint_group_index) {
+        const auto & [waypoints, interval] = waypoint_groups[*overlapping_waypoint_group_index];
+        if (s >= interval.start + extended_arc_length && s <= interval.end + extended_arc_length) {
+          continue;
+        }
+        overlapping_waypoint_group_index.reset();
+      }
+
+      for (size_t i = 0; i < waypoint_groups.size(); ++i) {
+        const auto & [waypoints, interval] = waypoint_groups[i];
+        if (s < interval.start + extended_arc_length || s > interval.end + extended_arc_length) {
+          continue;
+        }
+        for (const auto & waypoint : waypoints) {
+          add_path_point(waypoint.point, waypoint.lane_id);
+        }
+        overlapping_waypoint_group_index = i;
+        break;
+      }
+      if (overlapping_waypoint_group_index) {
+        continue;
+      }
+
+      add_path_point(*point_it, lanelet_it->id());
+      if (
+        point_it == std::prev(centerline.end()) &&
+        lanelet_it != std::prev(extended_lanelet_sequence.end())) {
+        if (
+          lanelet_it != extended_lanelet_sequence.begin() ||
+          lanelet_it->id() == lanelet_sequence.begin()->id()) {
+          path_points_with_lane_id.back().lane_ids.push_back(std::next(lanelet_it)->id());
+        } else {
+          path_points_with_lane_id.back().lane_ids = {std::next(lanelet_it)->id()};
+        }
+      }
+    }
+  }
+
+  if (path_points_with_lane_id.empty()) {
+    RCLCPP_ERROR(logger_, "No path points generated from lanelet sequence");
+    return std::nullopt;
+  }
+
+  interpolate_lane_change_sections(
+    path_points_with_lane_id, extended_lanelet_sequence, ego_velocity);
+
+  auto trajectory = autoware::experimental::trajectory::pretty_build(path_points_with_lane_id);
+  if (!trajectory) {
+    RCLCPP_ERROR(logger_, "Failed to build trajectory from path points");
+    return std::nullopt;
+  }
+
+  // Attach orientation for all the points
+  trajectory->align_orientation_with_trajectory_direction();
+
+  const auto s_path_start = utils::get_arc_length_on_path(
+    extended_lanelet_sequence, path_points_with_lane_id, extended_arc_length + s_start);
+  const auto s_path_end = utils::get_arc_length_on_path(
+    extended_lanelet_sequence, path_points_with_lane_id, extended_arc_length + s_end);
+
+  // Crop start first so that goal connection shortening does not skip start cropping
+  if (s_path_start > 0 && trajectory->length() > s_path_start) {
+    trajectory->crop(s_path_start, trajectory->length() - s_path_start);
+  }
+
+  // Adjust s_path_end relative to the new trajectory origin
+  const auto adjusted_s_path_end = s_path_end - s_path_start;
+
+  // Check if the goal point is in the search range
+  // Note: We only see if the goal is approaching the tail of the path.
+  const auto s_path_end_clamped = std::min(trajectory->length(), adjusted_s_path_end);
+  const auto distance_to_goal = autoware_utils::calc_distance2d(
+    trajectory->compute(s_path_end_clamped), route_context_.goal_pose);
+
+  bool goal_connection_applied = false;
+  if (distance_to_goal < params_.path_planning.smooth_goal_connection.search_radius_range) {
+    auto refined_path = utils::modify_path_for_smooth_goal_connection(
+      *trajectory, route_context_, params_.path_planning.smooth_goal_connection.search_radius_range,
+      params_.path_planning.smooth_goal_connection.pre_goal_offset);
+
+    if (refined_path) {
+      refined_path->align_orientation_with_trajectory_direction();
+      *trajectory = *refined_path;
+      goal_connection_applied = true;
+    }
+  }
+
+  // Crop end
+  if (!goal_connection_applied && trajectory->length() > adjusted_s_path_end) {
+    trajectory->crop(0., adjusted_s_path_end);
+  }
+
+  if (trajectory->length() < 1e-3) {
+    RCLCPP_WARN(logger_, "Trajectory length too short after cropping: %f", trajectory->length());
+    return std::nullopt;
+  }
+
+  // Compose the polished path
+  PathWithLaneId finalized_path_with_lane_id{};
+  finalized_path_with_lane_id.points = trajectory->restore();
+
+  if (finalized_path_with_lane_id.points.empty()) {
+    RCLCPP_ERROR(logger_, "Finalized path points are empty after cropping");
+    return std::nullopt;
+  }
+
+  // Set header which is needed to engage
+  finalized_path_with_lane_id.header.frame_id = route_context_.route_frame_id;
+  finalized_path_with_lane_id.header.stamp = clock_->now();
+
+  const auto [left_bound, right_bound] = utils::get_path_bounds(
+    extended_lanelet_sequence,
+    std::max(0., extended_arc_length + s_start - vehicle_info_.max_longitudinal_offset_m),
+    extended_arc_length + s_end + vehicle_info_.max_longitudinal_offset_m);
+  finalized_path_with_lane_id.left_bound = left_bound;
+  finalized_path_with_lane_id.right_bound = right_bound;
+
+  return finalized_path_with_lane_id;
+}
+
+// ===========================================================================
+// Lane change interpolation
+// ===========================================================================
+
+void PathPlanner::interpolate_lane_change_sections(
+  std::vector<PathPointWithLaneId> & path_points, const lanelet::LaneletSequence & lanelet_sequence,
+  const double ego_velocity)
+{
+  if (lanelet_sequence.size() < 2 || path_points.size() < 2) {
+    return;
+  }
+
+  const auto & shift_params = params_.path_planning.path_shift;
+  const auto & lanelets = lanelet_sequence.lanelets();
+
+  const auto boundary_idx = find_lane_change_boundary(lanelets, shift_params.minimum_shift_length);
+  if (!boundary_idx) {
+    return;
+  }
+
+  const auto & lanelet_prev = lanelets[*boundary_idx];
+  const auto & lanelet_next = lanelets[*boundary_idx + 1];
+
+  // Project the previous lanelet's end onto the next centerline to obtain
+  // lateral offset, yaw diff, initial curvature, and arc-length projection.
+  const auto info = compute_lane_change_boundary_info(lanelet_prev, lanelet_next);
+  if (info.abs_lateral_offset < shift_params.minimum_shift_length) {
+    return;
+  }
+
+  const auto prev_end_idx =
+    find_closest_path_index(path_points, lanelet_prev.id(), info.prev_end_geom);
+  if (!prev_end_idx) {
+    return;
+  }
+
+  const double clamped_v =
+    std::max(std::max(0.0, ego_velocity), shift_params.min_speed_for_curvature);
+  double L = compute_shift_length_from_lateral_accel(
+    info.abs_lateral_offset, clamped_v, shift_params.lateral_accel_limit,
+    shift_params.minimum_shift_distance);
+
+  // Intentionally limit the shift length to lanelet_next only; extending the
+  // shift across subsequent lanelets would require multi-lanelet interpolation
+  // in generate_shift_points/splice_shift_points and is not supported.
+  // TODO(odashima): check required behavior
+  const double available_length = info.next_centerline_length - info.s_projection;
+  if (L > available_length) {
+    RCLCPP_WARN(
+      logger_, "Lane change interpolation: shift length %.2f m > available %.2f m, clamping.", L,
+      available_length);
+    L = available_length;
+  }
+  if (L < 1e-3) {
+    return;
+  }
+
+  const auto coeffs =
+    compute_quintic_shift_coeffs(info.lateral_offset, info.yaw_diff, info.start_curvature, L);
+
+  const double next_speed_limit =
+    route_context_.traffic_rules_ptr
+      ->speedLimit(route_context_.lanelet_map_ptr->laneletLayer.get(lanelet_next.id()))
+      .speedLimit.value();
+
+  const auto interp_points = generate_shift_points(
+    info, coeffs, L, params_.path_planning.output.delta_arc_length, next_speed_limit, lanelet_next,
+    lanelet_prev.id());
+  if (interp_points.empty()) {
+    return;
+  }
+
+  splice_shift_points(
+    path_points, *prev_end_idx, interp_points, lanelet_next, info.s_projection + L);
+}
+
+// ===========================================================================
+// Trajectory shifting to base_link
+// ===========================================================================
+
+Trajectory PathPlanner::shift_trajectory_to_ego(
+  const Trajectory & trajectory, const geometry_msgs::msg::Pose & ego_pose,
+  const double ego_velocity, const double ego_yaw_rate, const TrajectoryShiftParams & shift_params,
+  const double delta_arc_length)
+{
+  if (trajectory.points.size() < 2) {
+    return trajectory;
+  }
+
+  const double lateral_offset =
+    autoware::motion_utils::calcLateralOffset(trajectory.points, ego_pose.position);
+  const size_t nearest_idx =
+    autoware::motion_utils::findNearestIndex(trajectory.points, ego_pose.position);
+  const double ego_yaw = tf2::getYaw(ego_pose.orientation);
+  const double traj_yaw = tf2::getYaw(trajectory.points.at(nearest_idx).pose.orientation);
+  const double signed_yaw_dev = autoware_utils::normalize_radian(ego_yaw - traj_yaw);
+  const double abs_yaw_dev = std::abs(signed_yaw_dev);
+
+  if (
+    std::abs(lateral_offset) < shift_params.minimum_shift_length &&
+    abs_yaw_dev < shift_params.minimum_shift_yaw) {
+    return trajectory;
+  }
+
+  const double clamped_velocity =
+    std::max(std::max(0.0, ego_velocity), shift_params.min_speed_for_curvature);
+  const double abs_d = std::abs(lateral_offset);
+  double L = compute_shift_length_from_lateral_accel(
+    abs_d, clamped_velocity, shift_params.lateral_accel_limit, shift_params.minimum_shift_distance);
+
+  double accumulated_length = 0.0;
+  size_t merge_idx = nearest_idx;
+  for (size_t i = nearest_idx; i + 1 < trajectory.points.size(); ++i) {
+    accumulated_length += autoware_utils::calc_distance2d(
+      trajectory.points.at(i).pose.position, trajectory.points.at(i + 1).pose.position);
+    merge_idx = i + 1;
+    if (accumulated_length >= L) {
+      break;
+    }
+  }
+  if (merge_idx >= trajectory.points.size() - 1) {
+    RCLCPP_WARN(
+      rclcpp::get_logger("minimum_rule_based_planner").get_child("path_shift_to_ego"),
+      "Trajectory is shorter than the target shift length (%.2f m < %.2f m). "
+      "Terminal boundary conditions (y=0, y'=0, y''=0) cannot be satisfied; "
+      "the shift polynomial will not converge smoothly at the merge point.",
+      accumulated_length, L);
+    L = accumulated_length;
+    merge_idx = trajectory.points.size() - 2;
+  }
+
+  const double kappa0 = ego_yaw_rate / clamped_velocity;
+  const auto coeffs = compute_quintic_shift_coeffs(lateral_offset, signed_yaw_dev, kappa0, L);
+
+  const double ref_velocity = trajectory.points.at(nearest_idx).longitudinal_velocity_mps;
+  std::vector<TrajectoryPoint> shifted_points;
+
+  TrajectoryPoint ego_pt;
+  ego_pt.pose = ego_pose;
+  ego_pt.longitudinal_velocity_mps = ref_velocity;
+  shifted_points.push_back(ego_pt);
+
+  for (double s = delta_arc_length; s < L; s += delta_arc_length) {
+    const double y_s = evaluate_quintic(coeffs, s);
+    const double yp_s = evaluate_quintic_derivative(coeffs, s);
+
+    const auto base_pose =
+      autoware::motion_utils::calcLongitudinalOffsetPose(trajectory.points, ego_pose.position, s);
+    if (!base_pose) {
+      break;
+    }
+
+    const double base_yaw = tf2::getYaw(base_pose->orientation);
+    TrajectoryPoint pt;
+    pt.pose.position.x = base_pose->position.x + y_s * (-std::sin(base_yaw));
+    pt.pose.position.y = base_pose->position.y + y_s * std::cos(base_yaw);
+    pt.pose.position.z = base_pose->position.z;
+    pt.pose.orientation =
+      autoware_utils::create_quaternion_from_yaw(base_yaw + std::atan2(yp_s, 1.0));
+    pt.longitudinal_velocity_mps = ref_velocity;
+    shifted_points.push_back(pt);
+  }
+
+  for (size_t i = merge_idx; i < trajectory.points.size(); ++i) {
+    shifted_points.push_back(trajectory.points.at(i));
+  }
+
+  Trajectory output;
+  output.header = trajectory.header;
+  output.points = shifted_points;
+  return output;
+}
+
+}  // namespace autoware::minimum_rule_based_planner

--- a/planning/autoware_minimum_rule_based_planner/src/path_planner.hpp
+++ b/planning/autoware_minimum_rule_based_planner/src/path_planner.hpp
@@ -116,12 +116,13 @@ public:
     double ego_velocity);
 
   // Trajectory shifting
-  Trajectory shift_trajectory_to_ego(
+  static Trajectory shift_trajectory_to_ego(
     const Trajectory & trajectory, const geometry_msgs::msg::Pose & ego_pose, double ego_velocity,
     double ego_yaw_rate, const TrajectoryShiftParams & shift_params, double delta_arc_length);
 
   // Path to trajectory conversion
-  Trajectory convert_path_to_trajectory(const PathWithLaneId & path, double resample_interval);
+  static Trajectory convert_path_to_trajectory(
+    const PathWithLaneId & path, double resample_interval);
 
   // Params update
   void update_params(const Params & params);

--- a/planning/autoware_minimum_rule_based_planner/src/path_planner.hpp
+++ b/planning/autoware_minimum_rule_based_planner/src/path_planner.hpp
@@ -1,0 +1,263 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef PATH_PLANNER_HPP_
+#define PATH_PLANNER_HPP_
+
+#include "type_alias.hpp"
+
+#include <autoware_utils_debug/time_keeper.hpp>
+#include <rclcpp/clock.hpp>
+#include <rclcpp/logger.hpp>
+
+#include <lanelet2_core/geometry/Lanelet.h>
+#include <lanelet2_routing/RoutingGraph.h>
+#include <lanelet2_traffic_rules/TrafficRules.h>
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace autoware::minimum_rule_based_planner
+{
+
+struct RouteContext
+{
+  lanelet::LaneletMapPtr lanelet_map_ptr{nullptr};
+  lanelet::traffic_rules::TrafficRulesPtr traffic_rules_ptr{nullptr};
+  lanelet::routing::RoutingGraphPtr routing_graph_ptr{nullptr};
+
+  std::string route_frame_id{};
+  geometry_msgs::msg::Pose goal_pose{};
+
+  lanelet::ConstLanelets route_lanelets{};
+  lanelet::ConstLanelets preferred_lanelets{};
+  lanelet::ConstLanelets start_lanelets{};
+  lanelet::ConstLanelets goal_lanelets{};
+
+  std::optional<lanelet::ConstLanelet> closest_preferred_lanelet;
+};
+
+struct WaypointGroup
+{
+  struct Waypoint
+  {
+    lanelet::ConstPoint3d point;
+    lanelet::Id lane_id;
+  };
+
+  struct Interval
+  {
+    double start;
+    double end;
+  };
+
+  std::vector<Waypoint> waypoints;
+  Interval interval;
+};
+
+template <typename T>
+struct PathRange
+{
+  T left;
+  T right;
+};
+
+struct TrajectoryShiftParams
+{
+  double minimum_shift_length{0.1};      // [m] lateral offset threshold to trigger shift
+  double minimum_shift_yaw{0.1};         // [rad] yaw deviation threshold to trigger shift
+  double minimum_shift_distance{5.0};    // [m] floor for shift distance
+  double min_speed_for_curvature{2.77};  // [m/s] lower bound on speed for kappa0 computation
+  double lateral_accel_limit{0.5};       // [m/s^2] allowed lateral acceleration budget
+};
+
+// ---------------------------------------------------------------------------
+// PathPlanner class
+// ---------------------------------------------------------------------------
+
+class PathPlanner
+{
+public:
+  PathPlanner(
+    const rclcpp::Logger & logger, rclcpp::Clock::SharedPtr clock,
+    std::shared_ptr<autoware_utils_debug::TimeKeeper> time_keeper, const Params & params,
+    const VehicleInfo & vehicle_info);
+
+  // Route / map initialisation
+  void set_planner_data(
+    const LaneletMapBin::ConstSharedPtr & lanelet_map_bin_ptr,
+    const LaneletRoute::ConstSharedPtr & route_ptr);
+
+  // State management
+  void set_route_context(const RouteContext & route_context);
+  RouteContext & route_context();
+  const RouteContext & route_context() const;
+
+  bool update_current_lanelet(const geometry_msgs::msg::Pose & current_pose);
+
+  // Path planning
+  std::optional<PathWithLaneId> plan_path(
+    const geometry_msgs::msg::Pose & current_pose, double ego_velocity);
+  std::optional<PathWithLaneId> generate_path(
+    const lanelet::LaneletSequence & lanelet_sequence, double s_start, double s_end,
+    double ego_velocity);
+
+  // Trajectory shifting
+  Trajectory shift_trajectory_to_ego(
+    const Trajectory & trajectory, const geometry_msgs::msg::Pose & ego_pose, double ego_velocity,
+    double ego_yaw_rate, const TrajectoryShiftParams & shift_params, double delta_arc_length);
+
+  // Path to trajectory conversion
+  Trajectory convert_path_to_trajectory(const PathWithLaneId & path, double resample_interval);
+
+  // Params update
+  void update_params(const Params & params);
+
+  // Lane change interpolation
+  void interpolate_lane_change_sections(
+    std::vector<PathPointWithLaneId> & path_points,
+    const lanelet::LaneletSequence & lanelet_sequence, double ego_velocity);
+
+private:
+  void set_route(const LaneletRoute::ConstSharedPtr & route_ptr);
+
+  rclcpp::Logger logger_;
+  rclcpp::Clock::SharedPtr clock_;
+  std::shared_ptr<autoware_utils_debug::TimeKeeper> time_keeper_;
+  Params params_;
+  VehicleInfo vehicle_info_;
+  RouteContext route_context_;
+  std::optional<lanelet::ConstLanelet> current_lanelet_;
+};
+
+// ---------------------------------------------------------------------------
+// Utility functions
+// ---------------------------------------------------------------------------
+namespace utils
+{
+
+/**
+ * @brief get lanelets within route that are in specified distance backward from target lanelet
+ */
+std::optional<lanelet::ConstLanelets> get_lanelets_within_route_up_to(
+  const lanelet::ConstLanelet & lanelet, const RouteContext & planner_data, const double distance);
+
+/**
+ * @brief get lanelets within route that are in specified distance forward from target lanelet
+ */
+std::optional<lanelet::ConstLanelets> get_lanelets_within_route_after(
+  const lanelet::ConstLanelet & lanelet, const RouteContext & planner_data, const double distance);
+
+/**
+ * @brief get previous lanelet within route
+ */
+std::optional<lanelet::ConstLanelet> get_previous_lanelet_within_route(
+  const lanelet::ConstLanelet & lanelet, const RouteContext & planner_data);
+
+/**
+ * @brief get next lanelet within route
+ */
+std::optional<lanelet::ConstLanelet> get_next_lanelet_within_route(
+  const lanelet::ConstLanelet & lanelet, const RouteContext & planner_data);
+
+/**
+ * @brief get waypoints in lanelet sequence and group them
+ */
+std::vector<WaypointGroup> get_waypoint_groups(
+  const lanelet::LaneletSequence & lanelet_sequence, const lanelet::LaneletMap & lanelet_map,
+  const double group_separation_threshold, const double interval_margin_ratio);
+
+/**
+ * @brief get position of first intersection (including self-intersection) in lanelet sequence
+ */
+std::optional<double> get_first_intersection_arc_length(
+  const lanelet::LaneletSequence & lanelet_sequence, const double s_start, const double s_end,
+  const double vehicle_length);
+
+/**
+ * @brief get position of first self-intersection of line string in arc length
+ */
+std::optional<double> get_first_self_intersection_arc_length(
+  const lanelet::BasicLineString2d & line_string);
+
+/**
+ * @brief get position of given point on centerline projected to path in arc length
+ */
+double get_arc_length_on_path(
+  const lanelet::LaneletSequence & lanelet_sequence, const std::vector<PathPointWithLaneId> & path,
+  const double s_centerline);
+
+/**
+ * @brief get path bounds for PathWithLaneId cropped within specified range
+ */
+PathRange<std::vector<geometry_msgs::msg::Point>> get_path_bounds(
+  const lanelet::LaneletSequence & lanelet_sequence, const double s_start, const double s_end);
+
+/**
+ * @brief crop line string
+ */
+std::vector<geometry_msgs::msg::Point> crop_line_string(
+  const std::vector<geometry_msgs::msg::Point> & line_string, const double s_start,
+  const double s_end);
+
+/**
+ * @brief get positions of given point on centerline projected to left / right bound in arc length
+ */
+PathRange<double> get_arc_length_on_bounds(
+  const lanelet::LaneletSequence & lanelet_sequence, const double s_centerline);
+
+/**
+ * @brief get positions of given point on left / right bound projected to centerline in arc length
+ */
+PathRange<std::optional<double>> get_arc_length_on_centerline(
+  const lanelet::LaneletSequence & lanelet_sequence, const std::optional<double> & s_left_bound,
+  const std::optional<double> & s_right_bound);
+
+/**
+ * @brief Recreate the path with a given goal pose
+ */
+PathPointTrajectory refine_path_for_goal(
+  const PathPointTrajectory & input, const geometry_msgs::msg::Pose & goal_pose,
+  const lanelet::Id goal_lane_id, const double search_radius_range, const double pre_goal_offset);
+
+/**
+ * @brief Extract lanelets from the trajectory
+ */
+lanelet::ConstLanelets extract_lanelets_from_trajectory(
+  const PathPointTrajectory & trajectory, const RouteContext & planner_data);
+
+/**
+ * @brief Check if the pose is in the lanelets
+ */
+bool is_in_lanelets(const geometry_msgs::msg::Pose & pose, const lanelet::ConstLanelets & lanes);
+
+/**
+ * @brief Check if the trajectory is inside the lanelets
+ */
+bool is_trajectory_inside_lanelets(
+  const PathPointTrajectory & refined_path, const lanelet::ConstLanelets & lanelets);
+
+/**
+ * @brief Modify path for smooth goal connection
+ */
+std::optional<PathPointTrajectory> modify_path_for_smooth_goal_connection(
+  const PathPointTrajectory & trajectory, const RouteContext & planner_data,
+  const double search_radius_range, const double pre_goal_offset);
+
+}  // namespace utils
+}  // namespace autoware::minimum_rule_based_planner
+
+#endif  // PATH_PLANNER_HPP_

--- a/planning/autoware_minimum_rule_based_planner/src/type_alias.hpp
+++ b/planning/autoware_minimum_rule_based_planner/src/type_alias.hpp
@@ -1,0 +1,71 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TYPE_ALIAS_HPP_
+#define TYPE_ALIAS_HPP_
+
+#include "autoware/trajectory_optimizer/trajectory_optimizer_plugins/trajectory_optimizer_plugin_base.hpp"
+#include "plugin_interface.hpp"
+
+#include <autoware/trajectory/path_point_with_lane_id.hpp>
+#include <autoware/vehicle_info_utils/vehicle_info.hpp>
+#include <autoware_minimum_rule_based_planner/minimum_rule_based_planner_parameters.hpp>
+#include <pluginlib/class_loader.hpp>
+
+#include <autoware_internal_planning_msgs/msg/candidate_trajectories.hpp>
+#include <autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>
+#include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
+#include <autoware_perception_msgs/msg/predicted_objects.hpp>
+#include <autoware_planning_msgs/msg/lanelet_route.hpp>
+#include <autoware_planning_msgs/msg/trajectory.hpp>
+#include <autoware_planning_msgs/msg/trajectory_point.hpp>
+#include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <unique_identifier_msgs/msg/uuid.hpp>
+
+#include <vector>
+
+namespace autoware::minimum_rule_based_planner
+{
+using autoware::vehicle_info_utils::VehicleInfo;
+using autoware_internal_planning_msgs::msg::CandidateTrajectories;
+using autoware_internal_planning_msgs::msg::PathPointWithLaneId;
+using autoware_internal_planning_msgs::msg::PathWithLaneId;
+using autoware_map_msgs::msg::LaneletMapBin;
+using autoware_perception_msgs::msg::PredictedObjects;
+using autoware_planning_msgs::msg::LaneletRoute;
+using autoware_planning_msgs::msg::Trajectory;
+using autoware_planning_msgs::msg::TrajectoryPoint;
+using geometry_msgs::msg::AccelWithCovarianceStamped;
+using nav_msgs::msg::Odometry;
+using sensor_msgs::msg::PointCloud2;
+using unique_identifier_msgs::msg::UUID;
+using Params = ::minimum_rule_based_planner::Params;
+using TrajectoryPoints = std::vector<TrajectoryPoint>;
+using PathPointTrajectory = autoware::experimental::trajectory::Trajectory<PathPointWithLaneId>;
+using TrajectoryPointTrajectory = autoware::experimental::trajectory::Trajectory<TrajectoryPoint>;
+
+using TrajectoryClass = PathPointTrajectory;
+
+using OptimizerPluginInterface =
+  autoware::trajectory_optimizer::plugin::TrajectoryOptimizerPluginBase;
+using OptimizerPluginLoader = pluginlib::ClassLoader<OptimizerPluginInterface>;
+
+using ModifierPluginLoader =
+  pluginlib::ClassLoader<minimum_rule_based_planner::plugin::PluginInterface>;
+
+}  // namespace autoware::minimum_rule_based_planner
+
+#endif  // TYPE_ALIAS_HPP_

--- a/planning/autoware_minimum_rule_based_planner/src/velocity_smoother.cpp
+++ b/planning/autoware_minimum_rule_based_planner/src/velocity_smoother.cpp
@@ -1,0 +1,393 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "velocity_smoother.hpp"
+
+#include <autoware/motion_utils/trajectory/trajectory.hpp>
+#include <autoware_utils_math/unit_conversion.hpp>
+
+#include <tf2/LinearMath/Quaternion.h>
+#include <tf2/convert.h>
+
+#include <algorithm>
+#include <cmath>
+#include <memory>
+#include <optional>
+#include <utility>
+#include <vector>
+
+namespace autoware::minimum_rule_based_planner
+{
+
+VelocitySmoother::VelocitySmoother(
+  const VelocitySmootherParams & params, const rclcpp::Logger & logger,
+  rclcpp::Clock::SharedPtr clock, const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
+  std::shared_ptr<autoware::velocity_smoother::JerkFilteredSmoother> jerk_filtered_smoother)
+: params_(params),
+  logger_(logger),
+  clock_(std::move(clock)),
+  jerk_filtered_smoother_(std::move(jerk_filtered_smoother))
+{
+  if (jerk_filtered_smoother_) {
+    jerk_filtered_smoother_->setWheelBase(vehicle_info.wheel_base_m);
+  }
+}
+
+void VelocitySmoother::optimize(
+  TrajectoryPoints & traj_points, const nav_msgs::msg::Odometry & current_odometry,
+  double current_acceleration)
+{
+  const double current_speed = current_odometry.twist.twist.linear.x;
+  const double & target_pull_out_speed_mps = params_.target_pull_out_speed_mps;
+  const double & target_pull_out_acc_mps2 = params_.target_pull_out_acc_mps2;
+  const double & max_speed_mps = params_.max_speed_mps;
+
+  // 1. Limit lateral acceleration (disabled by default)
+  if (params_.limit_lateral_acceleration) {
+    limit_lateral_acceleration(traj_points, params_.max_lateral_accel_mps2, current_odometry);
+  }
+
+  // 2. Calculate initial motion
+  auto initial_motion_speed = current_speed;
+  auto initial_motion_acc = current_acceleration;
+
+  if (current_speed < target_pull_out_speed_mps) {
+    // Vehicle is slow (starting/pull-out): use pull-out parameters
+    initial_motion_speed = target_pull_out_speed_mps;
+    initial_motion_acc = target_pull_out_acc_mps2;
+  } else if (!prev_output_.empty()) {
+    // Vehicle is moving: use prev_output for temporal consistency when tracking is good
+    const auto projected =
+      calc_projected_trajectory_point_from_ego(prev_output_, current_odometry.pose.pose);
+    if (projected) {
+      const double desired_vel = std::fabs(projected->longitudinal_velocity_mps);
+      const double desired_acc = projected->acceleration_mps2;
+      constexpr double replan_vel_deviation = 3.0;  // [m/s]
+      if (std::fabs(current_speed - desired_vel) <= replan_vel_deviation) {
+        initial_motion_speed = desired_vel;
+        initial_motion_acc = desired_acc;
+      }
+    }
+  }
+
+  // 3. Engage speed: clamp minimum velocity during pull-out
+  if (params_.set_engage_speed && (current_speed < target_pull_out_speed_mps)) {
+    // Check distance to stop point to avoid engaging when obstacle is ahead
+    const auto closest_idx =
+      autoware::motion_utils::findNearestIndex(traj_points, current_odometry.pose.pose.position);
+    const auto zero_vel_idx =
+      autoware::motion_utils::searchZeroVelocityIndex(traj_points, closest_idx, traj_points.size());
+
+    bool should_engage = true;
+    if (zero_vel_idx) {
+      const double stop_dist =
+        autoware::motion_utils::calcSignedArcLength(traj_points, closest_idx, *zero_vel_idx);
+      if (stop_dist <= params_.stop_dist_to_prohibit_engage) {
+        should_engage = false;
+      }
+    }
+
+    if (should_engage) {
+      clamp_velocities(
+        traj_points, static_cast<float>(initial_motion_speed),
+        static_cast<float>(initial_motion_acc));
+    }
+  }
+
+  // 4. Set max velocity
+  if (params_.limit_speed) {
+    set_max_velocity(traj_points, static_cast<float>(max_speed_mps));
+  }
+
+  // 5. Filter velocity using JerkFilteredSmoother
+  if (params_.smooth_velocities) {
+    filter_velocity(traj_points, initial_motion_speed, initial_motion_acc, current_odometry);
+
+    // Save output for temporal consistency in next cycle
+    if (!traj_points.empty()) {
+      prev_output_ = traj_points;
+    }
+  }
+}
+
+std::optional<TrajectoryPoint> VelocitySmoother::calc_projected_trajectory_point_from_ego(
+  const TrajectoryPoints & trajectory, const geometry_msgs::msg::Pose & ego_pose) const
+{
+  if (trajectory.size() < 2) {
+    return std::nullopt;
+  }
+
+  const auto seg_idx = autoware::motion_utils::findFirstNearestSegmentIndexWithSoftConstraints(
+    trajectory, ego_pose, params_.nearest_dist_threshold_m,
+    autoware_utils_math::deg2rad(params_.nearest_yaw_threshold_deg));
+
+  const auto & p0 = trajectory.at(seg_idx);
+  const auto & p1 = trajectory.at(seg_idx + 1);
+
+  const double dx = p1.pose.position.x - p0.pose.position.x;
+  const double dy = p1.pose.position.y - p0.pose.position.y;
+  const double seg_len_sq = dx * dx + dy * dy;
+
+  if (seg_len_sq < 1e-10) {
+    return p0;
+  }
+
+  const double ex = ego_pose.position.x - p0.pose.position.x;
+  const double ey = ego_pose.position.y - p0.pose.position.y;
+  const double ratio = std::clamp((ex * dx + ey * dy) / seg_len_sq, 0.0, 1.0);
+
+  TrajectoryPoint result = p0;
+  result.longitudinal_velocity_mps = static_cast<float>(
+    p0.longitudinal_velocity_mps +
+    ratio * (p1.longitudinal_velocity_mps - p0.longitudinal_velocity_mps));
+  result.acceleration_mps2 = static_cast<float>(
+    p0.acceleration_mps2 + ratio * (p1.acceleration_mps2 - p0.acceleration_mps2));
+
+  return result;
+}
+
+void VelocitySmoother::clamp_velocities(
+  TrajectoryPoints & traj_points, const float min_velocity, const float min_acceleration)
+{
+  std::for_each(
+    traj_points.begin(), traj_points.end(),
+    [min_velocity, min_acceleration](TrajectoryPoint & point) {
+      point.longitudinal_velocity_mps = std::max(point.longitudinal_velocity_mps, min_velocity);
+      point.acceleration_mps2 = std::max(point.acceleration_mps2, min_acceleration);
+    });
+}
+
+void VelocitySmoother::set_max_velocity(TrajectoryPoints & traj_points, const float max_velocity)
+{
+  if (traj_points.empty()) {
+    return;
+  }
+
+  if (traj_points.size() == 1) {
+    traj_points[0].longitudinal_velocity_mps =
+      std::min(traj_points[0].longitudinal_velocity_mps, max_velocity);
+    traj_points[0].acceleration_mps2 = 0.0f;
+    return;
+  }
+
+  std::vector<std::pair<size_t, size_t>> modified_segment_indices;
+  std::vector<double> original_dts;
+  original_dts.reserve(traj_points.size() - 1);
+
+  auto compute_dt_using_velocity_and_acc =
+    [](const TrajectoryPoint & from, const TrajectoryPoint & to) -> double {
+    const auto dv = static_cast<double>(to.longitudinal_velocity_mps) -
+                    static_cast<double>(from.longitudinal_velocity_mps);
+    const auto acc = static_cast<double>(from.acceleration_mps2);
+    constexpr double epsilon_acceleration = 1e-6;
+    const auto denominator_acc = std::max(std::abs(acc), epsilon_acceleration);
+    return std::abs(dv) / denominator_acc;
+  };
+
+  for (size_t i = 0; i < traj_points.size() - 1; ++i) {
+    original_dts.push_back(compute_dt_using_velocity_and_acc(traj_points[i], traj_points[i + 1]));
+  }
+
+  size_t segment_start = 0;
+  bool in_segment = false;
+
+  for (size_t i = 0; i < traj_points.size(); ++i) {
+    const bool exceeds_max = traj_points[i].longitudinal_velocity_mps > max_velocity;
+    if (exceeds_max && !in_segment) {
+      segment_start = i;
+      in_segment = true;
+    } else if (!exceeds_max && in_segment) {
+      modified_segment_indices.emplace_back(segment_start, i - 1);
+      in_segment = false;
+    }
+  }
+  if (in_segment) {
+    modified_segment_indices.emplace_back(segment_start, traj_points.size() - 1);
+  }
+
+  for (const auto & [start, end] : modified_segment_indices) {
+    for (size_t i = start; i <= end; ++i) {
+      traj_points[i].longitudinal_velocity_mps = max_velocity;
+    }
+    for (size_t i = start; i < end; ++i) {
+      traj_points[i].acceleration_mps2 = 0.0f;
+    }
+  }
+
+  for (const auto & [start, end] : modified_segment_indices) {
+    if (start > 0) {
+      const size_t idx_before = start - 1;
+      const double dt = original_dts[idx_before];
+      const auto v_before = static_cast<double>(traj_points[idx_before].longitudinal_velocity_mps);
+      const auto v_start = static_cast<double>(traj_points[start].longitudinal_velocity_mps);
+      const double new_acc = (v_start - v_before) / dt;
+      traj_points[idx_before].acceleration_mps2 = static_cast<float>(new_acc);
+    }
+    if (end < traj_points.size() - 1) {
+      const double dt = original_dts[end];
+      const auto v_end = static_cast<double>(traj_points[end].longitudinal_velocity_mps);
+      const auto v_after = static_cast<double>(traj_points[end + 1].longitudinal_velocity_mps);
+      const double new_acc = (v_after - v_end) / dt;
+      traj_points[end].acceleration_mps2 = static_cast<float>(new_acc);
+    }
+  }
+
+  traj_points.back().acceleration_mps2 = 0.0f;
+}
+
+void VelocitySmoother::limit_lateral_acceleration(
+  TrajectoryPoints & traj_points, const double max_lateral_accel_mps2,
+  const nav_msgs::msg::Odometry & current_odometry)
+{
+  if (traj_points.empty()) {
+    return;
+  }
+
+  auto get_delta_time = [](const auto & next, const auto & current) -> double {
+    return next->time_from_start.sec + next->time_from_start.nanosec * 1e-9 -
+           (current->time_from_start.sec + current->time_from_start.nanosec * 1e-9);
+  };
+
+  const auto & current_position = current_odometry.pose.pose.position;
+  motion_utils::calculate_time_from_start(traj_points, current_position);
+
+  const auto closest_index = motion_utils::findNearestIndex(traj_points, current_position);
+  const auto start_itr =
+    std::next(traj_points.begin(), static_cast<TrajectoryPoints::difference_type>(closest_index));
+
+  for (auto itr = start_itr; itr < std::prev(traj_points.end()); ++itr) {
+    const auto current_pose = itr->pose;
+    const auto next_pose = std::next(itr)->pose;
+    const auto delta_time = get_delta_time(std::next(itr), itr);
+
+    tf2::Quaternion q_current;
+    tf2::Quaternion q_next;
+    tf2::convert(current_pose.orientation, q_current);
+    tf2::convert(next_pose.orientation, q_next);
+    double delta_theta = q_current.angleShortestPath(q_next);
+    if (delta_theta > M_PI) {
+      delta_theta -= 2.0 * M_PI;
+    } else if (delta_theta < -M_PI) {
+      delta_theta += 2.0 * M_PI;
+    }
+
+    constexpr double epsilon_yaw_rate = 1.0e-5;
+    const double yaw_rate = std::max(std::abs(delta_theta / delta_time), epsilon_yaw_rate);
+    const double current_speed = std::abs(itr->longitudinal_velocity_mps);
+    const double lateral_acceleration = current_speed * yaw_rate;
+    if (lateral_acceleration < max_lateral_accel_mps2) continue;
+
+    itr->longitudinal_velocity_mps = static_cast<float>(max_lateral_accel_mps2 / yaw_rate);
+  }
+
+  motion_utils::calculate_time_from_start(traj_points, current_odometry.pose.pose.position);
+
+  // Recalculate longitudinal acceleration after velocity change
+  if (traj_points.size() >= 2) {
+    for (size_t i = 0; i + 1 < traj_points.size(); ++i) {
+      constexpr double min_dt = 1e-9;
+      const double curr_time = static_cast<double>(traj_points[i].time_from_start.sec) +
+                               static_cast<double>(traj_points[i].time_from_start.nanosec) * 1e-9;
+      const double next_time =
+        static_cast<double>(traj_points[i + 1].time_from_start.sec) +
+        static_cast<double>(traj_points[i + 1].time_from_start.nanosec) * 1e-9;
+      const double dt = std::max(next_time - curr_time, min_dt);
+      const double dv = static_cast<double>(traj_points[i + 1].longitudinal_velocity_mps) -
+                        static_cast<double>(traj_points[i].longitudinal_velocity_mps);
+      traj_points[i].acceleration_mps2 = static_cast<float>(dv / dt);
+    }
+    traj_points.back().acceleration_mps2 = 0.0f;
+  }
+}
+
+void VelocitySmoother::filter_velocity(
+  TrajectoryPoints & traj_points, const double initial_speed, const double initial_acc,
+  const nav_msgs::msg::Odometry & current_odometry)
+{
+  if (!jerk_filtered_smoother_) {
+    RCLCPP_ERROR_THROTTLE(logger_, *clock_, 5000, "JerkFilteredSmoother is not initialized");
+    return;
+  }
+
+  if (traj_points.size() < 2) {
+    return;
+  }
+
+  const double nearest_yaw_threshold_rad =
+    autoware_utils_math::deg2rad(params_.nearest_yaw_threshold_deg);
+
+  constexpr bool enable_smooth_limit = true;
+  constexpr bool use_resampling = true;
+
+  // Lateral acceleration filter
+  traj_points = jerk_filtered_smoother_->applyLateralAccelerationFilter(
+    traj_points, initial_speed, initial_acc, enable_smooth_limit, use_resampling);
+
+  // Steering rate limit (use_resample = false since already resampled above)
+  traj_points = jerk_filtered_smoother_->applySteeringRateLimit(traj_points, false);
+
+  // Resample trajectory with initial_motion_speed based interval distance
+  traj_points = jerk_filtered_smoother_->resampleTrajectory(
+    traj_points, initial_speed, current_odometry.pose.pose, params_.nearest_dist_threshold_m,
+    nearest_yaw_threshold_rad);
+
+  // Clip trajectory from closest point
+  const size_t traj_closest = autoware::motion_utils::findFirstNearestIndexWithSoftConstraints(
+    traj_points, current_odometry.pose.pose, params_.nearest_dist_threshold_m,
+    nearest_yaw_threshold_rad);
+
+  TrajectoryPoints clipped(
+    traj_points.begin() + static_cast<TrajectoryPoints::difference_type>(traj_closest),
+    traj_points.end());
+  traj_points = clipped;
+
+  // Set terminal velocity to 0 before QP
+  if (!traj_points.empty()) {
+    traj_points.back().longitudinal_velocity_mps = 0.0;
+  }
+
+  // Save stop point pose before QP (velocities will be modified by QP)
+  const auto stop_idx = autoware::motion_utils::searchZeroVelocityIndex(traj_points);
+  bool has_stop_pose = false;
+  geometry_msgs::msg::Pose stop_pose;
+  if (stop_idx) {
+    stop_pose = traj_points.at(*stop_idx).pose;
+    has_stop_pose = true;
+  }
+
+  // Apply JerkFilteredSmoother (forward/backward jerk filtering + QP)
+  std::vector<TrajectoryPoints> debug_trajectories;
+  if (!jerk_filtered_smoother_->apply(
+        initial_speed, initial_acc, traj_points, traj_points, debug_trajectories, false)) {
+    RCLCPP_WARN_THROTTLE(logger_, *clock_, 5000, "Fail to solve optimization.");
+  }
+
+  // Overwrite stop point - set 0 velocity from stop point onward
+  if (has_stop_pose) {
+    const auto nearest_output_idx = autoware::motion_utils::findNearestIndex(
+      traj_points, stop_pose, params_.nearest_dist_threshold_m, nearest_yaw_threshold_rad);
+    if (nearest_output_idx) {
+      for (size_t i = *nearest_output_idx; i < traj_points.size(); ++i) {
+        traj_points[i].longitudinal_velocity_mps = 0.0;
+      }
+    }
+  }
+
+  // Ensure terminal velocity is 0 after QP
+  if (!traj_points.empty()) {
+    traj_points.back().longitudinal_velocity_mps = 0.0;
+  }
+}
+
+}  // namespace autoware::minimum_rule_based_planner

--- a/planning/autoware_minimum_rule_based_planner/src/velocity_smoother.hpp
+++ b/planning/autoware_minimum_rule_based_planner/src/velocity_smoother.hpp
@@ -1,0 +1,86 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef VELOCITY_SMOOTHER_HPP_
+#define VELOCITY_SMOOTHER_HPP_
+
+#include "type_alias.hpp"
+
+#include <autoware/velocity_smoother/smoother/jerk_filtered_smoother.hpp>
+#include <autoware_utils_debug/time_keeper.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <geometry_msgs/msg/pose.hpp>
+
+#include <memory>
+#include <optional>
+#include <vector>
+
+namespace autoware::minimum_rule_based_planner
+{
+
+struct VelocitySmootherParams
+{
+  double nearest_dist_threshold_m;
+  double nearest_yaw_threshold_deg;
+  double target_pull_out_speed_mps;
+  double target_pull_out_acc_mps2;
+  double max_speed_mps;
+  double max_lateral_accel_mps2;
+  double stop_dist_to_prohibit_engage;
+  bool set_engage_speed;
+  bool limit_speed;
+  bool limit_lateral_acceleration;
+  bool smooth_velocities;
+};
+
+class VelocitySmoother
+{
+public:
+  VelocitySmoother(
+    const VelocitySmootherParams & params, const rclcpp::Logger & logger,
+    rclcpp::Clock::SharedPtr clock, const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
+    std::shared_ptr<autoware::velocity_smoother::JerkFilteredSmoother> jerk_filtered_smoother);
+
+  void optimize(
+    TrajectoryPoints & traj_points, const nav_msgs::msg::Odometry & current_odometry,
+    double current_acceleration);
+
+private:
+  static void clamp_velocities(
+    TrajectoryPoints & traj_points, float min_velocity, float min_acceleration);
+
+  static void set_max_velocity(TrajectoryPoints & traj_points, float max_velocity);
+
+  static void limit_lateral_acceleration(
+    TrajectoryPoints & traj_points, double max_lateral_accel_mps2,
+    const nav_msgs::msg::Odometry & current_odometry);
+
+  void filter_velocity(
+    TrajectoryPoints & traj_points, double initial_speed, double initial_acc,
+    const nav_msgs::msg::Odometry & current_odometry);
+
+  std::optional<TrajectoryPoint> calc_projected_trajectory_point_from_ego(
+    const TrajectoryPoints & trajectory, const geometry_msgs::msg::Pose & ego_pose) const;
+
+  VelocitySmootherParams params_;
+  rclcpp::Logger logger_;
+  rclcpp::Clock::SharedPtr clock_;
+  std::shared_ptr<autoware::velocity_smoother::JerkFilteredSmoother> jerk_filtered_smoother_;
+  TrajectoryPoints prev_output_;
+};
+
+}  // namespace autoware::minimum_rule_based_planner
+
+#endif  // VELOCITY_SMOOTHER_HPP_

--- a/planning/autoware_minimum_rule_based_planner/test/test_path_planner.cpp
+++ b/planning/autoware_minimum_rule_based_planner/test/test_path_planner.cpp
@@ -1,0 +1,283 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "path_planner.hpp"
+
+#include <autoware_utils_debug/time_keeper.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <memory>
+#include <vector>
+
+namespace autoware::minimum_rule_based_planner
+{
+namespace
+{
+
+std::shared_ptr<autoware_utils_debug::TimeKeeper> make_time_keeper()
+{
+  return std::make_shared<autoware_utils_debug::TimeKeeper>();
+}
+
+Params make_default_params()
+{
+  Params params;
+  params.path_planning.ego_nearest_lanelet.dist_threshold = 3.0;
+  params.path_planning.ego_nearest_lanelet.yaw_threshold = 1.57;
+  params.path_planning.path_length.backward = 50.0;
+  params.path_planning.path_length.forward = 100.0;
+  params.path_planning.output.delta_arc_length = 1.0;
+  params.path_planning.waypoint_group.separation_threshold = 1.0;
+  params.path_planning.waypoint_group.interval_margin_ratio = 0.5;
+  params.path_planning.smooth_goal_connection.search_radius_range = 15.0;
+  params.path_planning.smooth_goal_connection.pre_goal_offset = 3.0;
+  params.path_planning.path_shift.enable = false;
+  params.path_planning.path_shift.minimum_shift_length = 0.1;
+  params.path_planning.path_shift.minimum_shift_yaw = 0.1;
+  params.path_planning.path_shift.minimum_shift_distance = 5.0;
+  params.path_planning.path_shift.min_speed_for_curvature = 2.77;
+  params.path_planning.path_shift.lateral_accel_limit = 0.5;
+  return params;
+}
+
+autoware_planning_msgs::msg::TrajectoryPoint make_traj_point(double x, double y, float vel = 1.0f)
+{
+  autoware_planning_msgs::msg::TrajectoryPoint pt;
+  pt.pose.position.x = x;
+  pt.pose.position.y = y;
+  pt.pose.position.z = 0.0;
+  pt.pose.orientation.w = 1.0;
+  pt.longitudinal_velocity_mps = vel;
+  return pt;
+}
+
+Trajectory make_straight_trajectory(size_t num_points, double spacing, float velocity)
+{
+  Trajectory traj;
+  traj.header.frame_id = "map";
+  for (size_t i = 0; i < num_points; ++i) {
+    traj.points.push_back(make_traj_point(spacing * static_cast<double>(i), 0.0, velocity));
+  }
+  return traj;
+}
+
+geometry_msgs::msg::Pose make_pose(double x, double y, double yaw = 0.0)
+{
+  geometry_msgs::msg::Pose pose;
+  pose.position.x = x;
+  pose.position.y = y;
+  pose.position.z = 0.0;
+  pose.orientation.x = 0.0;
+  pose.orientation.y = 0.0;
+  pose.orientation.z = std::sin(yaw / 2.0);
+  pose.orientation.w = std::cos(yaw / 2.0);
+  return pose;
+}
+
+PathPointWithLaneId make_path_point(double x, double y, double vel = 1.0, int64_t lane_id = 1)
+{
+  PathPointWithLaneId pt;
+  pt.point.pose.position.x = x;
+  pt.point.pose.position.y = y;
+  pt.point.pose.position.z = 0.0;
+  pt.point.pose.orientation.w = 1.0;
+  pt.point.longitudinal_velocity_mps = static_cast<float>(vel);
+  pt.lane_ids.push_back(lane_id);
+  return pt;
+}
+
+}  // namespace
+
+// ============================================================
+// PathPlanner construction test
+// ============================================================
+
+TEST(PathPlannerTest, ConstructWithoutNode)
+{
+  auto logger = rclcpp::get_logger("test_path_planner");
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  auto params = make_default_params();
+  VehicleInfo vehicle_info{};
+  vehicle_info.wheel_base_m = 2.79;
+  vehicle_info.max_longitudinal_offset_m = 4.0;
+  vehicle_info.vehicle_length_m = 4.89;
+
+  EXPECT_NO_THROW(PathPlanner planner(logger, clock, make_time_keeper(), params, vehicle_info));
+}
+
+// ============================================================
+// shift_trajectory_to_ego tests
+// ============================================================
+
+TEST(PathPlannerTest, ShiftNotNeeded)
+{
+  auto logger = rclcpp::get_logger("test_path_planner");
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  auto params = make_default_params();
+  VehicleInfo vehicle_info{};
+  vehicle_info.wheel_base_m = 2.79;
+
+  PathPlanner planner(logger, clock, make_time_keeper(), params, vehicle_info);
+
+  auto traj = make_straight_trajectory(20, 1.0, 10.0f);
+  // Ego is exactly on the trajectory → no shift needed
+  auto ego_pose = make_pose(0.0, 0.0, 0.0);
+
+  TrajectoryShiftParams shift_params;
+  shift_params.minimum_shift_length = 0.1;
+  shift_params.minimum_shift_yaw = 0.1;
+
+  const auto result = planner.shift_trajectory_to_ego(traj, ego_pose, 10.0, 0.0, shift_params, 1.0);
+
+  // Should return the trajectory unchanged since offset and yaw are below threshold
+  ASSERT_EQ(result.points.size(), traj.points.size());
+  for (size_t i = 0; i < result.points.size(); ++i) {
+    EXPECT_NEAR(result.points[i].pose.position.x, traj.points[i].pose.position.x, 1e-3);
+    EXPECT_NEAR(result.points[i].pose.position.y, traj.points[i].pose.position.y, 1e-3);
+  }
+}
+
+TEST(PathPlannerTest, ShiftShortTrajectory)
+{
+  auto logger = rclcpp::get_logger("test_path_planner");
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  auto params = make_default_params();
+  VehicleInfo vehicle_info{};
+  vehicle_info.wheel_base_m = 2.79;
+
+  PathPlanner planner(logger, clock, make_time_keeper(), params, vehicle_info);
+
+  // Trajectory with fewer than 2 points → should return as-is
+  Trajectory short_traj;
+  short_traj.header.frame_id = "map";
+  short_traj.points.push_back(make_traj_point(0.0, 0.0, 10.0f));
+
+  auto ego_pose = make_pose(0.0, 1.0, 0.0);  // Offset ego
+  TrajectoryShiftParams shift_params;
+
+  const auto result =
+    planner.shift_trajectory_to_ego(short_traj, ego_pose, 10.0, 0.0, shift_params, 1.0);
+
+  ASSERT_EQ(result.points.size(), 1u);
+  EXPECT_NEAR(result.points[0].pose.position.x, 0.0, 1e-3);
+}
+
+TEST(PathPlannerTest, ShiftNormal)
+{
+  auto logger = rclcpp::get_logger("test_path_planner");
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  auto params = make_default_params();
+  VehicleInfo vehicle_info{};
+  vehicle_info.wheel_base_m = 2.79;
+
+  PathPlanner planner(logger, clock, make_time_keeper(), params, vehicle_info);
+
+  auto traj = make_straight_trajectory(50, 1.0, 10.0f);
+  // Ego is offset laterally (large offset to trigger shift)
+  auto ego_pose = make_pose(0.0, 2.0, 0.0);
+
+  TrajectoryShiftParams shift_params;
+  shift_params.minimum_shift_length = 0.1;
+  shift_params.minimum_shift_yaw = 0.1;
+  shift_params.minimum_shift_distance = 5.0;
+  shift_params.min_speed_for_curvature = 2.77;
+  shift_params.lateral_accel_limit = 0.5;
+
+  const auto result = planner.shift_trajectory_to_ego(traj, ego_pose, 10.0, 0.0, shift_params, 1.0);
+
+  // First point should be at ego position
+  EXPECT_NEAR(result.points.front().pose.position.x, ego_pose.position.x, 1e-3);
+  EXPECT_NEAR(result.points.front().pose.position.y, ego_pose.position.y, 1e-3);
+
+  // Last points should match original trajectory (merged back)
+  const auto & last_orig = traj.points.back();
+  const auto & last_result = result.points.back();
+  EXPECT_NEAR(last_result.pose.position.x, last_orig.pose.position.x, 1e-3);
+  EXPECT_NEAR(last_result.pose.position.y, last_orig.pose.position.y, 1e-3);
+}
+
+// ============================================================
+// convert_path_to_trajectory tests
+// ============================================================
+
+TEST(PathPlannerTest, ConvertPathToTrajectoryEmpty)
+{
+  auto logger = rclcpp::get_logger("test_path_planner");
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  auto params = make_default_params();
+  VehicleInfo vehicle_info{};
+  vehicle_info.wheel_base_m = 2.79;
+
+  PathPlanner planner(logger, clock, make_time_keeper(), params, vehicle_info);
+
+  const PathWithLaneId empty_path;
+  const auto result = planner.convert_path_to_trajectory(empty_path, 1.0);
+  EXPECT_TRUE(result.points.empty());
+}
+
+TEST(PathPlannerTest, ConvertPathToTrajectoryVelocityPreserved)
+{
+  auto logger = rclcpp::get_logger("test_path_planner");
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  auto params = make_default_params();
+  VehicleInfo vehicle_info{};
+  vehicle_info.wheel_base_m = 2.79;
+
+  PathPlanner planner(logger, clock, make_time_keeper(), params, vehicle_info);
+
+  PathWithLaneId path;
+  path.header.frame_id = "map";
+  const float speed = 5.0f;
+  for (int i = 0; i <= 10; ++i) {
+    path.points.push_back(make_path_point(static_cast<double>(i), 0.0, speed));
+  }
+
+  const auto result = planner.convert_path_to_trajectory(path, 1.0);
+  ASSERT_FALSE(result.points.empty());
+  for (const auto & pt : result.points) {
+    EXPECT_NEAR(pt.longitudinal_velocity_mps, speed, 1e-3f);
+  }
+}
+
+TEST(PathPlannerTest, ConvertPathToTrajectoryResamplingSpacing)
+{
+  auto logger = rclcpp::get_logger("test_path_planner");
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  auto params = make_default_params();
+  VehicleInfo vehicle_info{};
+  vehicle_info.wheel_base_m = 2.79;
+
+  PathPlanner planner(logger, clock, make_time_keeper(), params, vehicle_info);
+
+  PathWithLaneId path;
+  path.header.frame_id = "map";
+  for (int i = 0; i <= 10; ++i) {
+    path.points.push_back(make_path_point(static_cast<double>(i), 0.0, 1.0));
+  }
+
+  const double interval = 0.5;
+  const auto result = planner.convert_path_to_trajectory(path, interval);
+  ASSERT_GE(result.points.size(), 2u);
+
+  for (size_t i = 1; i + 1 < result.points.size(); ++i) {
+    const double dx = result.points[i].pose.position.x - result.points[i - 1].pose.position.x;
+    const double dy = result.points[i].pose.position.y - result.points[i - 1].pose.position.y;
+    EXPECT_NEAR(std::hypot(dx, dy), interval, 0.05);
+  }
+}
+
+}  // namespace autoware::minimum_rule_based_planner

--- a/planning/autoware_minimum_rule_based_planner/test/test_velocity_smoother.cpp
+++ b/planning/autoware_minimum_rule_based_planner/test/test_velocity_smoother.cpp
@@ -1,0 +1,355 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "velocity_smoother.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <memory>
+#include <vector>
+
+namespace autoware::minimum_rule_based_planner
+{
+namespace
+{
+
+TrajectoryPoint make_traj_point(double x, double y, float vel, float acc = 0.0f)
+{
+  TrajectoryPoint pt;
+  pt.pose.position.x = x;
+  pt.pose.position.y = y;
+  pt.pose.position.z = 0.0;
+  pt.pose.orientation.w = 1.0;
+  pt.longitudinal_velocity_mps = vel;
+  pt.acceleration_mps2 = acc;
+  return pt;
+}
+
+TrajectoryPoints make_straight_trajectory(
+  size_t num_points, double spacing, float velocity, float acc = 0.0f)
+{
+  TrajectoryPoints points;
+  points.reserve(num_points);
+  for (size_t i = 0; i < num_points; ++i) {
+    points.push_back(make_traj_point(spacing * static_cast<double>(i), 0.0, velocity, acc));
+  }
+  return points;
+}
+
+nav_msgs::msg::Odometry make_odometry(double x, double y, double speed)
+{
+  nav_msgs::msg::Odometry odom;
+  odom.pose.pose.position.x = x;
+  odom.pose.pose.position.y = y;
+  odom.pose.pose.position.z = 0.0;
+  odom.pose.pose.orientation.w = 1.0;
+  odom.twist.twist.linear.x = speed;
+  return odom;
+}
+
+VelocitySmootherParams make_default_params()
+{
+  VelocitySmootherParams params;
+  params.nearest_dist_threshold_m = 3.0;
+  params.nearest_yaw_threshold_deg = 45.0;
+  params.target_pull_out_speed_mps = 2.0;
+  params.target_pull_out_acc_mps2 = 1.0;
+  params.max_speed_mps = 20.0;
+  params.max_lateral_accel_mps2 = 2.0;
+  params.stop_dist_to_prohibit_engage = 3.0;
+  params.set_engage_speed = false;
+  params.limit_speed = false;
+  params.limit_lateral_acceleration = false;
+  params.smooth_velocities = false;
+  return params;
+}
+
+}  // namespace
+
+// ============================================================
+// VelocitySmoother construction without Node
+// ============================================================
+
+TEST(VelocitySmootherTest, ConstructWithoutNode)
+{
+  auto params = make_default_params();
+  auto logger = rclcpp::get_logger("test_velocity_smoother");
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  autoware::vehicle_info_utils::VehicleInfo vehicle_info{};
+  vehicle_info.wheel_base_m = 2.79;
+
+  // Construct without JerkFilteredSmoother (nullptr) - smoothing disabled
+  VelocitySmoother smoother(params, logger, clock, vehicle_info, nullptr);
+
+  auto traj = make_straight_trajectory(10, 1.0, 10.0f);
+  auto odom = make_odometry(0.0, 0.0, 10.0);
+  // Should not crash with smooth_velocities=false and nullptr smoother
+  smoother.optimize(traj, odom, 0.0);
+  EXPECT_FALSE(traj.empty());
+}
+
+// ============================================================
+// max_speed_mps limit
+// ============================================================
+
+TEST(VelocitySmootherTest, LimitSpeedClampsVelocity)
+{
+  auto params = make_default_params();
+  params.limit_speed = true;
+  params.max_speed_mps = 5.0;
+
+  auto logger = rclcpp::get_logger("test_velocity_smoother");
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  autoware::vehicle_info_utils::VehicleInfo vehicle_info{};
+  vehicle_info.wheel_base_m = 2.79;
+
+  VelocitySmoother smoother(params, logger, clock, vehicle_info, nullptr);
+
+  auto traj = make_straight_trajectory(10, 1.0, 10.0f);
+  auto odom = make_odometry(0.0, 0.0, 10.0);
+  smoother.optimize(traj, odom, 0.0);
+
+  for (const auto & pt : traj) {
+    EXPECT_LE(pt.longitudinal_velocity_mps, static_cast<float>(params.max_speed_mps) + 1e-3f);
+  }
+}
+
+TEST(VelocitySmootherTest, LimitSpeedDoesNotAffectSlowerPoints)
+{
+  auto params = make_default_params();
+  params.limit_speed = true;
+  params.max_speed_mps = 20.0;
+
+  auto logger = rclcpp::get_logger("test_velocity_smoother");
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  autoware::vehicle_info_utils::VehicleInfo vehicle_info{};
+  vehicle_info.wheel_base_m = 2.79;
+
+  VelocitySmoother smoother(params, logger, clock, vehicle_info, nullptr);
+
+  auto traj = make_straight_trajectory(10, 1.0, 10.0f);
+  auto odom = make_odometry(0.0, 0.0, 10.0);
+  smoother.optimize(traj, odom, 0.0);
+
+  // All points should remain at 10.0 since max_speed is 20.0
+  for (size_t i = 0; i < traj.size(); ++i) {
+    EXPECT_NEAR(traj[i].longitudinal_velocity_mps, 10.0f, 1e-3f);
+  }
+}
+
+// ============================================================
+// Engage speed (pull-out)
+// ============================================================
+
+TEST(VelocitySmootherTest, EngageSpeedClampsMinVelocity)
+{
+  auto params = make_default_params();
+  params.set_engage_speed = true;
+  params.target_pull_out_speed_mps = 3.0;
+  params.target_pull_out_acc_mps2 = 1.0;
+  params.stop_dist_to_prohibit_engage = 2.0;
+
+  auto logger = rclcpp::get_logger("test_velocity_smoother");
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  autoware::vehicle_info_utils::VehicleInfo vehicle_info{};
+  vehicle_info.wheel_base_m = 2.79;
+
+  VelocitySmoother smoother(params, logger, clock, vehicle_info, nullptr);
+
+  // Trajectory with low velocities, no zero-velocity stop point
+  auto traj = make_straight_trajectory(20, 1.0, 1.0f);
+  auto odom = make_odometry(0.0, 0.0, 0.5);  // ego is slow -> engage condition
+  smoother.optimize(traj, odom, 0.0);
+
+  // After engage clamp, velocities should be >= target_pull_out_speed_mps
+  for (const auto & pt : traj) {
+    EXPECT_GE(
+      pt.longitudinal_velocity_mps, static_cast<float>(params.target_pull_out_speed_mps) - 1e-3f);
+  }
+}
+
+TEST(VelocitySmootherTest, EngageSpeedProhibitedNearStopPoint)
+{
+  auto params = make_default_params();
+  params.set_engage_speed = true;
+  params.target_pull_out_speed_mps = 3.0;
+  params.target_pull_out_acc_mps2 = 1.0;
+  params.stop_dist_to_prohibit_engage = 10.0;  // large threshold
+
+  auto logger = rclcpp::get_logger("test_velocity_smoother");
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  autoware::vehicle_info_utils::VehicleInfo vehicle_info{};
+  vehicle_info.wheel_base_m = 2.79;
+
+  VelocitySmoother smoother(params, logger, clock, vehicle_info, nullptr);
+
+  // Trajectory with a stop point at index 5 (distance = 5m < 10m threshold)
+  auto traj = make_straight_trajectory(10, 1.0, 1.0f);
+  traj[5].longitudinal_velocity_mps = 0.0f;
+
+  auto odom = make_odometry(0.0, 0.0, 0.5);  // ego is slow
+  smoother.optimize(traj, odom, 0.0);
+
+  // Engage should NOT be applied, so low-velocity points should remain low
+  EXPECT_LT(
+    traj[0].longitudinal_velocity_mps, static_cast<float>(params.target_pull_out_speed_mps));
+}
+
+// ============================================================
+// Empty and minimal trajectory
+// ============================================================
+
+TEST(VelocitySmootherTest, EmptyTrajectoryDoesNotCrash)
+{
+  auto params = make_default_params();
+  auto logger = rclcpp::get_logger("test_velocity_smoother");
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  autoware::vehicle_info_utils::VehicleInfo vehicle_info{};
+  vehicle_info.wheel_base_m = 2.79;
+
+  VelocitySmoother smoother(params, logger, clock, vehicle_info, nullptr);
+
+  TrajectoryPoints traj;
+  auto odom = make_odometry(0.0, 0.0, 0.0);
+  smoother.optimize(traj, odom, 0.0);
+  EXPECT_TRUE(traj.empty());
+}
+
+TEST(VelocitySmootherTest, SinglePointTrajectoryDoesNotCrash)
+{
+  auto params = make_default_params();
+  auto logger = rclcpp::get_logger("test_velocity_smoother");
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  autoware::vehicle_info_utils::VehicleInfo vehicle_info{};
+  vehicle_info.wheel_base_m = 2.79;
+
+  VelocitySmoother smoother(params, logger, clock, vehicle_info, nullptr);
+
+  TrajectoryPoints traj;
+  traj.push_back(make_traj_point(0.0, 0.0, 10.0f));
+  auto odom = make_odometry(0.0, 0.0, 0.0);
+  smoother.optimize(traj, odom, 0.0);
+  EXPECT_EQ(traj.size(), 1u);
+}
+
+// ============================================================
+// set_max_velocity: partial over-speed segment
+// ============================================================
+
+TEST(VelocitySmootherTest, LimitSpeedPartialSegment)
+{
+  auto params = make_default_params();
+  params.limit_speed = true;
+  params.max_speed_mps = 10.0;
+
+  auto logger = rclcpp::get_logger("test_velocity_smoother");
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  autoware::vehicle_info_utils::VehicleInfo vehicle_info{};
+  vehicle_info.wheel_base_m = 2.79;
+
+  VelocitySmoother smoother(params, logger, clock, vehicle_info, nullptr);
+
+  // Points: [5, 5, 15, 15, 15, 5, 5] m/s
+  TrajectoryPoints traj;
+  traj.push_back(make_traj_point(0.0, 0.0, 5.0f, 1.0f));
+  traj.push_back(make_traj_point(1.0, 0.0, 5.0f, 1.0f));
+  traj.push_back(make_traj_point(2.0, 0.0, 15.0f, 1.0f));
+  traj.push_back(make_traj_point(3.0, 0.0, 15.0f, 1.0f));
+  traj.push_back(make_traj_point(4.0, 0.0, 15.0f, 1.0f));
+  traj.push_back(make_traj_point(5.0, 0.0, 5.0f, -1.0f));
+  traj.push_back(make_traj_point(6.0, 0.0, 5.0f, 0.0f));
+
+  auto odom = make_odometry(0.0, 0.0, 5.0);
+  smoother.optimize(traj, odom, 0.0);
+
+  // All points should be <= max_speed_mps
+  for (const auto & pt : traj) {
+    EXPECT_LE(pt.longitudinal_velocity_mps, 10.0f + 1e-3f);
+  }
+
+  // Points outside the over-speed segment should remain unchanged
+  EXPECT_NEAR(traj[0].longitudinal_velocity_mps, 5.0f, 1e-3f);
+  EXPECT_NEAR(traj[1].longitudinal_velocity_mps, 5.0f, 1e-3f);
+  EXPECT_NEAR(traj[5].longitudinal_velocity_mps, 5.0f, 1e-3f);
+}
+
+// ============================================================
+// Pull-out initial motion
+// ============================================================
+
+TEST(VelocitySmootherTest, PullOutUsesTargetSpeedWhenSlow)
+{
+  auto params = make_default_params();
+  // Enable limit_speed so we can observe clamped velocities
+  params.limit_speed = true;
+  params.max_speed_mps = 20.0;
+  params.set_engage_speed = true;
+  params.target_pull_out_speed_mps = 3.0;
+  params.target_pull_out_acc_mps2 = 1.5;
+  params.stop_dist_to_prohibit_engage = 1.0;
+
+  auto logger = rclcpp::get_logger("test_velocity_smoother");
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  autoware::vehicle_info_utils::VehicleInfo vehicle_info{};
+  vehicle_info.wheel_base_m = 2.79;
+
+  VelocitySmoother smoother(params, logger, clock, vehicle_info, nullptr);
+
+  // Trajectory with moderate speed, no stop point nearby
+  auto traj = make_straight_trajectory(20, 1.0, 5.0f);
+  // Ego is slow (below pull-out speed)
+  auto odom = make_odometry(0.0, 0.0, 1.0);
+  smoother.optimize(traj, odom, 0.0);
+
+  // Since ego speed < target_pull_out_speed, engage speed clamp should raise velocities
+  for (const auto & pt : traj) {
+    EXPECT_GE(
+      pt.longitudinal_velocity_mps, static_cast<float>(params.target_pull_out_speed_mps) - 1e-3f);
+  }
+}
+
+// ============================================================
+// All features disabled: trajectory passes through unchanged
+// ============================================================
+
+TEST(VelocitySmootherTest, AllFeaturesDisabledPassthrough)
+{
+  auto params = make_default_params();
+  // All features disabled by default in make_default_params
+
+  auto logger = rclcpp::get_logger("test_velocity_smoother");
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  autoware::vehicle_info_utils::VehicleInfo vehicle_info{};
+  vehicle_info.wheel_base_m = 2.79;
+
+  VelocitySmoother smoother(params, logger, clock, vehicle_info, nullptr);
+
+  auto traj = make_straight_trajectory(10, 1.0, 7.5f, 0.5f);
+  const auto traj_original = traj;
+  auto odom = make_odometry(0.0, 0.0, 7.5);
+  smoother.optimize(traj, odom, 0.0);
+
+  // Trajectory should be unchanged when all features are disabled
+  ASSERT_EQ(traj.size(), traj_original.size());
+  for (size_t i = 0; i < traj.size(); ++i) {
+    EXPECT_NEAR(
+      traj[i].longitudinal_velocity_mps, traj_original[i].longitudinal_velocity_mps, 1e-6f);
+    EXPECT_NEAR(traj[i].acceleration_mps2, traj_original[i].acceleration_mps2, 1e-6f);
+  }
+}
+
+}  // namespace autoware::minimum_rule_based_planner


### PR DESCRIPTION
## Description

This PR introduces a new package, `autoware_minimum_rule_based_planner`.

It is a minimum, rule-based trajectory planner that generates safe and feasible trajectories by following the planned route along the lanelet centerline and applying multi-stage optimization. It is intended as a lightweight backup/reference planner that depends only on the route and the HD map, without requiring the full behavior/motion planning stack.

Pipeline overview:

- **Centerline-based path planning** — builds a path along the lanelet centerline from the HD map, extending backward and forward from the ego pose.
- **Path shifting** — shifts the centerline path to start from the ego's current pose, using a curvature-aware shift distance derived from ego velocity and lateral-acceleration limits.
- **Trajectory smoothing** — applies an Elastic Band smoother via a trajectory-optimizer plugin interface.
- **Trajectory modification** — applies modifier plugins (`obstacle_stop`, `surround_obstacle_stop`) for safety, reusing `autoware_trajectory_modifier` utilities.
- **Velocity optimization** — computes a jerk-filtered velocity profile that respects acceleration, jerk, and lateral-acceleration constraints.

The package ships its node, launch file, plugin interfaces (`obstacle_stop`, `surround_obstacle_stop`), parameter/schema definitions, and unit tests for the path planner and velocity smoother.

## Related links

**Parent Issue:**

- Link

## How was this PR tested?

- Unit tests: `test_path_planner.cpp`, `test_velocity_smoother.cpp`.
- psim
- real vehicle experiments

## Notes for reviewers

This package reuses `autoware_trajectory_modifier` collision/utility APIs. The `obstacle_stop` plugin calls `get_nearest_object_collision(...)` with the `use_rss_check` overload, so it requires a version of `autoware_trajectory_modifier` that exposes that overload. Please make sure the depended-on `autoware_trajectory_modifier` in this repository provides the RSS-check overload; otherwise the `obstacle_stop` plugin will fail to build.

## Interface changes

This PR adds a new node, so all interfaces below are newly added.

### Topic changes

#### Additions and removals

| Change type | Topic Type | Topic Name | Message Type | Description |
|:--|:--|:--|:--|:--|
| Added | Sub | `~/input/route` | `autoware_planning_msgs/msg/LaneletRoute` | Planned route (transient_local QoS) |
| Added | Sub | `~/input/vector_map` | `autoware_map_msgs/msg/LaneletMapBin` | HD map (transient_local QoS) |
| Added | Sub | `~/input/odometry` | `nav_msgs/msg/Odometry` | Ego pose and velocity |
| Added | Sub | `~/input/acceleration` | `geometry_msgs/msg/AccelWithCovarianceStamped` | Ego acceleration |
| Added | Sub | `~/input/objects` | `autoware_perception_msgs/msg/PredictedObjects` | Surrounding obstacles |
| Added | Sub | `~/input/pointcloud` | `sensor_msgs/msg/PointCloud2` | Obstacle pointcloud (obstacle stop) |
| Added | Sub | `~/input/test/path_with_lane_id` | `autoware_internal_planning_msgs/msg/PathWithLaneId` | Test mode: bypasses path planning |
| Added | Pub | `~/output/candidate_trajectories` | `autoware_internal_planning_msgs/msg/CandidateTrajectories` | Planned trajectory |
| Added | Pub | `~/debug/path_with_lane_id` | `autoware_internal_planning_msgs/msg/PathWithLaneId` | Debug: planned path |
| Added | Pub | `~/debug/trajectory` | `autoware_planning_msgs/msg/Trajectory` | Debug: final output trajectory |
| Added | Pub | `~/debug/shifted_trajectory` | `autoware_planning_msgs/msg/Trajectory` | Debug: trajectory after path shifting |
| Added | Pub | `~/debug/optimizer/{name}/trajectory` | `autoware_planning_msgs/msg/Trajectory` | Debug: trajectory after each optimizer plugin |
| Added | Pub | `~/debug/modifier/{name}/trajectory` | `autoware_planning_msgs/msg/Trajectory` | Debug: trajectory after each modifier plugin |
| Added | Pub | `~/debug/processing_time_detail_ms` | `autoware_utils_debug/msg/ProcessingTimeDetail` | Debug: processing-time breakdown |
| Added | Pub | `~/debug/processing_time_ms` | `autoware_internal_debug_msgs/msg/Float64Stamped` | Debug: total processing time |
| Added | Pub | `~/obstacle_stop/debug/cluster_points` | `sensor_msgs/msg/PointCloud2` | Debug (obstacle_stop plugin): clustered points |
| Added | Pub | `~/obstacle_stop/debug/marker` | `visualization_msgs/msg/MarkerArray` | Debug (obstacle_stop plugin): markers |
| Added | Pub | `~/obstacle_stop/debug/text` | `autoware_internal_debug_msgs/msg/StringStamped` | Debug (obstacle_stop plugin): status text |
| Added | Pub | `~/surround_obstacle_stop/debug/text` | `autoware_internal_debug_msgs/msg/StringStamped` | Debug (surround_obstacle_stop plugin): status text |

### ROS Parameter Changes

#### Additions and removals

| Change type | Parameter Name | Type | Default Value | Description |
|:--|:--|:--|:--|:--|
| Added | `path_planner.*` | group | — | Centerline path generation, goal connection, path shifting |
| Added | `trajectory_optimizer.*` | group | — | Elastic Band smoother plugin settings |
| Added | `velocity_smoother.*` | group | — | Jerk-filtered velocity profile constraints |
| Added | `obstacle_stop.*` | group | — | Obstacle-stop modifier plugin (objects/pointcloud, `rss_params`) |
| Added | `surround_obstacle_stop.*` | group | — | Surround-obstacle-stop modifier plugin |

## Effects on system behavior

None for existing nodes — this PR only adds a new, self-contained planner node and does not modify or remove any existing package. Behavior changes only when this node is explicitly launched.
