### PR TITLE
refactor(pid_longitudinal_controller): extract smooth stop clock

### DIFF
--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
@@ -185,7 +185,7 @@ private:
   double m_brake_keeping_acc;
 
   // smooth stop
-  SmoothStop m_smooth_stop;
+  std::optional<SmoothStop> m_smooth_stop;
 
   // stop
   struct StoppedStateParams

--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/smooth_stop.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/smooth_stop.hpp
@@ -35,6 +35,25 @@ namespace autoware::motion::control::pid_longitudinal_controller
 class SmoothStop
 {
 public:
+  struct Params
+  {
+    double max_strong_acc;
+    double min_strong_acc;
+    double weak_acc;
+    double weak_stop_acc;
+    double strong_stop_acc;
+
+    double min_fast_vel;
+    double min_running_vel;
+    double min_running_acc;
+    double weak_stop_time;
+
+    double weak_stop_dist;
+    double strong_stop_dist;
+  };
+
+  explicit SmoothStop(const Params & params) : m_params(params) {}
+
   /**
    * @brief initialize the state of the smooth stop
    * @param [in] pred_vel_in_target predicted ego velocity when the stop command will be executed
@@ -46,31 +65,16 @@ public:
     const rclcpp::Time & current_time);
 
   /**
-   * @brief set the parameters of this smooth stop
-   * @param [in] max_strong_acc maximum strong acceleration value [m/s²]
-   * @param [in] min_strong_acc minumum strong acceleration value [m/s²]
-   * @param [in] weak_acc weak acceleration value [m/s²]
-   * @param [in] weak_stop_acc weak stopping acceleration value [m/s²]
-   * @param [in] strong_stop_acc strong stopping acceleration value [m/s²]
-   * @param [in] min_fast_vel minumum velocity to consider ego to be running fast [m/s]
-   * @param [in] min_running_vel minimum velocity to consider ego to be running [m/s]
-   * @param [in] min_running_acc minimum acceleration to consider ego to be running [m/s]
-   * @param [in] weak_stop_time time allowed for stopping with a weak acceleration [s]
-   * @param [in] weak_stop_dist distance to the stop point bellow which a weak accel is applied [m]
-   * @param [in] strong_stop_dist distance to the stop point bellow which a strong accel is applied
-   * [m]
+   * @brief update the parameters of this smooth stop, e.g. on a dynamic reconfiguration
+   * @param [in] params new parameters to apply
    */
-  void setParams(
-    double max_strong_acc, double min_strong_acc, double weak_acc, double weak_stop_acc,
-    double strong_stop_acc, double min_fast_vel, double min_running_vel, double min_running_acc,
-    double weak_stop_time, double weak_stop_dist, double strong_stop_dist);
+  void setParams(const Params & params);
 
   /**
    * @brief predict time when car stops by fitting some latest observed velocity history
    *        with linear function (v = at + b)
    * @param [in] vel_hist history of previous ego velocities as (rclcpp::Time, double[m/s]) pairs
    * @param [in] current_time time used as the reference point for the velocity history deltas
-   * @throw std::runtime_error if parameters have not been set
    */
   std::experimental::optional<double> calcTimeToStop(
     const std::vector<std::pair<rclcpp::Time, double>> & vel_hist,
@@ -88,7 +92,6 @@ public:
    * @param [in] vel_hist history of previous ego velocities as (rclcpp::Time, double[m/s]) pairs
    * @param [in] delay_time assumed time delay when the stop command will actually be executed
    * @param [in] current_time time at which this calculation occurs
-   * @throw std::runtime_error if parameters have not been set
    */
   double calculate(
     const double stop_dist, const double current_vel, const double current_acc,
@@ -96,29 +99,12 @@ public:
     const rclcpp::Time & current_time, DebugValues & debug_values);
 
 private:
-  struct Params
-  {
-    double max_strong_acc;
-    double min_strong_acc;
-    double weak_acc;
-    double weak_stop_acc;
-    double strong_stop_acc;
-
-    double min_fast_vel;
-    double min_running_vel;
-    double min_running_acc;
-    double weak_stop_time;
-
-    double weak_stop_dist;
-    double strong_stop_dist;
-  };
   Params m_params;
 
   enum class Mode { STRONG = 0, WEAK, WEAK_STOP, STRONG_STOP };
 
   double m_strong_acc;
   rclcpp::Time m_weak_acc_time;
-  bool m_is_set_params = false;
 };
 }  // namespace autoware::motion::control::pid_longitudinal_controller
 

