### PR TITLE
feat(control_evaluator): apply `agnocast_wrapper::Node` to `control_evaluator`

### DIFF
--- a/evaluator/autoware_control_evaluator/CMakeLists.txt
+++ b/evaluator/autoware_control_evaluator/CMakeLists.txt
@@ -10,9 +10,11 @@ ament_auto_add_library(control_evaluator_node SHARED
   DIRECTORY src
 )
 
-rclcpp_components_register_node(control_evaluator_node
+autoware_agnocast_wrapper_register_node(control_evaluator_node
   PLUGIN "control_diagnostics::ControlEvaluatorNode"
   EXECUTABLE control_evaluator
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
+  ROS2_EXECUTOR SingleThreadedExecutor
 )
 
 if(BUILD_TESTING)

--- a/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/control_evaluator_node.hpp
+++ b/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/control_evaluator_node.hpp
@@ -19,9 +19,9 @@
 #include "autoware/control_evaluator/metrics/metric.hpp"
 #include "autoware_utils/math/accumulator.hpp"
 
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <autoware/route_handler/route_handler.hpp>
 #include <autoware_utils/geometry/boost_geometry.hpp>
-#include <autoware_utils/ros/polling_subscriber.hpp>
 #include <autoware_utils/system/stop_watch.hpp>
 #include <autoware_utils_math/accumulator.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
@@ -72,7 +72,7 @@ using autoware_internal_planning_msgs::msg::PlanningFactorArray;
 /**
  * @brief Node for control evaluation
  */
-class ControlEvaluatorNode : public rclcpp::Node
+class ControlEvaluatorNode : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit ControlEvaluatorNode(const rclcpp::NodeOptions & node_options);
@@ -98,35 +98,31 @@ public:
   void onTimer();
 
 private:
-  autoware_utils::InterProcessPollingSubscriber<Odometry> odometry_sub_{this, "~/input/odometry"};
-  autoware_utils::InterProcessPollingSubscriber<AccelWithCovarianceStamped> accel_sub_{
-    this, "~/input/acceleration"};
-  autoware_utils::InterProcessPollingSubscriber<Trajectory> traj_sub_{this, "~/input/trajectory"};
-  autoware_utils::InterProcessPollingSubscriber<
-    LaneletRoute, autoware_utils::polling_policy::Newest>
-    route_subscriber_{this, "~/input/route", rclcpp::QoS{1}.transient_local()};
-  autoware_utils::InterProcessPollingSubscriber<
-    LaneletMapBin, autoware_utils::polling_policy::Newest>
-    vector_map_subscriber_{this, "~/input/vector_map", rclcpp::QoS{1}.transient_local()};
-  autoware_utils::InterProcessPollingSubscriber<PathWithLaneId> behavior_path_subscriber_{
-    this, "~/input/behavior_path"};
-  autoware_utils::InterProcessPollingSubscriber<SteeringReport> steering_sub_{
-    this, "~/input/steering_status"};
-  autoware_utils::InterProcessPollingSubscriber<PredictedObjects> objects_sub_{
-    this, "~/input/objects"};
-  std::unordered_map<
-    std::string, autoware_utils::InterProcessPollingSubscriber<PlanningFactorArray>>
+  AUTOWARE_POLLING_SUBSCRIBER_PTR(Odometry) odometry_sub_;
+  AUTOWARE_POLLING_SUBSCRIBER_PTR(AccelWithCovarianceStamped) accel_sub_;
+  AUTOWARE_POLLING_SUBSCRIBER_PTR(Trajectory) traj_sub_;
+  AUTOWARE_POLLING_SUBSCRIBER_PTR(LaneletRoute) route_subscriber_;
+  AUTOWARE_POLLING_SUBSCRIBER_PTR(LaneletMapBin) vector_map_subscriber_;
+  AUTOWARE_POLLING_SUBSCRIBER_PTR(PathWithLaneId) behavior_path_subscriber_;
+  AUTOWARE_POLLING_SUBSCRIBER_PTR(SteeringReport) steering_sub_;
+  AUTOWARE_POLLING_SUBSCRIBER_PTR(PredictedObjects) objects_sub_;
+  std::unordered_map<std::string, AUTOWARE_POLLING_SUBSCRIBER_PTR(PlanningFactorArray)>
     planning_factors_sub_;
   std::unordered_map<std::string, Accumulator<double>> stop_deviation_accumulators_;
   std::unordered_map<std::string, Accumulator<double>> stop_deviation_abs_accumulators_;
   std::unordered_set<std::string> stop_deviation_modules_;
 
-  rclcpp::Publisher<autoware_internal_debug_msgs::msg::Float64Stamped>::SharedPtr
-    processing_time_pub_;
-  rclcpp::Publisher<MetricArrayMsg>::SharedPtr metrics_pub_;
+  AUTOWARE_PUBLISHER_PTR(autoware_internal_debug_msgs::msg::Float64Stamped) processing_time_pub_;
+  AUTOWARE_PUBLISHER_PTR(MetricArrayMsg) metrics_pub_;
 
   // update Route Handler
   void getRouteData();
+  // Last applied stamps for the latched route/map polling subscribers. The agnocast wrapper's
+  // polling subscriber only offers the "Latest" policy (re-returns the cached message every call),
+  // whereas the original code used the "Newest" policy (apply once per new message). Guarding on
+  // these stamps reproduces the apply-once behavior and avoids re-processing the same map/route.
+  std::optional<rclcpp::Time> last_applied_route_stamp_{std::nullopt};
+  std::optional<rclcpp::Time> last_applied_map_stamp_{std::nullopt};
 
   // Parameters
   bool output_metrics_;
@@ -173,7 +169,7 @@ private:
   MetricArrayMsg metrics_msg_;
   VehicleInfo vehicle_info_;
   autoware::route_handler::RouteHandler route_handler_;
-  rclcpp::TimerBase::SharedPtr timer_;
+  AUTOWARE_TIMER_PTR timer_;
   std::optional<AccelWithCovarianceStamped> prev_acc_stamped_{std::nullopt};
   std::optional<double> prev_steering_angle_{std::nullopt};
   std::optional<double> prev_steering_rate_{std::nullopt};

--- a/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/control_evaluator_node.hpp
+++ b/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/control_evaluator_node.hpp
@@ -101,8 +101,10 @@ private:
   AUTOWARE_POLLING_SUBSCRIBER_PTR(Odometry) odometry_sub_;
   AUTOWARE_POLLING_SUBSCRIBER_PTR(AccelWithCovarianceStamped) accel_sub_;
   AUTOWARE_POLLING_SUBSCRIBER_PTR(Trajectory) traj_sub_;
-  AUTOWARE_POLLING_SUBSCRIBER_PTR(LaneletRoute) route_subscriber_;
-  AUTOWARE_POLLING_SUBSCRIBER_PTR(LaneletMapBin) vector_map_subscriber_;
+  AUTOWARE_POLLING_SUBSCRIBER_PTR(LaneletRoute, autoware::agnocast_wrapper::polling_policy::Newest)
+  route_subscriber_;
+  AUTOWARE_POLLING_SUBSCRIBER_PTR(LaneletMapBin, autoware::agnocast_wrapper::polling_policy::Newest)
+  vector_map_subscriber_;
   AUTOWARE_POLLING_SUBSCRIBER_PTR(PathWithLaneId) behavior_path_subscriber_;
   AUTOWARE_POLLING_SUBSCRIBER_PTR(SteeringReport) steering_sub_;
   AUTOWARE_POLLING_SUBSCRIBER_PTR(PredictedObjects) objects_sub_;
@@ -117,12 +119,6 @@ private:
 
   // update Route Handler
   void getRouteData();
-  // Last applied stamps for the latched route/map polling subscribers. The agnocast wrapper's
-  // polling subscriber only offers the "Latest" policy (re-returns the cached message every call),
-  // whereas the original code used the "Newest" policy (apply once per new message). Guarding on
-  // these stamps reproduces the apply-once behavior and avoids re-processing the same map/route.
-  std::optional<rclcpp::Time> last_applied_route_stamp_{std::nullopt};
-  std::optional<rclcpp::Time> last_applied_map_stamp_{std::nullopt};
 
   // Parameters
   bool output_metrics_;

--- a/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/control_evaluator_node.hpp
+++ b/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/control_evaluator_node.hpp
@@ -98,12 +98,12 @@ public:
   void onTimer();
 
 private:
-  AUTOWARE_POLLING_SUBSCRIBER_PTR(Odometry) odometry_sub_ =
-    create_polling_subscriber<Odometry>("~/input/odometry");
-  AUTOWARE_POLLING_SUBSCRIBER_PTR(AccelWithCovarianceStamped) accel_sub_ =
-    create_polling_subscriber<AccelWithCovarianceStamped>("~/input/acceleration");
-  AUTOWARE_POLLING_SUBSCRIBER_PTR(Trajectory) traj_sub_ =
-    create_polling_subscriber<Trajectory>("~/input/trajectory");
+  AUTOWARE_POLLING_SUBSCRIBER_PTR(Odometry)
+  odometry_sub_ = create_polling_subscriber<Odometry>("~/input/odometry");
+  AUTOWARE_POLLING_SUBSCRIBER_PTR(AccelWithCovarianceStamped)
+  accel_sub_ = create_polling_subscriber<AccelWithCovarianceStamped>("~/input/acceleration");
+  AUTOWARE_POLLING_SUBSCRIBER_PTR(Trajectory)
+  traj_sub_ = create_polling_subscriber<Trajectory>("~/input/trajectory");
   AUTOWARE_POLLING_SUBSCRIBER_PTR(LaneletRoute, autoware::agnocast_wrapper::polling_policy::Newest)
   route_subscriber_ =
     create_polling_subscriber<LaneletRoute, autoware::agnocast_wrapper::polling_policy::Newest>(
@@ -112,12 +112,12 @@ private:
   vector_map_subscriber_ =
     create_polling_subscriber<LaneletMapBin, autoware::agnocast_wrapper::polling_policy::Newest>(
       "~/input/vector_map", rclcpp::QoS{1}.transient_local());
-  AUTOWARE_POLLING_SUBSCRIBER_PTR(PathWithLaneId) behavior_path_subscriber_ =
-    create_polling_subscriber<PathWithLaneId>("~/input/behavior_path");
-  AUTOWARE_POLLING_SUBSCRIBER_PTR(SteeringReport) steering_sub_ =
-    create_polling_subscriber<SteeringReport>("~/input/steering_status");
-  AUTOWARE_POLLING_SUBSCRIBER_PTR(PredictedObjects) objects_sub_ =
-    create_polling_subscriber<PredictedObjects>("~/input/objects");
+  AUTOWARE_POLLING_SUBSCRIBER_PTR(PathWithLaneId)
+  behavior_path_subscriber_ = create_polling_subscriber<PathWithLaneId>("~/input/behavior_path");
+  AUTOWARE_POLLING_SUBSCRIBER_PTR(SteeringReport)
+  steering_sub_ = create_polling_subscriber<SteeringReport>("~/input/steering_status");
+  AUTOWARE_POLLING_SUBSCRIBER_PTR(PredictedObjects)
+  objects_sub_ = create_polling_subscriber<PredictedObjects>("~/input/objects");
   std::unordered_map<std::string, AUTOWARE_POLLING_SUBSCRIBER_PTR(PlanningFactorArray)>
     planning_factors_sub_;
   std::unordered_map<std::string, Accumulator<double>> stop_deviation_accumulators_;

--- a/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/control_evaluator_node.hpp
+++ b/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/control_evaluator_node.hpp
@@ -98,16 +98,26 @@ public:
   void onTimer();
 
 private:
-  AUTOWARE_POLLING_SUBSCRIBER_PTR(Odometry) odometry_sub_;
-  AUTOWARE_POLLING_SUBSCRIBER_PTR(AccelWithCovarianceStamped) accel_sub_;
-  AUTOWARE_POLLING_SUBSCRIBER_PTR(Trajectory) traj_sub_;
+  AUTOWARE_POLLING_SUBSCRIBER_PTR(Odometry) odometry_sub_ =
+    create_polling_subscriber<Odometry>("~/input/odometry");
+  AUTOWARE_POLLING_SUBSCRIBER_PTR(AccelWithCovarianceStamped) accel_sub_ =
+    create_polling_subscriber<AccelWithCovarianceStamped>("~/input/acceleration");
+  AUTOWARE_POLLING_SUBSCRIBER_PTR(Trajectory) traj_sub_ =
+    create_polling_subscriber<Trajectory>("~/input/trajectory");
   AUTOWARE_POLLING_SUBSCRIBER_PTR(LaneletRoute, autoware::agnocast_wrapper::polling_policy::Newest)
-  route_subscriber_;
+  route_subscriber_ =
+    create_polling_subscriber<LaneletRoute, autoware::agnocast_wrapper::polling_policy::Newest>(
+      "~/input/route", rclcpp::QoS{1}.transient_local());
   AUTOWARE_POLLING_SUBSCRIBER_PTR(LaneletMapBin, autoware::agnocast_wrapper::polling_policy::Newest)
-  vector_map_subscriber_;
-  AUTOWARE_POLLING_SUBSCRIBER_PTR(PathWithLaneId) behavior_path_subscriber_;
-  AUTOWARE_POLLING_SUBSCRIBER_PTR(SteeringReport) steering_sub_;
-  AUTOWARE_POLLING_SUBSCRIBER_PTR(PredictedObjects) objects_sub_;
+  vector_map_subscriber_ =
+    create_polling_subscriber<LaneletMapBin, autoware::agnocast_wrapper::polling_policy::Newest>(
+      "~/input/vector_map", rclcpp::QoS{1}.transient_local());
+  AUTOWARE_POLLING_SUBSCRIBER_PTR(PathWithLaneId) behavior_path_subscriber_ =
+    create_polling_subscriber<PathWithLaneId>("~/input/behavior_path");
+  AUTOWARE_POLLING_SUBSCRIBER_PTR(SteeringReport) steering_sub_ =
+    create_polling_subscriber<SteeringReport>("~/input/steering_status");
+  AUTOWARE_POLLING_SUBSCRIBER_PTR(PredictedObjects) objects_sub_ =
+    create_polling_subscriber<PredictedObjects>("~/input/objects");
   std::unordered_map<std::string, AUTOWARE_POLLING_SUBSCRIBER_PTR(PlanningFactorArray)>
     planning_factors_sub_;
   std::unordered_map<std::string, Accumulator<double>> stop_deviation_accumulators_;

--- a/evaluator/autoware_control_evaluator/launch/control_evaluator.launch.xml
+++ b/evaluator/autoware_control_evaluator/launch/control_evaluator.launch.xml
@@ -9,9 +9,12 @@
   <arg name="input/steering_status" default="/vehicle/status/steering_status"/>
   <arg name="input/objects" default="/perception/object_recognition/objects"/>
 
+  <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
+
   <!-- control evaluator -->
   <group>
     <node name="control_evaluator" exec="control_evaluator" pkg="autoware_control_evaluator">
+      <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
       <param from="$(find-pkg-share autoware_control_evaluator)/config/control_evaluator.param.yaml"/>
       <param name="output_metrics" value="$(var output_metrics)"/>
       <remap from="~/input/odometry" to="$(var input/odometry)"/>

--- a/evaluator/autoware_control_evaluator/package.xml
+++ b/evaluator/autoware_control_evaluator/package.xml
@@ -16,6 +16,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_deprecated_boundary_departure_checker</depend>
   <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_lanelet2_utils</depend>

--- a/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
+++ b/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
@@ -82,6 +82,21 @@ ControlEvaluatorNode::ControlEvaluatorNode(const rclcpp::NodeOptions & node_opti
 {
   using std::placeholders::_1;
 
+  // Polling subscribers
+  odometry_sub_ = this->create_polling_subscriber<Odometry>("~/input/odometry", rclcpp::QoS{1});
+  accel_sub_ = this->create_polling_subscriber<AccelWithCovarianceStamped>(
+    "~/input/acceleration", rclcpp::QoS{1});
+  traj_sub_ = this->create_polling_subscriber<Trajectory>("~/input/trajectory", rclcpp::QoS{1});
+  route_subscriber_ = this->create_polling_subscriber<LaneletRoute>(
+    "~/input/route", rclcpp::QoS{1}.transient_local());
+  vector_map_subscriber_ = this->create_polling_subscriber<LaneletMapBin>(
+    "~/input/vector_map", rclcpp::QoS{1}.transient_local());
+  behavior_path_subscriber_ =
+    this->create_polling_subscriber<PathWithLaneId>("~/input/behavior_path", rclcpp::QoS{1});
+  steering_sub_ =
+    this->create_polling_subscriber<SteeringReport>("~/input/steering_status", rclcpp::QoS{1});
+  objects_sub_ = this->create_polling_subscriber<PredictedObjects>("~/input/objects", rclcpp::QoS{1});
+
   // planning_factor subscribers
   std::vector<std::string> stop_deviation_modules_list =
     declare_parameter<std::vector<std::string>>(
@@ -93,8 +108,8 @@ ControlEvaluatorNode::ControlEvaluatorNode(const rclcpp::NodeOptions & node_opti
     declare_parameter<std::string>("planning_factor_metrics.topic_prefix");
   for (const auto & module_name : stop_deviation_modules_) {
     planning_factors_sub_.emplace(
-      module_name, autoware_utils::InterProcessPollingSubscriber<PlanningFactorArray>(
-                     this, topic_prefix + module_name));
+      module_name, this->create_polling_subscriber<PlanningFactorArray>(
+                     topic_prefix + module_name, rclcpp::QoS{1}));
     stop_deviation_accumulators_.emplace(module_name, Accumulator<double>());
     stop_deviation_abs_accumulators_.emplace(module_name, Accumulator<double>());
   }
@@ -142,8 +157,8 @@ ControlEvaluatorNode::ControlEvaluatorNode(const rclcpp::NodeOptions & node_opti
 
   // Timer callback to publish evaluator diagnostics
   using namespace std::literals::chrono_literals;
-  timer_ =
-    rclcpp::create_timer(this, get_clock(), 100ms, std::bind(&ControlEvaluatorNode::onTimer, this));
+  timer_ = autoware::agnocast_wrapper::create_timer(
+    this, get_clock(), 100ms, std::bind(&ControlEvaluatorNode::onTimer, this));
 }
 
 ControlEvaluatorNode::~ControlEvaluatorNode()
@@ -231,21 +246,25 @@ void ControlEvaluatorNode::getRouteData()
 {
   // route
   {
-    const auto msg = route_subscriber_.take_data();
-    if (msg) {
+    const auto msg = route_subscriber_->take_data();
+    // Apply only when a newer message arrives (the wrapper's polling subscriber re-returns the
+    // cached latched message every call; guard on the stamp to preserve apply-once semantics).
+    if (msg && last_applied_route_stamp_ != rclcpp::Time(msg->header.stamp)) {
       if (msg->segments.empty()) {
         RCLCPP_ERROR(get_logger(), "input route is empty. ignored");
       } else {
         route_handler_.setRoute(*msg);
+        last_applied_route_stamp_ = rclcpp::Time(msg->header.stamp);
       }
     }
   }
 
   // map
   {
-    const auto msg = vector_map_subscriber_.take_data();
-    if (msg) {
+    const auto msg = vector_map_subscriber_->take_data();
+    if (msg && last_applied_map_stamp_ != rclcpp::Time(msg->header.stamp)) {
       route_handler_.setMap(*msg);
+      last_applied_map_stamp_ = rclcpp::Time(msg->header.stamp);
     }
   }
 }
@@ -545,7 +564,7 @@ void ControlEvaluatorNode::AddGoalDeviationMetricMsg(const Odometry & odom)
 void ControlEvaluatorNode::AddStopDeviationMetricMsg()
 {
   const auto get_min_distance_signed =
-    [](const PlanningFactorArray::ConstSharedPtr & planning_factors) -> std::optional<double> {
+    [](const auto & planning_factors) -> std::optional<double> {
     std::optional<double> min_distance = std::nullopt;
     for (const auto & factor : planning_factors->factors) {
       if (factor.behavior == PlanningFactor::STOP) {
@@ -563,7 +582,7 @@ void ControlEvaluatorNode::AddStopDeviationMetricMsg()
   // get min_distance from each module
   std::vector<std::pair<std::string, double>> min_distances;
   for (auto & [module_name, planning_factor_sub_] : planning_factors_sub_) {
-    const auto planning_factors = planning_factor_sub_.take_data();
+    const auto planning_factors = planning_factor_sub_->take_data();
     if (
       !planning_factors || planning_factors->factors.empty() ||
       stop_deviation_modules_.count(module_name) == 0) {
@@ -663,7 +682,7 @@ void ControlEvaluatorNode::onTimer()
 {
   autoware_utils::StopWatch<std::chrono::milliseconds> stop_watch;
 
-  const auto odom = odometry_sub_.take_data();
+  const auto odom = odometry_sub_->take_data();
   if (odom) {
     const Pose ego_pose = odom->pose.pose;
     ego_speed_ = std::abs(odom->twist.twist.linear.x);
@@ -672,19 +691,19 @@ void ControlEvaluatorNode::onTimer()
     AddStopDeviationMetricMsg();
 
     // add object related metrics
-    const auto objects = objects_sub_.take_data();
+    const auto objects = objects_sub_->take_data();
     if (objects) {
       AddObjectMetricMsg(*odom, *objects);
     }
 
     // add kinematic info
-    const auto acc = accel_sub_.take_data();
+    const auto acc = accel_sub_->take_data();
     if (acc) {
       AddKinematicStateMetricMsg(*odom, *acc);
     }
 
     // add deviation metrics
-    const auto traj = traj_sub_.take_data();
+    const auto traj = traj_sub_->take_data();
     if (traj && !traj->points.empty()) {
       AddLateralDeviationMetricMsg(*traj, ego_pose.position);
       AddYawDeviationMetricMsg(*traj, ego_pose);
@@ -699,7 +718,7 @@ void ControlEvaluatorNode::onTimer()
       AddGoalDeviationMetricMsg(*odom);
 
       // add boundary distance metrics
-      const auto behavior_path = behavior_path_subscriber_.take_data();
+      const auto behavior_path = behavior_path_subscriber_->take_data();
       if (behavior_path) {
         AddBoundaryDistanceMetricMsg(*behavior_path, ego_pose);
       }
@@ -708,21 +727,23 @@ void ControlEvaluatorNode::onTimer()
   }
 
   // add steering metrics
-  const auto steering_status = steering_sub_.take_data();
+  const auto steering_status = steering_sub_->take_data();
   if (steering_status) {
     AddSteeringMetricMsg(*steering_status);
   }
 
-  // Publish metrics
-  metrics_msg_.stamp = now();
-  metrics_pub_->publish(metrics_msg_);
+  // Publish metrics (zero-copy: borrow the output buffer, move the accumulated array into it)
+  auto metrics_out = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(metrics_pub_);
+  *metrics_out = std::move(metrics_msg_);
+  metrics_out->stamp = now();
+  metrics_pub_->publish(std::move(metrics_out));
   metrics_msg_ = MetricArrayMsg{};
 
   // Publish processing time
-  autoware_internal_debug_msgs::msg::Float64Stamped processing_time_msg;
-  processing_time_msg.stamp = get_clock()->now();
-  processing_time_msg.data = stop_watch.toc();
-  processing_time_pub_->publish(processing_time_msg);
+  auto processing_time_msg = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(processing_time_pub_);
+  processing_time_msg->stamp = get_clock()->now();
+  processing_time_msg->data = stop_watch.toc();
+  processing_time_pub_->publish(std::move(processing_time_msg));
 }
 }  // namespace control_diagnostics
 

--- a/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
+++ b/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
@@ -93,7 +93,8 @@ ControlEvaluatorNode::ControlEvaluatorNode(const rclcpp::NodeOptions & node_opti
     declare_parameter<std::string>("planning_factor_metrics.topic_prefix");
   for (const auto & module_name : stop_deviation_modules_) {
     planning_factors_sub_.emplace(
-      module_name, this->create_polling_subscriber<PlanningFactorArray>(topic_prefix + module_name));
+      module_name,
+      this->create_polling_subscriber<PlanningFactorArray>(topic_prefix + module_name));
     stop_deviation_accumulators_.emplace(module_name, Accumulator<double>());
     stop_deviation_abs_accumulators_.emplace(module_name, Accumulator<double>());
   }

--- a/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
+++ b/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
@@ -41,7 +41,6 @@
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
-#include <utility>
 #include <vector>
 
 namespace control_diagnostics
@@ -83,23 +82,6 @@ ControlEvaluatorNode::ControlEvaluatorNode(const rclcpp::NodeOptions & node_opti
 {
   using std::placeholders::_1;
 
-  // Polling subscribers
-  odometry_sub_ = this->create_polling_subscriber<Odometry>("~/input/odometry", rclcpp::QoS{1});
-  accel_sub_ = this->create_polling_subscriber<AccelWithCovarianceStamped>(
-    "~/input/acceleration", rclcpp::QoS{1});
-  traj_sub_ = this->create_polling_subscriber<Trajectory>("~/input/trajectory", rclcpp::QoS{1});
-  namespace polling_policy = autoware::agnocast_wrapper::polling_policy;
-  route_subscriber_ = this->create_polling_subscriber<LaneletRoute, polling_policy::Newest>(
-    "~/input/route", rclcpp::QoS{1}.transient_local());
-  vector_map_subscriber_ = this->create_polling_subscriber<LaneletMapBin, polling_policy::Newest>(
-    "~/input/vector_map", rclcpp::QoS{1}.transient_local());
-  behavior_path_subscriber_ =
-    this->create_polling_subscriber<PathWithLaneId>("~/input/behavior_path", rclcpp::QoS{1});
-  steering_sub_ =
-    this->create_polling_subscriber<SteeringReport>("~/input/steering_status", rclcpp::QoS{1});
-  objects_sub_ =
-    this->create_polling_subscriber<PredictedObjects>("~/input/objects", rclcpp::QoS{1});
-
   // planning_factor subscribers
   std::vector<std::string> stop_deviation_modules_list =
     declare_parameter<std::vector<std::string>>(
@@ -111,8 +93,7 @@ ControlEvaluatorNode::ControlEvaluatorNode(const rclcpp::NodeOptions & node_opti
     declare_parameter<std::string>("planning_factor_metrics.topic_prefix");
   for (const auto & module_name : stop_deviation_modules_) {
     planning_factors_sub_.emplace(
-      module_name, this->create_polling_subscriber<PlanningFactorArray>(
-                     topic_prefix + module_name, rclcpp::QoS{1}));
+      module_name, this->create_polling_subscriber<PlanningFactorArray>(topic_prefix + module_name));
     stop_deviation_accumulators_.emplace(module_name, Accumulator<double>());
     stop_deviation_abs_accumulators_.emplace(module_name, Accumulator<double>());
   }
@@ -730,18 +711,16 @@ void ControlEvaluatorNode::onTimer()
     AddSteeringMetricMsg(*steering_status);
   }
 
-  // Publish metrics (zero-copy: borrow the output buffer, move the accumulated array into it)
-  auto metrics_out = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(metrics_pub_);
-  *metrics_out = std::move(metrics_msg_);
-  metrics_out->stamp = now();
-  metrics_pub_->publish(std::move(metrics_out));
+  // Publish metrics
+  metrics_msg_.stamp = now();
+  metrics_pub_->publish(metrics_msg_);
   metrics_msg_ = MetricArrayMsg{};
 
   // Publish processing time
-  auto processing_time_msg = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(processing_time_pub_);
-  processing_time_msg->stamp = get_clock()->now();
-  processing_time_msg->data = stop_watch.toc();
-  processing_time_pub_->publish(std::move(processing_time_msg));
+  autoware_internal_debug_msgs::msg::Float64Stamped processing_time_msg;
+  processing_time_msg.stamp = get_clock()->now();
+  processing_time_msg.data = stop_watch.toc();
+  processing_time_pub_->publish(processing_time_msg);
 }
 }  // namespace control_diagnostics
 

--- a/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
+++ b/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
@@ -41,6 +41,7 @@
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 namespace control_diagnostics
@@ -87,15 +88,17 @@ ControlEvaluatorNode::ControlEvaluatorNode(const rclcpp::NodeOptions & node_opti
   accel_sub_ = this->create_polling_subscriber<AccelWithCovarianceStamped>(
     "~/input/acceleration", rclcpp::QoS{1});
   traj_sub_ = this->create_polling_subscriber<Trajectory>("~/input/trajectory", rclcpp::QoS{1});
-  route_subscriber_ = this->create_polling_subscriber<LaneletRoute>(
+  namespace polling_policy = autoware::agnocast_wrapper::polling_policy;
+  route_subscriber_ = this->create_polling_subscriber<LaneletRoute, polling_policy::Newest>(
     "~/input/route", rclcpp::QoS{1}.transient_local());
-  vector_map_subscriber_ = this->create_polling_subscriber<LaneletMapBin>(
+  vector_map_subscriber_ = this->create_polling_subscriber<LaneletMapBin, polling_policy::Newest>(
     "~/input/vector_map", rclcpp::QoS{1}.transient_local());
   behavior_path_subscriber_ =
     this->create_polling_subscriber<PathWithLaneId>("~/input/behavior_path", rclcpp::QoS{1});
   steering_sub_ =
     this->create_polling_subscriber<SteeringReport>("~/input/steering_status", rclcpp::QoS{1});
-  objects_sub_ = this->create_polling_subscriber<PredictedObjects>("~/input/objects", rclcpp::QoS{1});
+  objects_sub_ =
+    this->create_polling_subscriber<PredictedObjects>("~/input/objects", rclcpp::QoS{1});
 
   // planning_factor subscribers
   std::vector<std::string> stop_deviation_modules_list =
@@ -247,14 +250,11 @@ void ControlEvaluatorNode::getRouteData()
   // route
   {
     const auto msg = route_subscriber_->take_data();
-    // Apply only when a newer message arrives (the wrapper's polling subscriber re-returns the
-    // cached latched message every call; guard on the stamp to preserve apply-once semantics).
-    if (msg && last_applied_route_stamp_ != rclcpp::Time(msg->header.stamp)) {
+    if (msg) {
       if (msg->segments.empty()) {
         RCLCPP_ERROR(get_logger(), "input route is empty. ignored");
       } else {
         route_handler_.setRoute(*msg);
-        last_applied_route_stamp_ = rclcpp::Time(msg->header.stamp);
       }
     }
   }
@@ -262,9 +262,8 @@ void ControlEvaluatorNode::getRouteData()
   // map
   {
     const auto msg = vector_map_subscriber_->take_data();
-    if (msg && last_applied_map_stamp_ != rclcpp::Time(msg->header.stamp)) {
+    if (msg) {
       route_handler_.setMap(*msg);
-      last_applied_map_stamp_ = rclcpp::Time(msg->header.stamp);
     }
   }
 }
@@ -563,8 +562,7 @@ void ControlEvaluatorNode::AddGoalDeviationMetricMsg(const Odometry & odom)
 
 void ControlEvaluatorNode::AddStopDeviationMetricMsg()
 {
-  const auto get_min_distance_signed =
-    [](const auto & planning_factors) -> std::optional<double> {
+  const auto get_min_distance_signed = [](const auto & planning_factors) -> std::optional<double> {
     std::optional<double> min_distance = std::nullopt;
     for (const auto & factor : planning_factors->factors) {
       if (factor.behavior == PlanningFactor::STOP) {

--- a/evaluator/autoware_control_evaluator/test/test_control_evaluator_node.cpp
+++ b/evaluator/autoware_control_evaluator/test/test_control_evaluator_node.cpp
@@ -236,7 +236,7 @@ protected:
 
   void spin_some()
   {
-    rclcpp::spin_some(eval_node);
+    rclcpp::spin_some(eval_node->get_node_base_interface());
     rclcpp::spin_some(dummy_node);
     rclcpp::sleep_for(std::chrono::milliseconds(100));
   }

--- a/evaluator/autoware_control_evaluator/test/test_control_evaluator_node.cpp
+++ b/evaluator/autoware_control_evaluator/test/test_control_evaluator_node.cpp
@@ -57,6 +57,11 @@ class EvalTest : public ::testing::Test
 protected:
   void SetUp() override
   {
+    const auto * const enable_agnocast = std::getenv("ENABLE_AGNOCAST");
+    if (enable_agnocast != nullptr && std::string(enable_agnocast) == "1") {
+      GTEST_SKIP() << "This test launches a node and is skipped under ENABLE_AGNOCAST=1";
+    }
+
     rclcpp::init(0, nullptr);
 
     rclcpp::NodeOptions options;


### PR DESCRIPTION
## Description
Apply `agnocast_wrapper::Node` to `autoware_control_evaluator`.
Please read https://github.com/autowarefoundation/autoware/issues/7007 for the context and review guidelines of `autoware_agnocast_wrapper` adoption. 
Also, please refer to https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/docs/review_guide.md for the review guide of `autoware_agnocast_wrapper` application PR. FYI: This node take [Method2](https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/docs/review_guide.md#method-2-agnocast_wrappernode-inheritance) of two integrations methods.

**AgnocastOnlyCallbackIsolatedExecutor:**
When built and run with `ENABLE_AGNOCAST=1`, the node runs on a `AgnocastOnlyCallbackIsolatedExecutor` (CIE), the standard executor for `agnocast_wrapper::Node`. Please check for potential race conditions only if the node meets **all** of the following:

1. It was originally running on a `SingleThreadedExecutor`.
2. It has multiple callback groups (the default is one).
3. Shared variables are accessed across those callback groups without mutex protection.

**Nodes already running on `MultiThreadedExecutor` are unaffected**, since their callbacks already run concurrently.

## Related Links

  - https://github.com/autowarefoundation/autoware/issues/7007
  - https://github.com/orgs/autowarefoundation/discussions/6804

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
  - Build: `colcon build` succeeds with both `ENABLE_AGNOCAST=1` and `ENABLE_AGNOCAST=0`.
  - Unit tests: 9/9 pass with `ENABLE_AGNOCAST=0`; all 9 are skipped when `ENABLE_AGNOCAST=1` (node-launching tests, per the `autoware_agnocast_wrapper` unit-test policy). The test logic is unchanged.
  - LSim/PSim (sample rosbag): Runs to completion under both `ENABLE_AGNOCAST=0` and `ENABLE_AGNOCAST=1`, with no `process died` or similar failures.
  - Standalone launch: Confirmed the target node is launched as a standalone node (not inside a component container), since `agnocast::Node` does not currently work inside a component container — this is required for correct operation, not merely a convention.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior
None when ENABLE_AGNOCAST is not set or set to 0 on runtime. When ENABLE_AGNOCAST=1, CPU Time used in this node for message serialization/deserialization will be reduced.