### PR TITLE
fix(map_based_prediction): fix use_after_free bug of `map_based_prediction` when `agnocast::Node` applied

### DIFF
--- a/perception/autoware_map_based_prediction/lib/map_based_prediction_node/callbacks.cpp
+++ b/perception/autoware_map_based_prediction/lib/map_based_prediction_node/callbacks.cpp
@@ -192,12 +192,16 @@ void ObjectsCallback::objectsCallback(
       output.objects.end(), retrieved_objects.objects.begin(), retrieved_objects.objects.end());
   }
 
+  // Capture the stamp before moving output_msg into publish(): after the move, `output` (a
+  // reference to *output_msg) dangles once publish() hands the message to the publisher, which
+  // frees/recycles it. Reading output.header.stamp afterwards is a use-after-free.
+  const auto output_stamp = output.header.stamp;
   publish(std::move(output_msg), debug_markers);
 
   const auto processing_time_ms = stop_watch_ptr_->toc("processing_time", true);
   const auto cyclic_time_ms = stop_watch_ptr_->toc("cyclic_time", true);
 
-  if (diagnostics_) diagnostics_->update(output.header.stamp, processing_time_ms, cyclic_time_ms);
+  if (diagnostics_) diagnostics_->update(output_stamp, processing_time_ms, cyclic_time_ms);
 }
 
 void ObjectsCallback::publish(

--- a/perception/autoware_map_based_prediction/lib/map_based_prediction_node/callbacks.cpp
+++ b/perception/autoware_map_based_prediction/lib/map_based_prediction_node/callbacks.cpp
@@ -192,12 +192,13 @@ void ObjectsCallback::objectsCallback(
       output.objects.end(), retrieved_objects.objects.begin(), retrieved_objects.objects.end());
   }
 
+  const auto output_stamp = output.header.stamp;
   publish(std::move(output_msg), debug_markers);
 
   const auto processing_time_ms = stop_watch_ptr_->toc("processing_time", true);
   const auto cyclic_time_ms = stop_watch_ptr_->toc("cyclic_time", true);
 
-  if (diagnostics_) diagnostics_->update(output.header.stamp, processing_time_ms, cyclic_time_ms);
+  if (diagnostics_) diagnostics_->update(output_stamp, processing_time_ms, cyclic_time_ms);
 }
 
 void ObjectsCallback::publish(


### PR DESCRIPTION
## Description
Fix to  copy `output.header.stamp` into a local before moving `output_msg`, and use that copy for `diagnostics_->update`.


### Problem
  In `objectsCallback`, `output` is a reference to `*output_msg`. `output_msg` is moved into `publish()`, which hands the message to the publisher and frees/recycles it. The subsequent `diagnostics_->update(output.header.stamp, ...)` then reads `output` through the now-dangling reference — a use-after-free. When the freed block was reused before the read, `header.stamp.sec` held garbage (often negative), so `rclcpp::Time` threw.

## Related links
The bug was introduced in https://github.com/autowarefoundation/autoware_universe/pull/12879.

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
I've confirmed that this fix solve the problem in psim test.
[TIER IV Internal Slack](https://star4.slack.com/archives/C04HK9T2E0N/p1783310607195909?thread_ts=1783283323.082639&cid=C04HK9T2E0N)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