--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/smooth_stop.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/smooth_stop.hpp
@@ -18,11 +18,10 @@
 #include "autoware/pid_longitudinal_controller/debug_values.hpp"
 #include "rclcpp/rclcpp.hpp"
 
-#include <experimental/optional>  // NOLINT
-
 #include <algorithm>
 #include <cmath>
 #include <limits>
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -76,7 +75,7 @@ public:
    * @param [in] vel_hist history of previous ego velocities as (rclcpp::Time, double[m/s]) pairs
    * @param [in] current_time time used as the reference point for the velocity history deltas
    */
-  std::experimental::optional<double> calcTimeToStop(
+  std::optional<double> calcTimeToStop(
     const std::vector<std::pair<rclcpp::Time, double>> & vel_hist,
     const rclcpp::Time & current_time) const;
 

--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/smooth_stop.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/smooth_stop.hpp
@@ -39,8 +39,11 @@ public:
    * @brief initialize the state of the smooth stop
    * @param [in] pred_vel_in_target predicted ego velocity when the stop command will be executed
    * @param [in] pred_stop_dist predicted stop distance when the stop command will be executed
+   * @param [in] current_time time at which this initialization occurs
    */
-  void init(const double pred_vel_in_target, const double pred_stop_dist);
+  void init(
+    const double pred_vel_in_target, const double pred_stop_dist,
+    const rclcpp::Time & current_time);
 
   /**
    * @brief set the parameters of this smooth stop
@@ -66,10 +69,12 @@ public:
    * @brief predict time when car stops by fitting some latest observed velocity history
    *        with linear function (v = at + b)
    * @param [in] vel_hist history of previous ego velocities as (rclcpp::Time, double[m/s]) pairs
+   * @param [in] current_time time used as the reference point for the velocity history deltas
    * @throw std::runtime_error if parameters have not been set
    */
   std::experimental::optional<double> calcTimeToStop(
-    const std::vector<std::pair<rclcpp::Time, double>> & vel_hist) const;
+    const std::vector<std::pair<rclcpp::Time, double>> & vel_hist,
+    const rclcpp::Time & current_time) const;
 
   /**
    * @brief calculate accel command while stopping
@@ -82,12 +87,13 @@ public:
    * @param [in] current_acc current acceleration of ego [m/s²]
    * @param [in] vel_hist history of previous ego velocities as (rclcpp::Time, double[m/s]) pairs
    * @param [in] delay_time assumed time delay when the stop command will actually be executed
+   * @param [in] current_time time at which this calculation occurs
    * @throw std::runtime_error if parameters have not been set
    */
   double calculate(
     const double stop_dist, const double current_vel, const double current_acc,
     const std::vector<std::pair<rclcpp::Time, double>> & vel_hist, const double delay_time,
-    DebugValues & debug_values);
+    const rclcpp::Time & current_time, DebugValues & debug_values);
 
 private:
   struct Params

