### PR TITLE
fix(diffusion_planner): filter neighbors by shape type and rename ignore_unknown_neighbors to ignore_polygon_neighbors

### DIFF
--- a/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
+++ b/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
@@ -24,7 +24,7 @@
         start_time_s: 2.0
     planning_frequency_hz: 10.0
     ignore_neighbors: false
-    ignore_unknown_neighbors: true
+    ignore_polygon_neighbors: true
     traffic_light_group_msg_timeout_seconds: 0.2
     batch_size: 1
     temperature: [0.0]

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/conversion/agent.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/conversion/agent.hpp
@@ -136,7 +136,7 @@ private:
  */
 struct AgentData
 {
-  void update_histories(const TrackedObjects & objects, const bool ignore_unknown_agents);
+  void update_histories(const TrackedObjects & objects, const bool ignore_polygon_agents);
 
   // Transform histories, trim to max_num_agent, and return the processed vector.
   std::vector<AgentHistory> transformed_and_trimmed_histories(

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_core.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_core.hpp
@@ -123,7 +123,7 @@ struct DiffusionPlannerParams
   bool build_only;
   double planning_frequency_hz;
   bool ignore_neighbors;
-  bool ignore_unknown_neighbors;
+  bool ignore_polygon_neighbors;
   double traffic_light_group_msg_timeout_seconds;
   int batch_size;
   std::vector<double> temperature_list;

--- a/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
+++ b/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
@@ -107,10 +107,10 @@
           "default": false,
           "description": "Ignore neighbor agents"
         },
-        "ignore_unknown_neighbors": {
+        "ignore_polygon_neighbors": {
           "type": "boolean",
           "default": true,
-          "description": "Ignore neighbor agents with unknown class"
+          "description": "Ignore neighbor agents whose shape is a polygon (shapeless, without dimensions)"
         },
         "traffic_light_group_msg_timeout_seconds": {
           "type": "number",

--- a/planning/autoware_diffusion_planner/src/conversion/agent.cpp
+++ b/planning/autoware_diffusion_planner/src/conversion/agent.cpp
@@ -19,10 +19,13 @@
 
 #include <algorithm>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace autoware::diffusion_planner
 {
+
+using autoware_perception_msgs::msg::Shape;
 
 namespace
 {
@@ -48,11 +51,39 @@ AgentLabel get_model_label(const TrackedObject & object)
   }
 }
 
-bool is_unknown_object(const TrackedObject & object)
+// The tracker output shape type reflects the object type produced by each tracker, so it is the
+// robust way (rather than the classification) to tell shapeless polygon agents apart.
+bool is_polygon_object(const TrackedObject & object)
 {
-  const auto autoware_label =
-    autoware::object_recognition_utils::getHighestProbLabel(object.classification);
-  return autoware_label == autoware_perception_msgs::msg::ObjectClassification::UNKNOWN;
+  return object.shape.type == Shape::POLYGON;
+}
+
+// Return the agent footprint as {width, length} [m], resolved per shape type because each type
+// populates the shape message differently.
+std::pair<double, double> get_width_and_length(const TrackedObject & object)
+{
+  const auto & dimensions = object.shape.dimensions;
+  switch (object.shape.type) {
+    case Shape::CYLINDER:
+      // Only the diameter (dimensions.x) is defined; use it for both axes.
+      return {dimensions.x, dimensions.x};
+    case Shape::POLYGON: {
+      // No dimensions are provided; derive the extent from the footprint polygon.
+      const auto & points = object.shape.footprint.points;
+      if (points.empty()) {
+        return {0.0, 0.0};
+      }
+      const auto [min_x, max_x] = std::minmax_element(
+        points.begin(), points.end(), [](const auto & a, const auto & b) { return a.x < b.x; });
+      const auto [min_y, max_y] = std::minmax_element(
+        points.begin(), points.end(), [](const auto & a, const auto & b) { return a.y < b.y; });
+      return {max_y->y - min_y->y, max_x->x - min_x->x};
+    }
+    case Shape::BOUNDING_BOX:
+    default:
+      // dimensions.x is length, dimensions.y is width.
+      return {dimensions.y, dimensions.x};
+  }
 }
 
 }  // namespace
@@ -74,6 +105,7 @@ AgentState::AgentState(const TrackedObject & object, const rclcpp::Time & timest
   const double velocity_norm = std::hypot(linear_vel.x, linear_vel.y);
   const double velocity_x = velocity_norm * cos_yaw;
   const double velocity_y = velocity_norm * sin_yaw;
+  const auto [width, length] = get_width_and_length(original_info);
 
   return {
     static_cast<float>(pose(0, 3)),
@@ -82,20 +114,20 @@ AgentState::AgentState(const TrackedObject & object, const rclcpp::Time & timest
     static_cast<float>(sin_yaw),
     static_cast<float>(velocity_x),
     static_cast<float>(velocity_y),
-    static_cast<float>(original_info.shape.dimensions.y),  // width
-    static_cast<float>(original_info.shape.dimensions.x),  // length
+    static_cast<float>(width),
+    static_cast<float>(length),
     static_cast<float>(label == AgentLabel::VEHICLE),
     static_cast<float>(label == AgentLabel::PEDESTRIAN),
     static_cast<float>(label == AgentLabel::BICYCLE),
   };
 }
 
-void AgentData::update_histories(const TrackedObjects & objects, const bool ignore_unknown_agents)
+void AgentData::update_histories(const TrackedObjects & objects, const bool ignore_polygon_agents)
 {
   const rclcpp::Time objects_timestamp(objects.header.stamp);
   std::vector<std::string> found_ids;
   for (const TrackedObject & object : objects.objects) {
-    if (ignore_unknown_agents && is_unknown_object(object)) {
+    if (ignore_polygon_agents && is_polygon_object(object)) {
       continue;
     }
     const std::string object_id = autoware_utils_uuid::to_hex_string(object.object_id);

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
@@ -278,7 +278,7 @@ std::optional<FrameContext> DiffusionPlannerCore::create_frame_context(
   }
 
   // Update neighbor agent data
-  agent_data_.update_histories(*effective_objects, params_.ignore_unknown_neighbors);
+  agent_data_.update_histories(*effective_objects, params_.ignore_polygon_neighbors);
   const auto processed_neighbor_histories =
     agent_data_.transformed_and_trimmed_histories(map_to_ego_transform, NEIGHBOR_SHAPE[1]);
 

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
@@ -184,8 +184,8 @@ void DiffusionPlanner::set_up_params()
   params_.build_only = this->declare_parameter<bool>("build_only", false);
   params_.planning_frequency_hz = this->declare_parameter<double>("planning_frequency_hz", 10.0);
   params_.ignore_neighbors = this->declare_parameter<bool>("ignore_neighbors", false);
-  params_.ignore_unknown_neighbors =
-    this->declare_parameter<bool>("ignore_unknown_neighbors", false);
+  params_.ignore_polygon_neighbors =
+    this->declare_parameter<bool>("ignore_polygon_neighbors", false);
   params_.traffic_light_group_msg_timeout_seconds =
     this->declare_parameter<double>("traffic_light_group_msg_timeout_seconds", 0.2);
   params_.batch_size = this->declare_parameter<int>("batch_size", 1);
@@ -298,7 +298,7 @@ SetParametersResult DiffusionPlanner::on_parameter(
     update_param<std::string>(parameters, "model.precision", temp_params.trt_precision);
     update_param<bool>(parameters, "model.use_cuda_graph", temp_params.use_cuda_graph);
     update_param<bool>(
-      parameters, "ignore_unknown_neighbors", temp_params.ignore_unknown_neighbors);
+      parameters, "ignore_polygon_neighbors", temp_params.ignore_polygon_neighbors);
     update_param<bool>(parameters, "ignore_neighbors", temp_params.ignore_neighbors);
     update_param<double>(
       parameters, "traffic_light_group_msg_timeout_seconds",

--- a/planning/autoware_diffusion_planner/test/diffusion_planner_integration_test.cpp
+++ b/planning/autoware_diffusion_planner/test/diffusion_planner_integration_test.cpp
@@ -51,7 +51,7 @@ protected:
        {"turn_indicator_onnx_model_path", "/tmp/test_turn_indicator.onnx"},
        {"args_path", "/tmp/test_args.json"},
        {"timer_period", 0.1},
-       {"ignore_unknown_neighbors", true},
+       {"ignore_polygon_neighbors", true},
        {"publish_debug_markers", false}});
 
     // Note: This will fail to initialize ONNX Runtime without a valid model


### PR DESCRIPTION
## Description

Neighbor-agent filtering in the diffusion planner previously keyed off the object **classification** (`UNKNOWN`). That is fragile: whether an agent is usable for the model actually depends on whether it has a real footprint, which is reflected by the tracker **shape type**, not by its class label.

This PR reworks the filter to be shape-based and renames the parameter accordingly.

### Changes

- **Rename** `ignore_unknown_neighbors` → `ignore_polygon_neighbors` across the param file, JSON schema, core params struct, node param declaration/`on_parameter`, and the integration test.
- **Filter by shape, not class**: replace `is_unknown_object()` (checks highest-prob label `== UNKNOWN`) with `is_polygon_object()` (checks `shape.type == POLYGON`). The tracker output shape type is the robust signal for shapeless polygon agents.
- **Per-shape width/length resolution** (`get_width_and_length()`): each shape type populates the shape message differently, so resolve `{width, length}` accordingly:
  - `BOUNDING_BOX`: `{dimensions.y, dimensions.x}`
  - `CYLINDER`: diameter (`dimensions.x`) for both axes
  - `POLYGON`: derive extent from the footprint polygon bounds (0 if empty)

### Behavior

- Agents whose shape is a polygon (shapeless, no dimensions) are ignored when the flag is enabled, instead of only those classified `UNKNOWN`.
- Cylinder/polygon agents that are kept now get sensible width/length instead of raw (possibly zero) bounding-box dimensions.

## Tests performed

- Existing integration test updated to the new parameter name.

## Notes

Draft: parameter rename is API-visible — downstream launch/config referencing `ignore_unknown_neighbors` must be updated.
