### PR TITLE
feat(boundary_departure): visualize segments where departure occurs

### DIFF
--- a/common/autoware_boundary_departure_checker/src/detail/debug.cpp
+++ b/common/autoware_boundary_departure_checker/src/detail/debug.cpp
@@ -233,7 +233,7 @@ MarkerArray create_debug_markers(
   hysteresis_state.critical_departure_history.for_each_side([&](const auto & side_value) {
     autoware_utils_visualization::append_marker_array(
       create_departure_footprint_marker(
-        side_value, footprints, curr_time, base_link_z, ++virtual_wall_id),
+        side_value, footprints, curr_time, base_link_z, virtual_wall_id),
       &marker_array);
     autoware_utils_visualization::append_marker_array(
       create_virtual_wall_marker(side_value, curr_time, base_link_z, virtual_wall_id),

--- a/common/autoware_boundary_departure_checker/src/detail/debug.cpp
+++ b/common/autoware_boundary_departure_checker/src/detail/debug.cpp
@@ -236,7 +236,7 @@ MarkerArray create_debug_markers(
         side_value, footprints, curr_time, base_link_z, ++virtual_wall_id),
       &marker_array);
     autoware_utils_visualization::append_marker_array(
-      create_virtual_wall_marker(side_value, curr_time, base_link_z, ++virtual_wall_id),
+      create_virtual_wall_marker(side_value, curr_time, base_link_z, virtual_wall_id),
       &marker_array);
   });
 

--- a/common/autoware_boundary_departure_checker/src/detail/debug.cpp
+++ b/common/autoware_boundary_departure_checker/src/detail/debug.cpp
@@ -19,10 +19,12 @@
 #include "autoware/boundary_departure_checker/detail/type_alias.hpp"
 
 #include <autoware_utils_geometry/boost_geometry.hpp>
+#include <autoware_utils_geometry/geometry.hpp>
 #include <autoware_utils_visualization/marker_helper.hpp>
 
 #include <std_msgs/msg/detail/color_rgba__struct.hpp>
 
+#include <cmath>
 #include <string>
 
 namespace color
@@ -54,15 +56,19 @@ inline ColorRGBA magenta(float a = 0.99)
   return autoware_utils_visualization::create_marker_color(1., 0., 1., a);
 }
 
+inline ColorRGBA white(float a = 0.99)
+{
+  return autoware_utils_visualization::create_marker_color(1., 1., 1., a);
+}
+
 }  // namespace color
 
 namespace autoware::boundary_departure_checker::debug
 {
 MarkerArray create_departure_footprint_marker(
   const ProjectionsToBound & projections_to_bound, const footprints::Footprints & footprints,
-  const builtin_interfaces::msg::Time & curr_time, const double base_link_z)
+  const builtin_interfaces::msg::Time & curr_time, const double base_link_z, int32_t & id)
 {
-  int32_t id{0};
   const auto add_marker = [&](
                             const auto color, const ProjectionToBound & projection_to_bound,
                             const std::string & type) -> Marker {
@@ -164,6 +170,51 @@ Marker create_projected_segment_bound_marker(
   return marker;
 }
 
+MarkerArray create_virtual_wall_marker(
+  const ProjectionsToBound & projections_to_bound, const builtin_interfaces::msg::Time & curr_time,
+  const double base_link_z, int32_t & id)
+{
+  MarkerArray marker_array;
+
+  for (const auto & pt : projections_to_bound) {
+    if (!pt.is_critical()) {
+      continue;
+    }
+
+    const auto & p1 = pt.nearest_bound_seg.first;
+    const auto & p2 = pt.nearest_bound_seg.second;
+
+    const double dx = p2.x() - p1.x();
+    const double dy = p2.y() - p1.y();
+    const double length = std::hypot(dx, dy);
+    const double cx = (p1.x() + p2.x()) * 0.5;
+    const double cy = (p1.y() + p2.y()) * 0.5;
+    const double yaw = std::atan2(dy, dx);
+
+    auto wall_marker = autoware_utils_visualization::create_default_marker(
+      "map", curr_time, "uncrossable_departure_wall", ++id, visualization_msgs::msg::Marker::CUBE,
+      autoware_utils_visualization::create_marker_scale(length, 0.1, 2.0), color::red(0.5));
+    wall_marker.pose.position.x = cx;
+    wall_marker.pose.position.y = cy;
+    wall_marker.pose.position.z = base_link_z + 1.0;
+    wall_marker.pose.orientation = autoware_utils_geometry::create_quaternion_from_yaw(yaw);
+    marker_array.markers.push_back(wall_marker);
+
+    auto text_marker = autoware_utils_visualization::create_default_marker(
+      "map", curr_time, "uncrossable_departure_wall", ++id,
+      visualization_msgs::msg::Marker::TEXT_VIEW_FACING,
+      autoware_utils_visualization::create_marker_scale(0.0, 0.0, 0.5), color::white());
+    text_marker.pose.position.x = cx;
+    text_marker.pose.position.y = cy;
+    text_marker.pose.position.z = base_link_z + 2.5;
+    text_marker.pose.orientation = autoware_utils_geometry::create_quaternion_from_yaw(yaw);
+    text_marker.text = "uncrossable_departure";
+    marker_array.markers.push_back(text_marker);
+  }
+
+  return marker_array;
+}
+
 MarkerArray create_debug_markers(
   const HysteresisState & hysteresis_state, const footprints::Footprints & footprints,
   const EgoDynamicState & ego_state, const bool enable_developer_marker)
@@ -177,9 +228,15 @@ MarkerArray create_debug_markers(
   });
   const double base_link_z = ego_state.pose_with_cov.pose.position.z;
   MarkerArray marker_array;
+  int32_t virtual_wall_id{0};
+
   hysteresis_state.critical_departure_history.for_each_side([&](const auto & side_value) {
     autoware_utils_visualization::append_marker_array(
-      create_departure_footprint_marker(side_value, footprints, curr_time, base_link_z),
+      create_departure_footprint_marker(
+        side_value, footprints, curr_time, base_link_z, ++virtual_wall_id),
+      &marker_array);
+    autoware_utils_visualization::append_marker_array(
+      create_virtual_wall_marker(side_value, curr_time, base_link_z, ++virtual_wall_id),
       &marker_array);
   });
 


### PR DESCRIPTION
## Description

Cherry-pick for https://github.com/tier4/autoware_universe/pull/3094

- Adds `create_virtual_wall_marker` in debug.cpp to visualize the exact boundary segment being crossed when the ego vehicle is in a `CRITICAL` departure state
- The wall is rendered as a semi-transparent red CUBE aligned to the boundary segment (length = segment length, height = 2m), with a `TEXT_VIEW_FACING` label `uncrossable_departure` floating above it
- Both left and right critical departure sides are visualized; a shared `int32_t` id counter is passed by reference across side calls to guarantee unique (namespace, id) pairs in the
  `uncrossable_departure_wall` `namespace`
- The virtual wall markers are emitted unconditionally (not gated by enable_developer_marker), matching the same visibility tier as the existing departure footprint markers

### Example

<img width="1118" height="961" alt="image" src="https://github.com/user-attachments/assets/3971a0cb-9742-4355-b1c4-7042e71b40b9" />

<img width="1325" height="881" alt="image" src="https://github.com/user-attachments/assets/3cbb7f51-0393-42b1-a81b-0083e9780aa1" />


## Related links

**Parent Issue:**

[TIER IV Internal Issue Link](https://tier4.atlassian.net/browse/PDDP-315)

## How was this PR tested?

Compile, build success and able to visualize.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