--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/smooth_stop.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/smooth_stop.hpp
@@ -70,16 +70,6 @@ public:
   void setParams(const Params & params);
 
   /**
-   * @brief predict time when car stops by fitting some latest observed velocity history
-   *        with linear function (v = at + b)
-   * @param [in] vel_hist history of previous ego velocities as (rclcpp::Time, double[m/s]) pairs
-   * @param [in] current_time time used as the reference point for the velocity history deltas
-   */
-  std::optional<double> calcTimeToStop(
-    const std::vector<std::pair<rclcpp::Time, double>> & vel_hist,
-    const rclcpp::Time & current_time) const;
-
-  /**
    * @brief calculate accel command while stopping
    *        Decrease velocity with m_strong_acc,
    *        then loose brake pedal with m_params.weak_acc to stop smoothly

--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -760,7 +760,7 @@ void PidLongitudinalController::updateControlState(const ControlData & control_d
         const double pred_stop_dist =
           control_data.stop_dist -
           0.5 * (pred_vel_in_target + current_vel) * m_delay_compensation_time;
-        m_smooth_stop.init(pred_vel_in_target, pred_stop_dist);
+        m_smooth_stop.init(pred_vel_in_target, pred_stop_dist, clock_->now());
         return changeControlState(ControlState::STOPPING);
       }
     } else {
@@ -912,7 +912,7 @@ PidLongitudinalController::Motion PidLongitudinalController::calcCtrlCmd(
       } else if (m_control_state == ControlState::STOPPING) {
         raw_ctrl_cmd.acc = m_smooth_stop.calculate(
           control_data.stop_dist, control_data.current_motion.vel, control_data.current_motion.acc,
-          m_vel_hist, m_delay_compensation_time, m_debug_values);
+          m_vel_hist, m_delay_compensation_time, clock_->now(), m_debug_values);
         raw_ctrl_cmd.vel = m_stopped_state_params.vel;
 
         RCLCPP_DEBUG(

--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -159,9 +159,10 @@ PidLongitudinalController::PidLongitudinalController(
     const double strong_stop_dist{
       node.declare_parameter<double>("smooth_stop_strong_stop_dist")};  // [m]
 
-    m_smooth_stop.setParams(
-      max_strong_acc, min_strong_acc, weak_acc, weak_stop_acc, strong_stop_acc, max_fast_vel,
-      min_running_vel, min_running_acc, weak_stop_time, weak_stop_dist, strong_stop_dist);
+    m_smooth_stop.emplace(
+      SmoothStop::Params{
+        max_strong_acc, min_strong_acc, weak_acc, weak_stop_acc, strong_stop_acc, max_fast_vel,
+        min_running_vel, min_running_acc, weak_stop_time, weak_stop_dist, strong_stop_dist});
   }
 
   // parameters for stop state
@@ -373,9 +374,10 @@ rcl_interfaces::msg::SetParametersResult PidLongitudinalController::paramCallbac
     update_param("smooth_stop_weak_stop_time", weak_stop_time);
     update_param("smooth_stop_weak_stop_dist", weak_stop_dist);
     update_param("smooth_stop_strong_stop_dist", strong_stop_dist);
-    m_smooth_stop.setParams(
-      max_strong_acc, min_strong_acc, weak_acc, weak_stop_acc, strong_stop_acc, max_fast_vel,
-      min_running_vel, min_running_acc, weak_stop_time, weak_stop_dist, strong_stop_dist);
+    m_smooth_stop->setParams(
+      SmoothStop::Params{
+        max_strong_acc, min_strong_acc, weak_acc, weak_stop_acc, strong_stop_acc, max_fast_vel,
+        min_running_vel, min_running_acc, weak_stop_time, weak_stop_dist, strong_stop_dist});
   }
 
   // stop state
@@ -760,7 +762,7 @@ void PidLongitudinalController::updateControlState(const ControlData & control_d
         const double pred_stop_dist =
           control_data.stop_dist -
           0.5 * (pred_vel_in_target + current_vel) * m_delay_compensation_time;
-        m_smooth_stop.init(pred_vel_in_target, pred_stop_dist, clock_->now());
+        m_smooth_stop->init(pred_vel_in_target, pred_stop_dist, clock_->now());
         return changeControlState(ControlState::STOPPING);
       }
     } else {
@@ -910,7 +912,7 @@ PidLongitudinalController::Motion PidLongitudinalController::calcCtrlCmd(
             .longitudinal_velocity_mps,
           raw_ctrl_cmd.acc);
       } else if (m_control_state == ControlState::STOPPING) {
-        raw_ctrl_cmd.acc = m_smooth_stop.calculate(
+        raw_ctrl_cmd.acc = m_smooth_stop->calculate(
           control_data.stop_dist, control_data.current_motion.vel, control_data.current_motion.acc,
           m_vel_hist, m_delay_compensation_time, clock_->now(), m_debug_values);
         raw_ctrl_cmd.vel = m_stopped_state_params.vel;

--- a/control/autoware_pid_longitudinal_controller/src/smooth_stop.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/smooth_stop.cpp
@@ -24,9 +24,10 @@
 
 namespace autoware::motion::control::pid_longitudinal_controller
 {
-void SmoothStop::init(const double pred_vel_in_target, const double pred_stop_dist)
+void SmoothStop::init(
+  const double pred_vel_in_target, const double pred_stop_dist, const rclcpp::Time & current_time)
 {
-  m_weak_acc_time = rclcpp::Clock{RCL_ROS_TIME}.now();
+  m_weak_acc_time = current_time;
 
   // when distance to stopline is near the car
   if (pred_stop_dist < std::numeric_limits<double>::epsilon()) {
@@ -61,7 +62,8 @@ void SmoothStop::setParams(
 }
 
 std::experimental::optional<double> SmoothStop::calcTimeToStop(
-  const std::vector<std::pair<rclcpp::Time, double>> & vel_hist) const
+  const std::vector<std::pair<rclcpp::Time, double>> & vel_hist,
+  const rclcpp::Time & current_time) const
 {
   if (!m_is_set_params) {
     throw std::runtime_error("Trying to calculate uninitialized SmoothStop");
@@ -74,13 +76,12 @@ std::experimental::optional<double> SmoothStop::calcTimeToStop(
   }
 
   // calculate some variables for fitting
-  const rclcpp::Time current_ros_time = rclcpp::Clock{RCL_ROS_TIME}.now();
   double mean_t = 0.0;
   double mean_v = 0.0;
   double sum_tv = 0.0;
   double sum_tt = 0.0;
   for (const auto & vel : vel_hist) {
-    const double t = (vel.first - current_ros_time).seconds();
+    const double t = (vel.first - current_time).seconds();
     const double v = vel.second;
 
     mean_t += t / vel_hist_size;
@@ -117,14 +118,14 @@ std::experimental::optional<double> SmoothStop::calcTimeToStop(
 double SmoothStop::calculate(
   const double stop_dist, const double current_vel, const double current_acc,
   const std::vector<std::pair<rclcpp::Time, double>> & vel_hist, const double delay_time,
-  DebugValues & debug_values)
+  const rclcpp::Time & current_time, DebugValues & debug_values)
 {
   if (!m_is_set_params) {
     throw std::runtime_error("Trying to calculate uninitialized SmoothStop");
   }
 
   // predict time to stop
-  const auto time_to_stop = calcTimeToStop(vel_hist);
+  const auto time_to_stop = calcTimeToStop(vel_hist, current_time);
 
   // calculate some flags
   const bool is_fast_vel = std::abs(current_vel) > m_params.min_fast_vel;
@@ -151,13 +152,13 @@ double SmoothStop::calculate(
       return m_strong_acc;
     }
 
-    m_weak_acc_time = rclcpp::Clock{RCL_ROS_TIME}.now();
+    m_weak_acc_time = current_time;
     debug_values.setValues(DebugValues::TYPE::SMOOTH_STOP_MODE, static_cast<int>(Mode::WEAK));
     return m_params.weak_acc;
   }
 
   // for 0.5 seconds after the car stopped
-  if ((rclcpp::Clock{RCL_ROS_TIME}.now() - m_weak_acc_time).seconds() < 0.5) {
+  if ((current_time - m_weak_acc_time).seconds() < 0.5) {
     debug_values.setValues(DebugValues::TYPE::SMOOTH_STOP_MODE, static_cast<int>(Mode::WEAK));
     return m_params.weak_acc;
   }

--- a/control/autoware_pid_longitudinal_controller/src/smooth_stop.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/smooth_stop.cpp
@@ -43,9 +43,10 @@ void SmoothStop::setParams(const Params & params)
   m_params = params;
 }
 
-std::optional<double> SmoothStop::calcTimeToStop(
-  const std::vector<std::pair<rclcpp::Time, double>> & vel_hist,
-  const rclcpp::Time & current_time) const
+namespace
+{
+std::optional<double> calcTimeToStop(
+  const std::vector<std::pair<rclcpp::Time, double>> & vel_hist, const rclcpp::Time & current_time)
 {
   // return when vel_hist is empty
   const double vel_hist_size = static_cast<double>(vel_hist.size());
@@ -92,6 +93,7 @@ std::optional<double> SmoothStop::calcTimeToStop(
 
   return {};
 }
+}  // namespace
 
 double SmoothStop::calculate(
   const double stop_dist, const double current_vel, const double current_acc,

--- a/control/autoware_pid_longitudinal_controller/src/smooth_stop.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/smooth_stop.cpp
@@ -39,36 +39,15 @@ void SmoothStop::init(
   m_strong_acc = std::max(std::min(m_strong_acc, m_params.max_strong_acc), m_params.min_strong_acc);
 }
 
-void SmoothStop::setParams(
-  double max_strong_acc, double min_strong_acc, double weak_acc, double weak_stop_acc,
-  double strong_stop_acc, double min_fast_vel, double min_running_vel, double min_running_acc,
-  double weak_stop_time, double weak_stop_dist, double strong_stop_dist)
+void SmoothStop::setParams(const Params & params)
 {
-  m_params.max_strong_acc = max_strong_acc;
-  m_params.min_strong_acc = min_strong_acc;
-  m_params.weak_acc = weak_acc;
-  m_params.weak_stop_acc = weak_stop_acc;
-  m_params.strong_stop_acc = strong_stop_acc;
-
-  m_params.min_fast_vel = min_fast_vel;
-  m_params.min_running_vel = min_running_vel;
-  m_params.min_running_acc = min_running_acc;
-  m_params.weak_stop_time = weak_stop_time;
-
-  m_params.weak_stop_dist = weak_stop_dist;
-  m_params.strong_stop_dist = strong_stop_dist;
-
-  m_is_set_params = true;
+  m_params = params;
 }
 
 std::experimental::optional<double> SmoothStop::calcTimeToStop(
   const std::vector<std::pair<rclcpp::Time, double>> & vel_hist,
   const rclcpp::Time & current_time) const
 {
-  if (!m_is_set_params) {
-    throw std::runtime_error("Trying to calculate uninitialized SmoothStop");
-  }
-
   // return when vel_hist is empty
   const double vel_hist_size = static_cast<double>(vel_hist.size());
   if (vel_hist_size == 0.0) {
@@ -120,10 +99,6 @@ double SmoothStop::calculate(
   const std::vector<std::pair<rclcpp::Time, double>> & vel_hist, const double delay_time,
   const rclcpp::Time & current_time, DebugValues & debug_values)
 {
-  if (!m_is_set_params) {
-    throw std::runtime_error("Trying to calculate uninitialized SmoothStop");
-  }
-
   // predict time to stop
   const auto time_to_stop = calcTimeToStop(vel_hist, current_time);
 

--- a/control/autoware_pid_longitudinal_controller/src/smooth_stop.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/smooth_stop.cpp
@@ -14,11 +14,10 @@
 
 #include "autoware/pid_longitudinal_controller/smooth_stop.hpp"
 
-#include <experimental/optional>  // NOLINT
-
 #include <algorithm>
 #include <cmath>
 #include <limits>
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -44,7 +43,7 @@ void SmoothStop::setParams(const Params & params)
   m_params = params;
 }
 
-std::experimental::optional<double> SmoothStop::calcTimeToStop(
+std::optional<double> SmoothStop::calcTimeToStop(
   const std::vector<std::pair<rclcpp::Time, double>> & vel_hist,
   const rclcpp::Time & current_time) const
 {

--- a/control/autoware_pid_longitudinal_controller/test/test_smooth_stop.cpp
+++ b/control/autoware_pid_longitudinal_controller/test/test_smooth_stop.cpp
@@ -17,7 +17,6 @@
 #include "rclcpp/rclcpp.hpp"
 
 #include <chrono>
-#include <thread>
 #include <utility>
 #include <vector>
 
@@ -45,8 +44,11 @@ TEST(TestSmoothStop, calculate_stopping_acceleration)
   SmoothStop ss;
   DebugValues debug_values;
 
+  // fake, fully-controlled clock: no real sleeping and no dependency on wall-clock time
+  Time now(0, 0, RCL_ROS_TIME);
+
   // Cannot calculate before setting parameters
-  EXPECT_THROW(ss.calculate(0.0, 0.0, 0.0, {}, delay_time, debug_values), std::runtime_error);
+  EXPECT_THROW(ss.calculate(0.0, 0.0, 0.0, {}, delay_time, now, debug_values), std::runtime_error);
 
   ss.setParams(
     max_strong_acc, min_strong_acc, weak_acc, weak_stop_acc, strong_stop_acc, max_fast_vel,
@@ -56,7 +58,6 @@ TEST(TestSmoothStop, calculate_stopping_acceleration)
   double stop_dist;
   double current_vel;
   double current_acc = 0.0;
-  const Time now = rclcpp::Clock{RCL_ROS_TIME}.now();
   const std::vector<std::pair<Time, double>> velocity_history = {
     {now - Duration(3, 0), 3.0}, {now - Duration(2, 0), 2.0}, {now - Duration(1, 0), 1.0}};
   double accel;
@@ -65,42 +66,42 @@ TEST(TestSmoothStop, calculate_stopping_acceleration)
   vel_in_target = 5.0;
   stop_dist = strong_stop_dist - 0.1;
   current_vel = 2.0;
-  ss.init(vel_in_target, stop_dist);
-  accel =
-    ss.calculate(stop_dist, current_vel, current_acc, velocity_history, delay_time, debug_values);
+  ss.init(vel_in_target, stop_dist, now);
+  accel = ss.calculate(
+    stop_dist, current_vel, current_acc, velocity_history, delay_time, now, debug_values);
   EXPECT_EQ(accel, strong_stop_acc);
   EXPECT_EQ(debug_values.getValue(DebugValues::TYPE::SMOOTH_STOP_MODE), 3);
 
   // weak stop when the stop distance is below the threshold (but not bellow the strong_stop_dist)
   stop_dist = weak_stop_dist - 0.1;
   current_vel = 2.0;
-  ss.init(vel_in_target, stop_dist);
-  accel =
-    ss.calculate(stop_dist, current_vel, current_acc, velocity_history, delay_time, debug_values);
+  ss.init(vel_in_target, stop_dist, now);
+  accel = ss.calculate(
+    stop_dist, current_vel, current_acc, velocity_history, delay_time, now, debug_values);
   EXPECT_EQ(accel, weak_stop_acc);
   EXPECT_EQ(debug_values.getValue(DebugValues::TYPE::SMOOTH_STOP_MODE), 2);
 
   // if not running, weak accel for 0.5 seconds after the previous init or previous weak_acc
   stop_dist = 0.0;
   current_vel = 0.0;
-  accel =
-    ss.calculate(stop_dist, current_vel, current_acc, velocity_history, delay_time, debug_values);
+  accel = ss.calculate(
+    stop_dist, current_vel, current_acc, velocity_history, delay_time, now, debug_values);
   EXPECT_EQ(accel, weak_acc);
   EXPECT_EQ(debug_values.getValue(DebugValues::TYPE::SMOOTH_STOP_MODE), 1);
-  std::this_thread::sleep_for(std::chrono::milliseconds(250));
-  accel =
-    ss.calculate(stop_dist, current_vel, current_acc, velocity_history, delay_time, debug_values);
+  now = now + std::chrono::milliseconds(250);
+  accel = ss.calculate(
+    stop_dist, current_vel, current_acc, velocity_history, delay_time, now, debug_values);
   EXPECT_EQ(accel, weak_acc);
   EXPECT_EQ(debug_values.getValue(DebugValues::TYPE::SMOOTH_STOP_MODE), 1);
-  std::this_thread::sleep_for(std::chrono::milliseconds(500));
-  accel =
-    ss.calculate(stop_dist, current_vel, current_acc, velocity_history, delay_time, debug_values);
+  now = now + std::chrono::milliseconds(500);
+  accel = ss.calculate(
+    stop_dist, current_vel, current_acc, velocity_history, delay_time, now, debug_values);
   EXPECT_NE(accel, weak_acc);
   EXPECT_NE(debug_values.getValue(DebugValues::TYPE::SMOOTH_STOP_MODE), 1);
 
   // strong stop when the car is not running (and is at least 0.5seconds after initialization)
-  accel =
-    ss.calculate(stop_dist, current_vel, current_acc, velocity_history, delay_time, debug_values);
+  accel = ss.calculate(
+    stop_dist, current_vel, current_acc, velocity_history, delay_time, now, debug_values);
   EXPECT_EQ(accel, strong_stop_acc);
   EXPECT_EQ(debug_values.getValue(DebugValues::TYPE::SMOOTH_STOP_MODE), 3);
 
@@ -109,23 +110,23 @@ TEST(TestSmoothStop, calculate_stopping_acceleration)
   stop_dist = 1.0;
   current_vel = 1.0;
   vel_in_target = 1.0;
-  ss.init(vel_in_target, stop_dist);
-  accel =
-    ss.calculate(stop_dist, current_vel, current_acc, velocity_history, delay_time, debug_values);
+  ss.init(vel_in_target, stop_dist, now);
+  accel = ss.calculate(
+    stop_dist, current_vel, current_acc, velocity_history, delay_time, now, debug_values);
   EXPECT_EQ(accel, max_strong_acc);
   EXPECT_EQ(debug_values.getValue(DebugValues::TYPE::SMOOTH_STOP_MODE), 0);
 
   vel_in_target = std::sqrt(2.0);
-  ss.init(vel_in_target, stop_dist);
-  accel =
-    ss.calculate(stop_dist, current_vel, current_acc, velocity_history, delay_time, debug_values);
+  ss.init(vel_in_target, stop_dist, now);
+  accel = ss.calculate(
+    stop_dist, current_vel, current_acc, velocity_history, delay_time, now, debug_values);
   EXPECT_EQ(accel, min_strong_acc);
   EXPECT_EQ(debug_values.getValue(DebugValues::TYPE::SMOOTH_STOP_MODE), 0);
 
   for (double vel_in_target = 1.1; vel_in_target < std::sqrt(2.0); vel_in_target += 0.1) {
-    ss.init(vel_in_target, stop_dist);
-    accel =
-      ss.calculate(stop_dist, current_vel, current_acc, velocity_history, delay_time, debug_values);
+    ss.init(vel_in_target, stop_dist, now);
+    accel = ss.calculate(
+      stop_dist, current_vel, current_acc, velocity_history, delay_time, now, debug_values);
     EXPECT_GT(accel, min_strong_acc);
     EXPECT_LT(accel, max_strong_acc);
   }

--- a/control/autoware_pid_longitudinal_controller/test/test_smooth_stop.cpp
+++ b/control/autoware_pid_longitudinal_controller/test/test_smooth_stop.cpp
@@ -41,18 +41,17 @@ TEST(TestSmoothStop, calculate_stopping_acceleration)
 
   const double delay_time = 0.17;
 
+  DebugValues debug_values;
+
   SmoothStop ss{SmoothStop::Params{
     max_strong_acc, min_strong_acc, weak_acc, weak_stop_acc, strong_stop_acc, max_fast_vel,
     min_running_vel, min_running_acc, weak_stop_time, weak_stop_dist, strong_stop_dist}};
-  DebugValues debug_values;
-
-  // fake, fully-controlled clock: no real sleeping and no dependency on wall-clock time
-  Time now(0, 0, RCL_ROS_TIME);
 
   double vel_in_target;
   double stop_dist;
   double current_vel;
   double current_acc = 0.0;
+  Time now(0, 0, RCL_ROS_TIME);
   const std::vector<std::pair<Time, double>> velocity_history = {
     {now - Duration(3, 0), 3.0}, {now - Duration(2, 0), 2.0}, {now - Duration(1, 0), 1.0}};
   double accel;

--- a/control/autoware_pid_longitudinal_controller/test/test_smooth_stop.cpp
+++ b/control/autoware_pid_longitudinal_controller/test/test_smooth_stop.cpp
@@ -41,18 +41,13 @@ TEST(TestSmoothStop, calculate_stopping_acceleration)
 
   const double delay_time = 0.17;
 
-  SmoothStop ss;
+  SmoothStop ss{SmoothStop::Params{
+    max_strong_acc, min_strong_acc, weak_acc, weak_stop_acc, strong_stop_acc, max_fast_vel,
+    min_running_vel, min_running_acc, weak_stop_time, weak_stop_dist, strong_stop_dist}};
   DebugValues debug_values;
 
   // fake, fully-controlled clock: no real sleeping and no dependency on wall-clock time
   Time now(0, 0, RCL_ROS_TIME);
-
-  // Cannot calculate before setting parameters
-  EXPECT_THROW(ss.calculate(0.0, 0.0, 0.0, {}, delay_time, now, debug_values), std::runtime_error);
-
-  ss.setParams(
-    max_strong_acc, min_strong_acc, weak_acc, weak_stop_acc, strong_stop_acc, max_fast_vel,
-    min_running_vel, min_running_acc, weak_stop_time, weak_stop_dist, strong_stop_dist);
 
   double vel_in_target;
   double stop_dist;


### PR DESCRIPTION
## Description

Removes `SmoothStop`'s hidden dependency on the ROS clock and its unconfigured-state invalid path, both of which hurt testability.

- `SmoothStop::init`, `calcTimeToStop`, and `calculate` previously called `rclcpp::Clock{RCL_ROS_TIME}.now()` internally, coupling this pure deceleration-profile logic to the ROS runtime and forcing tests to sleep on the real wall clock to exercise its time-based branches (e.g. the 0.5s post-stop hold). 
- `SmoothStop::Params` is now a public struct required by the constructor, so an unconfigured `SmoothStop` can no longer be constructed. This removes the `m_is_set_params` flag and the two `std::runtime_error` throws in `calculate()`/`calcTimeToStop()` that previously guarded against calling them before `setParams()`.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

```bash
colcon build --packages-select autoware_pid_longitudinal_controller
colcon test --packages-select autoware_pid_longitudinal_controller --event-handlers console_direct+
```

All existing tests, including `TestSmoothStop.calculate_stopping_acceleration`, pass. The 0.5s-window portion of that test now runs in 0ms instead of ~750ms of real sleep.


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
