### PR TITLE
refactor(autoware_traffic_light_classifier): extract a Node-free CNNClassifierCore

### DIFF
--- a/perception/autoware_traffic_light_classifier/CMakeLists.txt
+++ b/perception/autoware_traffic_light_classifier/CMakeLists.txt
@@ -169,10 +169,21 @@ if(BUILD_TESTING)
     ${OpenCV_LIBRARIES}
   )
 
-  # GPU/TensorRT characterization test for CNNClassifier (only compiled under
-  # TRT+CUDA, hence the gate). It builds a node, so it uses the ROS-isolated runner;
-  # TIMEOUT covers the first-time TensorRT engine build.
+  # Tests that depend on TensorRT/CUDA code, built only when those libraries are available.
   if(TRT_AVAIL AND CUDA_AVAIL)
+    # ROS-free unit tests for CNNClassifierCore's static helpers (label decode +
+    # debug-image geometry) -- no GPU needed at run time, unlike test_cnn_classifier.
+    ament_auto_add_gtest(test_cnn_classifier_core
+      test/test_cnn_classifier_core.cpp
+    )
+    target_link_libraries(test_cnn_classifier_core
+      ${PROJECT_NAME}
+      ${OpenCV_LIBRARIES}
+      ${CUDA_LIBRARIES}
+    )
+
+    # GPU/TensorRT characterization test for CNNClassifier. It builds a node, so it uses
+    # the ROS-isolated runner; TIMEOUT covers the first-time TensorRT engine build.
     ament_add_ros_isolated_gtest(test_cnn_classifier
       test/test_cnn_classifier.cpp
       TIMEOUT 600

--- a/perception/autoware_traffic_light_classifier/src/classifier/cnn_classifier.cpp
+++ b/perception/autoware_traffic_light_classifier/src/classifier/cnn_classifier.cpp
@@ -16,45 +16,193 @@
 
 #include "../traffic_light_classifier_process.hpp"
 
-#include <ament_index_cpp/get_package_share_directory.hpp>
+#include <opencv2/imgproc.hpp>
 
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
 
 #include <algorithm>
+#include <fstream>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
 namespace autoware::traffic_light
 {
-CNNClassifier::CNNClassifier(rclcpp::Node * node_ptr) : node_ptr_(node_ptr)
+// ============================= CNNClassifierCore =============================
+// Node-free CNN (TensorRT) classification core.
+
+CNNClassifierCore::CNNClassifierCore(const CNNConfig & config)
+{
+  if (config.mean.size() != 3 || config.std.size() != 3) {
+    throw std::invalid_argument("mean and std must be of size 3");
+  }
+  labels_ = config.labels;
+  classifier_ = std::make_unique<autoware::tensorrt_classifier::TrtClassifier>(
+    config.model_path, config.precision, config.mean, config.std);
+  batch_size_ = classifier_->getBatchSize();
+}
+
+CNNClassifierCore::ClassifierResult CNNClassifierCore::classify(const std::vector<cv::Mat> & images)
+{
+  ClassifierResult result;
+  result.signals.signals.resize(images.size());
+
+  std::vector<cv::Mat> image_batch;
+  size_t signal_i = 0;
+  for (size_t image_i = 0; image_i < images.size(); image_i++) {
+    image_batch.emplace_back(images[image_i]);
+    // keep the actual batch size
+    const size_t true_batch_size = image_batch.size();
+    // insert fake images since the TRT model requires a static batch size
+    if (image_i + 1 == images.size()) {
+      while (static_cast<int>(image_batch.size()) < batch_size_) {
+        image_batch.emplace_back(image_batch.front());
+      }
+    }
+    if (static_cast<int>(image_batch.size()) == batch_size_) {
+      std::vector<float> confidences;
+      std::vector<int> classes;
+      const bool res = classifier_->doInference(image_batch, classes, confidences);
+      if (!res || classes.empty() || confidences.empty()) {
+        result.success = false;
+        return result;
+      }
+      for (size_t i = 0; i < true_batch_size; i++) {
+        const auto elements = decode_label(labels_[classes[i]], confidences[i]);
+        auto & signal_elements = result.signals.signals[signal_i].elements;
+        signal_elements.insert(signal_elements.end(), elements.begin(), elements.end());
+        signal_i++;
+      }
+      image_batch.clear();
+    }
+  }
+  result.success = true;
+  return result;
+}
+
+std::vector<tier4_perception_msgs::msg::TrafficLightElement> CNNClassifierCore::decode_label(
+  const std::string & label, float confidence)
+{
+  // label names are assumed to be comma-separated to represent each lamp
+  // e.g.
+  //   label:       "red,red-cross,right"
+  //   split_label: ["red", "red-cross", "right"]
+  // if a token has no color suffix, set GREEN to the color state.
+  // if a token has no shape suffix, set CIRCLE to the shape state.
+  std::vector<tier4_perception_msgs::msg::TrafficLightElement> elements;
+  std::vector<std::string> split_label;
+  boost::algorithm::split(split_label, label, boost::is_any_of(","));
+  for (const auto & lamp_label : split_label) {
+    tier4_perception_msgs::msg::TrafficLightElement element;
+    if (lamp_label.find("-") != std::string::npos) {
+      // found "-" delimiter in the label string
+      std::vector<std::string> color_and_shape;
+      boost::algorithm::split(color_and_shape, lamp_label, boost::is_any_of("-"));
+      element.color = utils::convertColorStringtoT4(color_and_shape.at(0));
+      element.shape = utils::convertShapeStringtoT4(color_and_shape.at(1));
+    } else {
+      if (lamp_label == std::string("unknown")) {
+        // if the label is unknown, set UNKNOWN to color and shape
+        element.color = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
+        element.shape = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
+      } else if (utils::isColorLabel(lamp_label)) {
+        element.color = utils::convertColorStringtoT4(lamp_label);
+        element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
+      } else {
+        element.color = tier4_perception_msgs::msg::TrafficLightElement::GREEN;
+        element.shape = utils::convertShapeStringtoT4(lamp_label);
+      }
+    }
+    element.confidence = confidence;
+    elements.push_back(element);
+  }
+  return elements;
+}
+
+cv::Mat CNNClassifierCore::make_debug_image(
+  const cv::Mat & roi_image, const tier4_perception_msgs::msg::TrafficLight & signal)
+{
+  float confidence = 0.0f;
+  std::string label;
+  for (std::size_t i = 0; i < signal.elements.size(); i++) {
+    const auto & light = signal.elements.at(i);
+    const auto light_label =
+      utils::convertColorT4toString(light.color) + "-" + utils::convertShapeT4toString(light.shape);
+    label += light_label;
+    // all lamp confidences are the same
+    confidence = light.confidence;
+    if (i < signal.elements.size() - 1) {
+      label += ",";
+    }
+  }
+
+  const int expand_w = 200;
+  const int expand_h = std::max(static_cast<int>((expand_w * roi_image.rows) / roi_image.cols), 1);
+
+  cv::Mat debug_image;
+  cv::resize(roi_image, debug_image, cv::Size(expand_w, expand_h));
+  cv::Mat text_img(cv::Size(expand_w, 50), CV_8UC3, cv::Scalar(0, 0, 0));
+  const std::string text = label + " " + std::to_string(confidence);
+  cv::putText(
+    text_img, text, cv::Point(5, 25), cv::FONT_HERSHEY_COMPLEX, 0.5, cv::Scalar(0, 255, 0), 1);
+  cv::vconcat(debug_image, text_img, debug_image);
+  return debug_image;
+}
+
+// ============================== CNNClassifier ==============================
+// ROS adapter: declares parameters, reads the label file, publishes debug images, and
+// delegates classification to the Node-free core.
+
+namespace
+{
+// Read the label file into a vector of lines. Logs and throws std::runtime_error if the
+// file cannot be opened, so a misconfigured path fails node construction fast rather than
+// leaving the classifier with an empty label table (which would be an out-of-range
+// lookup at inference time).
+std::vector<std::string> read_label_file(rclcpp::Node * node, const std::string & filepath)
+{
+  std::ifstream labels_file(filepath);
+  if (!labels_file.is_open()) {
+    RCLCPP_ERROR(node->get_logger(), "Could not open label file. [%s]", filepath.c_str());
+    throw std::runtime_error("Could not open label file: " + filepath);
+  }
+  std::vector<std::string> labels;
+  std::string label;
+  while (std::getline(labels_file, label)) {
+    labels.push_back(label);
+  }
+  return labels;
+}
+
+// Declare the CNN parameters on `node`, read the label file, and return the resulting
+// config. ROS params cannot load std::vector<float>, so mean/std are declared as
+// std::vector<double> and narrowed here -- keeping that quirk in the adapter so the core
+// sees plain std::vector<float>.
+CNNConfig declare_cnn_config(rclcpp::Node * node)
+{
+  const std::string precision = node->declare_parameter<std::string>("precision");
+  const std::string label_path = node->declare_parameter<std::string>("label_path");
+  const std::string model_path = node->declare_parameter<std::string>("model_path");
+  const auto mean_d = node->declare_parameter<std::vector<double>>("mean");
+  const auto std_d = node->declare_parameter<std::vector<double>>("std");
+
+  CNNConfig config;
+  config.model_path = model_path;
+  config.precision = precision;
+  config.labels = read_label_file(node, label_path);
+  config.mean = std::vector<float>(mean_d.begin(), mean_d.end());
+  config.std = std::vector<float>(std_d.begin(), std_d.end());
+  return config;
+}
+}  // namespace
+
+CNNClassifier::CNNClassifier(rclcpp::Node * node_ptr)
+: node_ptr_(node_ptr), core_(declare_cnn_config(node_ptr))
 {
   image_pub_ = image_transport::create_publisher(
     node_ptr_, "~/output/debug/image", rclcpp::QoS{1}.get_rmw_qos_profile());
-
-  std::string precision;
-  std::string label_file_path;
-  std::string model_file_path;
-  precision = node_ptr_->declare_parameter<std::string>("precision");
-  label_file_path = node_ptr_->declare_parameter<std::string>("label_path");
-  model_file_path = node_ptr_->declare_parameter<std::string>("model_path");
-  // ros param does not support loading std::vector<float>
-  // we have to load std::vector<double> and transfer to std::vector<float>
-  auto mean_d = node_ptr->declare_parameter<std::vector<double>>("mean");
-  auto std_d = node_ptr->declare_parameter<std::vector<double>>("std");
-  mean_ = std::vector<float>(mean_d.begin(), mean_d.end());
-  std_ = std::vector<float>(std_d.begin(), std_d.end());
-  if (mean_.size() != 3 || std_.size() != 3) {
-    RCLCPP_ERROR(node_ptr->get_logger(), "mean and std must be of size 3");
-    return;
-  }
-
-  readLabelfile(label_file_path, labels_);
-
-  classifier_ = std::make_unique<autoware::tensorrt_classifier::TrtClassifier>(
-    model_file_path, precision, mean_, std_);
-  batch_size_ = classifier_->getBatchSize();
 }
 
 bool CNNClassifier::getTrafficSignals(
@@ -65,123 +213,33 @@ bool CNNClassifier::getTrafficSignals(
     RCLCPP_WARN(node_ptr_->get_logger(), "image number should be equal to traffic signal number!");
     return false;
   }
-  std::vector<cv::Mat> image_batch;
-  int signal_i = 0;
 
-  for (size_t image_i = 0; image_i < images.size(); image_i++) {
-    image_batch.emplace_back(images[image_i]);
-    // keep the actual batch size
-    size_t true_batch_size = image_batch.size();
-    // insert fake image since the TRT model requires static batch size
-    if (image_i + 1 == images.size()) {
-      while (static_cast<int>(image_batch.size()) < batch_size_) {
-        image_batch.emplace_back(image_batch.front());
-      }
-    }
-    if (static_cast<int>(image_batch.size()) == batch_size_) {
-      std::vector<float> probabilities;
-      std::vector<int> classes;
-      bool res = classifier_->doInference(image_batch, classes, probabilities);
-      if (!res || classes.empty() || probabilities.empty()) {
-        return false;
-      }
-      for (size_t i = 0; i < true_batch_size; i++) {
-        postProcess(classes[i], probabilities[i], traffic_signals.signals[signal_i]);
-        /* debug */
-        if (0 < image_pub_.getNumSubscribers()) {
-          outputDebugImage(image_batch[i], traffic_signals.signals[signal_i]);
-        }
-        signal_i++;
-      }
-      image_batch.clear();
-    }
-  }
-  return true;
-}
-
-void CNNClassifier::outputDebugImage(
-  cv::Mat & debug_image, const tier4_perception_msgs::msg::TrafficLight & traffic_signal)
-{
-  float probability = 0.0f;
-  std::string label;
-  for (std::size_t i = 0; i < traffic_signal.elements.size(); i++) {
-    auto light = traffic_signal.elements.at(i);
-    const auto light_label =
-      utils::convertColorT4toString(light.color) + "-" + utils::convertShapeT4toString(light.shape);
-    label += light_label;
-    // all lamp confidence are the same
-    probability = light.confidence;
-    if (i < traffic_signal.elements.size() - 1) {
-      label += ",";
-    }
-  }
-
-  const int expand_w = 200;
-  const int expand_h =
-    std::max(static_cast<int>((expand_w * debug_image.rows) / debug_image.cols), 1);
-
-  cv::resize(debug_image, debug_image, cv::Size(expand_w, expand_h));
-  cv::Mat text_img(cv::Size(expand_w, 50), CV_8UC3, cv::Scalar(0, 0, 0));
-  std::string text = label + " " + std::to_string(probability);
-  cv::putText(
-    text_img, text, cv::Point(5, 25), cv::FONT_HERSHEY_COMPLEX, 0.5, cv::Scalar(0, 255, 0), 1);
-  cv::vconcat(debug_image, text_img, debug_image);
-
-  const auto debug_image_msg =
-    cv_bridge::CvImage(std_msgs::msg::Header(), "rgb8", debug_image).toImageMsg();
-  image_pub_.publish(debug_image_msg);
-}
-
-void CNNClassifier::postProcess(
-  int class_index, float prob, tier4_perception_msgs::msg::TrafficLight & traffic_signal) const
-{
-  std::string match_label = labels_[class_index];
-
-  // label names are assumed to be comma-separated to represent each lamp
-  // e.g.
-  // match_label: "red","red-cross","right"
-  // split_label: ["red","red-cross","right"]
-  // if shape doesn't have color suffix, set GREEN to color state.
-  // if color doesn't have shape suffix, set CIRCLE to shape state.
-  std::vector<std::string> split_label;
-  boost::algorithm::split(split_label, match_label, boost::is_any_of(","));
-  for (auto label : split_label) {
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    if (label.find("-") != std::string::npos) {
-      // found "-" delimiter in label string
-      std::vector<std::string> color_and_shape;
-      boost::algorithm::split(color_and_shape, label, boost::is_any_of("-"));
-      element.color = utils::convertColorStringtoT4(color_and_shape.at(0));
-      element.shape = utils::convertShapeStringtoT4(color_and_shape.at(1));
-    } else {
-      if (label == std::string("unknown")) {
-        // if label is unknown, set UNKNOWN to color and shape
-        element.color = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
-        element.shape = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
-      } else if (utils::isColorLabel(label)) {
-        element.color = utils::convertColorStringtoT4(label);
-        element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-      } else {
-        element.color = tier4_perception_msgs::msg::TrafficLightElement::GREEN;
-        element.shape = utils::convertShapeStringtoT4(label);
-      }
-    }
-    element.confidence = prob;
-    traffic_signal.elements.push_back(element);
-  }
-}
-
-bool CNNClassifier::readLabelfile(std::string filepath, std::vector<std::string> & labels)
-{
-  std::ifstream labelsFile(filepath);
-  if (!labelsFile.is_open()) {
-    RCLCPP_ERROR(node_ptr_->get_logger(), "Could not open label file. [%s]", filepath.c_str());
+  const CNNClassifierCore::ClassifierResult result = core_.classify(images);
+  if (!result.success) {
+    RCLCPP_ERROR(node_ptr_->get_logger(), "failed to classify traffic light image by cnn");
     return false;
   }
-  std::string label;
-  while (getline(labelsFile, label)) {
-    labels.push_back(label);
+
+  // Publish one debug image per ROI only when a debug consumer is attached.
+  if (0 < image_pub_.getNumSubscribers()) {
+    for (size_t i = 0; i < images.size(); i++) {
+      const auto debug_image_msg =
+        cv_bridge::CvImage(
+          std_msgs::msg::Header(), "rgb8",
+          CNNClassifierCore::make_debug_image(images[i], result.signals.signals[i]))
+          .toImageMsg();
+      image_pub_.publish(debug_image_msg);
+    }
   }
+
+  // Attach the core's per-image elements to the caller's pre-populated signals,
+  // preserving the traffic_light_id / traffic_light_type set upstream.
+  for (size_t i = 0; i < traffic_signals.signals.size(); i++) {
+    auto & elements = traffic_signals.signals[i].elements;
+    const auto & classified = result.signals.signals[i].elements;
+    elements.insert(elements.end(), classified.begin(), classified.end());
+  }
+
   return true;
 }
 

--- a/perception/autoware_traffic_light_classifier/src/classifier/cnn_classifier.hpp
+++ b/perception/autoware_traffic_light_classifier/src/classifier/cnn_classifier.hpp
@@ -17,16 +17,13 @@
 
 #include "classifier_interface.hpp"
 
-#include <autoware/cuda_utils/cuda_unique_ptr.hpp>
-#include <autoware/cuda_utils/stream_unique_ptr.hpp>
 #include <autoware/tensorrt_classifier/tensorrt_classifier.hpp>
-#include <autoware/tensorrt_common/tensorrt_common.hpp>
 #include <image_transport/image_transport.hpp>
 #include <opencv2/core/core.hpp>
-#include <opencv2/highgui/highgui.hpp>
-#include <opencv2/opencv.hpp>
 #include <rclcpp/rclcpp.hpp>
 
+#include <tier4_perception_msgs/msg/traffic_light.hpp>
+#include <tier4_perception_msgs/msg/traffic_light_array.hpp>
 #include <tier4_perception_msgs/msg/traffic_light_element.hpp>
 
 #if __has_include(<cv_bridge/cv_bridge.hpp>)
@@ -35,20 +32,67 @@
 #include <cv_bridge/cv_bridge.h>
 #endif
 
-#include <fstream>
-#include <map>
 #include <memory>
 #include <string>
 #include <vector>
 
 namespace autoware::traffic_light
 {
+// Configuration for CNNClassifierCore. model_path is a file path (TrtClassifier loads
+// the model itself); labels are the pre-read label-file lines, so the core does no file
+// I/O of its own.
+struct CNNConfig
+{
+  std::string model_path;
+  std::string precision;
+  std::vector<std::string> labels;
+  std::vector<float> mean;
+  std::vector<float> std;
+};
 
-using autoware::cuda_utils::CudaUniquePtr;
-using autoware::cuda_utils::CudaUniquePtrHost;
-using autoware::cuda_utils::makeCudaStream;
-using autoware::cuda_utils::StreamUniquePtr;
+// CNN (TensorRT) classification core; the engine is whatever model is configured
+// (e.g. MobileNet-v2 or EfficientNet-b1). Its constructor builds a TensorRT engine, so
+// instantiating it needs a GPU and the model; decode_label and make_debug_image are
+// static so they can be exercised without one.
+class CNNClassifierCore
+{
+public:
+  // One signal per input image, elements populated by the label decode. traffic_light_id
+  // / type are left unset -- the caller associates them.
+  struct ClassifierResult
+  {
+    tier4_perception_msgs::msg::TrafficLightArray signals;
+    bool success = false;
+  };
 
+  // Builds the TensorRT engine from config.model_path and stores the label table. Throws
+  // std::invalid_argument if mean/std are not size 3 (a TrtClassifier precondition).
+  explicit CNNClassifierCore(const CNNConfig & config);
+
+  // Classify each ROI image into one signal, batching up to the model's static batch
+  // size. NON-const: TrtClassifier::doInference mutates the engine's internal buffers.
+  ClassifierResult classify(const std::vector<cv::Mat> & images);
+
+  // Decode one model label string into per-lamp elements: comma-separated lamps, each a
+  // "color-shape" token, a bare color (-> CIRCLE), a bare shape (-> GREEN), or "unknown".
+  // Every element gets `confidence`.
+  static std::vector<tier4_perception_msgs::msg::TrafficLightElement> decode_label(
+    const std::string & label, float confidence);
+
+  // Render one debug image: the ROI resized to a fixed width with a label / confidence
+  // text strip below. Returns a fresh Mat (does not mutate roi_image).
+  static cv::Mat make_debug_image(
+    const cv::Mat & roi_image, const tier4_perception_msgs::msg::TrafficLight & signal);
+
+private:
+  std::unique_ptr<autoware::tensorrt_classifier::TrtClassifier> classifier_;
+  std::vector<std::string> labels_;
+  int batch_size_ = 0;
+};
+
+// Thin ROS adapter around CNNClassifierCore. Owns the node-facing concerns (parameter
+// declaration, label-file reading, debug-image publishing, logging) and delegates
+// classification to the core. Public API is unchanged.
 class CNNClassifier : public ClassifierInterface
 {
 public:
@@ -60,20 +104,9 @@ public:
     tier4_perception_msgs::msg::TrafficLightArray & traffic_signals) override;
 
 private:
-  void postProcess(
-    int class_index, float prob, tier4_perception_msgs::msg::TrafficLight & traffic_signal) const;
-  bool readLabelfile(std::string filepath, std::vector<std::string> & labels);
-  void outputDebugImage(
-    cv::Mat & debug_image, const tier4_perception_msgs::msg::TrafficLight & traffic_signal);
-
-private:
   rclcpp::Node * node_ptr_;
-  int batch_size_;
-  std::unique_ptr<autoware::tensorrt_classifier::TrtClassifier> classifier_;
   image_transport::Publisher image_pub_;
-  std::vector<std::string> labels_;
-  std::vector<float> mean_;
-  std::vector<float> std_;
+  CNNClassifierCore core_;
 };
 
 }  // namespace autoware::traffic_light

--- a/perception/autoware_traffic_light_classifier/test/test_cnn_classifier_core.cpp
+++ b/perception/autoware_traffic_light_classifier/test/test_cnn_classifier_core.cpp
@@ -1,0 +1,178 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//
+// ROS-free unit tests for CNNClassifierCore's pure, GPU-free helpers.
+//
+// CNNClassifierCore's constructor builds a TensorRT engine (needs a GPU + model) and
+// classify() runs inference, so neither can run in a hardware-free test -- that path is
+// covered by the GPU-gated characterization test test_cnn_classifier.cpp. The two pure
+// helpers, decode_label() and make_debug_image(), are static and depend only on the
+// perception message types + OpenCV, so they are exercised here without a node, a GPU,
+// or a model.
+//
+// Tests follow Arrange-Act-Assert.
+//
+
+#include "../src/classifier/cnn_classifier.hpp"
+
+#include <opencv2/core.hpp>
+
+#include <tier4_perception_msgs/msg/traffic_light.hpp>
+#include <tier4_perception_msgs/msg/traffic_light_element.hpp>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+namespace tl = autoware::traffic_light;
+
+using tier4_perception_msgs::msg::TrafficLight;
+using tier4_perception_msgs::msg::TrafficLightElement;
+
+// A single "color-shape" token decodes to one element with both fields mapped.
+TEST(CnnClassifierCoreDecodeLabelTest, ColorShapeToken)
+{
+  // Arrange / Act
+  const auto elements = tl::CNNClassifierCore::decode_label("red-cross", 0.5f);
+
+  // Assert
+  ASSERT_EQ(elements.size(), 1u);
+  EXPECT_EQ(elements[0].color, TrafficLightElement::RED);
+  EXPECT_EQ(elements[0].shape, TrafficLightElement::CROSS);
+}
+
+// Comma-separated tokens decode to one element each, and the per-token branches differ:
+// a bare color implies a CIRCLE shape while a "color-shape" token maps the shape. This
+// pins both the comma loop and the per-token branch selection in one case.
+TEST(CnnClassifierCoreDecodeLabelTest, CommaSeparatedLampsDecodePerToken)
+{
+  // Arrange / Act
+  const auto elements = tl::CNNClassifierCore::decode_label("red,red-right", 0.5f);
+
+  // Assert
+  ASSERT_EQ(elements.size(), 2u);
+  EXPECT_EQ(elements[0].color, TrafficLightElement::RED);
+  EXPECT_EQ(elements[0].shape, TrafficLightElement::CIRCLE);
+  EXPECT_EQ(elements[1].color, TrafficLightElement::RED);
+  EXPECT_EQ(elements[1].shape, TrafficLightElement::RIGHT_ARROW);
+}
+
+// A bare "unknown" token maps both color and shape to UNKNOWN.
+TEST(CnnClassifierCoreDecodeLabelTest, UnknownToken)
+{
+  // Arrange / Act
+  const auto elements = tl::CNNClassifierCore::decode_label("unknown", 0.5f);
+
+  // Assert
+  ASSERT_EQ(elements.size(), 1u);
+  EXPECT_EQ(elements[0].color, TrafficLightElement::UNKNOWN);
+  EXPECT_EQ(elements[0].shape, TrafficLightElement::UNKNOWN);
+}
+
+// A bare color token implies a CIRCLE shape.
+TEST(CnnClassifierCoreDecodeLabelTest, BareColorImpliesCircle)
+{
+  // Arrange / Act
+  const auto elements = tl::CNNClassifierCore::decode_label("green", 0.5f);
+
+  // Assert
+  ASSERT_EQ(elements.size(), 1u);
+  EXPECT_EQ(elements[0].color, TrafficLightElement::GREEN);
+  EXPECT_EQ(elements[0].shape, TrafficLightElement::CIRCLE);
+}
+
+// A bare shape token (no color prefix) defaults the color to GREEN -- the surprising
+// fall-through branch worth pinning.
+TEST(CnnClassifierCoreDecodeLabelTest, BareShapeDefaultsToGreen)
+{
+  // Arrange / Act
+  const auto elements = tl::CNNClassifierCore::decode_label("right", 0.5f);
+
+  // Assert
+  ASSERT_EQ(elements.size(), 1u);
+  EXPECT_EQ(elements[0].color, TrafficLightElement::GREEN);
+  EXPECT_EQ(elements[0].shape, TrafficLightElement::RIGHT_ARROW);
+}
+
+// The passed confidence is propagated to every decoded lamp element.
+TEST(CnnClassifierCoreDecodeLabelTest, ConfidencePropagatedToEveryLamp)
+{
+  // Arrange
+  const float confidence = 0.75f;
+
+  // Act
+  const auto elements = tl::CNNClassifierCore::decode_label("red,green-right,unknown", confidence);
+
+  // Assert
+  ASSERT_EQ(elements.size(), 3u);
+  for (const auto & element : elements) {
+    EXPECT_FLOAT_EQ(element.confidence, confidence);
+  }
+}
+
+// make_debug_image lays out the ROI resized to a fixed 200px width above a 50px text
+// strip. A non-square ROI makes an accidental rows/cols swap detectable.
+TEST(CnnClassifierCoreDebugImageTest, MosaicGeometry)
+{
+  // Arrange -- distinct width and height; one element so the label strip is exercised.
+  const int roi_width = 100;
+  const int roi_height = 50;
+  const cv::Mat roi(roi_height, roi_width, CV_8UC3, cv::Scalar(0, 255, 0));
+  TrafficLight signal;
+  TrafficLightElement element;
+  element.color = TrafficLightElement::GREEN;
+  element.shape = TrafficLightElement::CIRCLE;
+  element.confidence = 0.9f;
+  signal.elements.push_back(element);
+
+  // Act
+  const cv::Mat debug_image = tl::CNNClassifierCore::make_debug_image(roi, signal);
+
+  // Assert -- width fixed at 200, height = scaled ROI (200*50/100 == 100) + 50px strip.
+  EXPECT_EQ(debug_image.cols, 200);
+  EXPECT_EQ(debug_image.rows, 100 + 50);
+  EXPECT_EQ(debug_image.type(), CV_8UC3);
+}
+
+// make_debug_image returns a fresh Mat and does not mutate the input ROI (the old
+// in-place outputDebugImage resized its argument).
+TEST(CnnClassifierCoreDebugImageTest, DoesNotMutateInput)
+{
+  // Arrange
+  const int roi_width = 100;
+  const int roi_height = 50;
+  cv::Mat roi(roi_height, roi_width, CV_8UC3, cv::Scalar(0, 255, 0));
+  TrafficLight signal;
+  TrafficLightElement element;
+  element.color = TrafficLightElement::GREEN;
+  element.shape = TrafficLightElement::CIRCLE;
+  element.confidence = 0.9f;
+  signal.elements.push_back(element);
+
+  // Act
+  tl::CNNClassifierCore::make_debug_image(roi, signal);
+
+  // Assert
+  EXPECT_EQ(roi.cols, roi_width);
+  EXPECT_EQ(roi.rows, roi_height);
+}
+
+}  // namespace
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Description

This PR extracts a **Node-free `CNNClassifierCore`** from `CNNClassifier`, mirroring the `ColorClassifierCore` split in #12916. The classification logic can now be constructed from a plain `CNNConfig` and its pure helpers called directly — no node, no parameters, no RMW. The change is scoped to `src/classifier/cnn_classifier.{hpp,cpp}` (plus the CMake/test wiring):

- **`CNNClassifierCore`** depends only on TensorRT + OpenCV + `tier4_perception_msgs` (no `rclcpp`, `image_transport`, `cv_bridge`, or logging). Constructed from a `CNNConfig` (pre-read label lines + model path + precision + mean/std); return-based API `ClassifierResult classify(const std::vector<cv::Mat> &)`. The engine build stays in the constructor, but the two pure helpers `decode_label` and `make_debug_image` are `static`, so they run without a GPU or a model.
- **`CNNClassifier`** remains a thin ROS adapter with an **unchanged public API** (same `rclcpp::Node *` constructor and `getTrafficSignals` override). It keeps the ROS-facing concerns: parameter declaration, label-file reading, `~/output/debug/image` publishing, logging, the images/signals size guard, and element merging (preserving upstream　traffic-light id/type).

`ClassifierInterface`, the color backend, and the node files are intentionally left untouched.

## Related links

**Parent Issue:**

- None

Sibling refactor (same package, color backend): #12916

## How was this PR tested?

- `colcon build --packages-select autoware_traffic_light_classifier` → success
- `colcon test --packages-select autoware_traffic_light_classifier`
  - **`test_cnn_classifier_core`** (new, ROS-free) → 8/8 pass
  - **`test_cnn_classifier`** (existing GPU characterization, kept **unchanged**) → 6/6 pass, confirming the refactor preserves behavior
- `clang-format` / `cpplint` clean (pre-commit)

## Notes for reviewers

- Scope is intentionally minimal and self-contained. `CNNClassifier`'s public API and the `ClassifierInterface` contract are unchanged, so all call sites compile without modification.
- The new `test_cnn_classifier_core` is gated on `TRT_AVAIL AND CUDA_AVAIL` because it links `${PROJECT_NAME}` (the only config that compiles `cnn_classifier.cpp`), but it exercises only the static GPU-free helpers, so it needs no GPU at run time — unlike `test_cnn_classifier`.

## Interface changes

None. `CNNClassifier`'s public API and the `ClassifierInterface` abstract interface are unchanged.

## Effects on system behavior

Behavior-preserving on the success path (verified by the unchanged characterization test).
One intentional hardening, a direct consequence of moving construction into a Node-free core that signals failure by throwing rather than by leaving itself half-built:

- A **missing/unreadable label file** now throws `std::runtime_error` at construction. Before, `readLabelfile`'s return value was ignored, leaving `labels_` empty and causing an out-of-range `labels_[class_index]` at inference time.
- A **wrong-size `mean`/`std`** now throws `std::invalid_argument`. Before, the constructor logged and returned early, leaving `classifier_` null and faulting at inference time.

Both replace a latent silent-failure/UB path with fail-fast node construction.
