### PR TITLE
fix(trajectory_validator): replace is feasible input from trajectory points to candidate trajectory

### DIFF
--- a/planning/autoware_trajectory_selector/test/dummy_plugin/dummy_validator_plugin.cpp
+++ b/planning/autoware_trajectory_selector/test/dummy_plugin/dummy_validator_plugin.cpp
@@ -32,8 +32,9 @@ public:
   DummyFilter() : ValidatorInterface("DummyFilter") {}
 
   result_t is_feasible(
-    const TrajectoryPoints & traj_points, const FilterContext & /*context*/) final
+    const CandidateTrajectory & candidate_trajectory, const FilterContext & /*context*/) final
   {
+    const auto & traj_points = candidate_trajectory.points;
     if (traj_points.empty()) {
       return tl::make_unexpected("Empty trajectory");
     }

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/safety/uncrossable_boundary_departure.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/safety/uncrossable_boundary_departure.hpp
@@ -31,7 +31,8 @@ public:
   {
   }
 
-  result_t is_feasible(const TrajectoryPoints & traj_points, const FilterContext & context) final;
+  result_t is_feasible(
+    const CandidateTrajectory & candidate_trajectory, const FilterContext & context) final;
 
   void update_parameters(const validator::Params & params) final;
 

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/safety/vehicle_constraint_filter.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/safety/vehicle_constraint_filter.hpp
@@ -33,7 +33,8 @@ class VehicleConstraintFilter final : public plugin::ValidatorInterface
 public:
   VehicleConstraintFilter();
 
-  result_t is_feasible(const TrajectoryPoints & traj_points, const FilterContext & context) final;
+  result_t is_feasible(
+    const CandidateTrajectory & candidate_trajectory, const FilterContext & context) final;
 
   void update_parameters(const validator::Params & params) final;
 

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/traffic_rule/traffic_light_filter.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/traffic_rule/traffic_light_filter.hpp
@@ -34,7 +34,8 @@ class TrafficLightFilter : public ValidatorInterface
 public:
   TrafficLightFilter();
 
-  result_t is_feasible(const TrajectoryPoints & traj_points, const FilterContext & context) final;
+  result_t is_feasible(
+    const CandidateTrajectory & candidate_trajectory, const FilterContext & context) final;
 
   void update_parameters(const validator::Params & params) final;
 

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/validator_interface.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/validator_interface.hpp
@@ -22,6 +22,7 @@
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
 #include <tl_expected/expected.hpp>
 
+#include <autoware_internal_planning_msgs/msg/candidate_trajectory.hpp>
 #include <autoware_planning_msgs/msg/trajectory_point.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
@@ -35,6 +36,7 @@ namespace autoware::trajectory_validator::plugin
 using autoware_planning_msgs::msg::TrajectoryPoint;
 using TrajectoryPoints = std::vector<TrajectoryPoint>;
 using VehicleInfo = autoware::vehicle_info_utils::VehicleInfo;
+using autoware_internal_planning_msgs::msg::CandidateTrajectory;
 using autoware_trajectory_validator::msg::MetricReport;
 using autoware_trajectory_validator::msg::RiskLevel;
 
@@ -69,7 +71,7 @@ public:
    * @param context Current world state snapshot.
    */
   virtual result_t is_feasible(
-    const TrajectoryPoints & traj_points, const FilterContext & context) = 0;
+    const CandidateTrajectory & candidate_trajectory, const FilterContext & context) = 0;
 
   /**
    * @brief Updates the plugin's internal configuration from the latest parameter values.

--- a/planning/autoware_trajectory_validator/src/detail/trajectory_validator.cpp
+++ b/planning/autoware_trajectory_validator/src/detail/trajectory_validator.cpp
@@ -43,9 +43,10 @@ TrajectoryValidatorReport TrajectoryValidator::process(
     uuid_to_name[autoware_utils_uuid::to_hex_string(info.generator_id)] = info.generator_name.data;
   }
 
-  for (const auto & trajectory : input_trajectories.candidate_trajectories) {
+  for (const auto & candidate_trajectory : input_trajectories.candidate_trajectories) {
     EvaluationTable table;
-    const auto hex_generator_id = autoware_utils_uuid::to_hex_string(trajectory.generator_id);
+    const auto hex_generator_id =
+      autoware_utils_uuid::to_hex_string(candidate_trajectory.generator_id);
     table.generator_id = hex_generator_id;
 
     std::vector<autoware_trajectory_validator::msg::MetricReport> combined_metrics;
@@ -56,7 +57,7 @@ TrajectoryValidatorReport TrajectoryValidator::process(
       evaluation.is_shadow_mode = plugin->is_shadow_mode();
 
       stop_watch.tic(evaluation.plugin_name);
-      const auto res = plugin->is_feasible(trajectory.points, context);
+      const auto res = plugin->is_feasible(candidate_trajectory, context);
 
       if (!res) {
         evaluation.is_feasible = false;
@@ -78,7 +79,7 @@ TrajectoryValidatorReport TrajectoryValidator::process(
     report.evaluation_tables.push_back(table);
 
     if (table.all_acceptable()) {
-      report.valid_trajectories.candidate_trajectories.push_back(trajectory);
+      report.valid_trajectories.candidate_trajectories.push_back(candidate_trajectory);
     }
 
     const bool all_feasible = table.all_feasible();
@@ -89,9 +90,9 @@ TrajectoryValidatorReport TrajectoryValidator::process(
     RiskLevel risk_level;
     risk_level.level = all_feasible ? RiskLevel::SAFE : RiskLevel::DANGER;
     report.validation_reports.push_back(
-      autoware_trajectory_validator::build<ValidationReport>()
-        .trajectory_stamp(trajectory.header.stamp)
-        .generator_id(trajectory.generator_id)
+      autoware_trajectory_validator::build<autoware_trajectory_validator::msg::ValidationReport>()
+        .trajectory_stamp(candidate_trajectory.header.stamp)
+        .generator_id(candidate_trajectory.generator_id)
         .generator_name(uuid_to_name.at(hex_generator_id))
         .risk(risk_level)
         .metrics(std::move(combined_metrics)));

--- a/planning/autoware_trajectory_validator/src/filters/safety/uncrossable_boundary_departure.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/uncrossable_boundary_departure.cpp
@@ -22,8 +22,9 @@
 namespace autoware::trajectory_validator::plugin::safety
 {
 UncrossableBoundaryDepartureFilter::result_t UncrossableBoundaryDepartureFilter::is_feasible(
-  const TrajectoryPoints & traj_points, const FilterContext & context)
+  const CandidateTrajectory & candidate_trajectory, const FilterContext & context)
 {
+  const auto & traj_points = candidate_trajectory.points;
   if (const auto validate_context = validate_filter_context(context); !validate_context) {
     return tl::make_unexpected(validate_context.error());
   }

--- a/planning/autoware_trajectory_validator/src/filters/safety/vehicle_constraint_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/vehicle_constraint_filter.cpp
@@ -115,8 +115,9 @@ void VehicleConstraintFilter::update_parameters(const validator::Params & params
 }
 
 VehicleConstraintFilter::result_t VehicleConstraintFilter::is_feasible(
-  const TrajectoryPoints & traj_points, const FilterContext &)
+  const CandidateTrajectory & candidate_trajectory, const FilterContext &)
 {
+  const auto & traj_points = candidate_trajectory.points;
   if (!vehicle_info_ptr_) {
     return tl::make_unexpected("Vehicle info not set");
   }

--- a/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_filter.cpp
@@ -118,8 +118,9 @@ void TrafficLightFilter::set_vehicle_info(const VehicleInfo & vehicle_info)
 }
 
 TrafficLightFilter::result_t TrafficLightFilter::is_feasible(
-  const TrajectoryPoints & traj_points, const FilterContext & context)
+  const CandidateTrajectory & candidate_trajectory, const FilterContext & context)
 {
+  const auto & traj_points = candidate_trajectory.points;
   if (const auto has_invalid_input = is_invalid_input(context, vehicle_info_ptr_)) {
     return tl::make_unexpected(*has_invalid_input);
   }

--- a/planning/autoware_trajectory_validator/test/plugins/test_traffic_light_filter.cpp
+++ b/planning/autoware_trajectory_validator/test/plugins/test_traffic_light_filter.cpp
@@ -179,7 +179,9 @@ protected:
     const std::vector<TrajectoryPoint> & points, const bool expected_feasible,
     const std::string & message = "")
   {
-    const auto res = filter_->is_feasible(points, context_);
+    autoware_internal_planning_msgs::msg::CandidateTrajectory candidate_trajectory;
+    candidate_trajectory.points = points;
+    const auto res = filter_->is_feasible(candidate_trajectory, context_);
     ASSERT_TRUE(res.has_value()) << "is_feasible should not return an error";
     EXPECT_EQ(res->is_feasible, expected_feasible) << message;
   }
@@ -204,7 +206,9 @@ TEST_F(TrafficLightFilterTest, IsInfeasibleWithoutMapAndSignals)
   const auto points = create_trajectory(0.0, 1.0);
   context_.lanelet_map = nullptr;
   context_.traffic_light_signals = nullptr;
-  EXPECT_FALSE(filter_->is_feasible(points, context_))
+  autoware_internal_planning_msgs::msg::CandidateTrajectory candidate_trajectory;
+  candidate_trajectory.points = points;
+  EXPECT_FALSE(filter_->is_feasible(candidate_trajectory, context_))
     << "Should not be feasible without a map or traffic light signals";
 }
 TEST_F(TrafficLightFilterTest, IsInfeasibleWithoutMap)
@@ -213,7 +217,9 @@ TEST_F(TrafficLightFilterTest, IsInfeasibleWithoutMap)
   // dummy map and light signal
   context_.lanelet_map = nullptr;
   set_traffic_light_signal(0, TrafficLightElement::RED);
-  EXPECT_FALSE(filter_->is_feasible(points, context_))
+  autoware_internal_planning_msgs::msg::CandidateTrajectory candidate_trajectory;
+  candidate_trajectory.points = points;
+  EXPECT_FALSE(filter_->is_feasible(candidate_trajectory, context_))
     << "Should not be feasible without a map (cannot verify whether a trajectory crosses a traffic "
        "light)";
 }
@@ -222,7 +228,9 @@ TEST_F(TrafficLightFilterTest, IsInfeasibleWithoutSignals)
   auto points = create_trajectory(0.0, 1.0);
   create_and_set_map(0, 0);
   context_.traffic_light_signals = nullptr;
-  EXPECT_FALSE(filter_->is_feasible(points, context_))
+  autoware_internal_planning_msgs::msg::CandidateTrajectory candidate_trajectory;
+  candidate_trajectory.points = points;
+  EXPECT_FALSE(filter_->is_feasible(candidate_trajectory, context_))
     << "Should not be feasible without traffic light signals (cannot verify whether a trajectory "
        "crosses a traffic "
        "light)";
@@ -232,7 +240,9 @@ TEST_F(TrafficLightFilterTest, IsInfeasibleWithoutRoute)
   auto points = create_trajectory(0.0, 1.0);
   create_and_set_map(0, 0);
   context_.route = nullptr;
-  EXPECT_FALSE(filter_->is_feasible(points, context_).has_value())
+  autoware_internal_planning_msgs::msg::CandidateTrajectory candidate_trajectory;
+  candidate_trajectory.points = points;
+  EXPECT_FALSE(filter_->is_feasible(candidate_trajectory, context_).has_value())
     << "Should not be feasible without a route";
 }
 

--- a/planning/autoware_trajectory_validator/test/plugins/test_vehicle_constraint_filter.cpp
+++ b/planning/autoware_trajectory_validator/test/plugins/test_vehicle_constraint_filter.cpp
@@ -61,7 +61,9 @@ TEST(VehicleConstraintFilterTest, FeasibleWhenAllConstraintsSatisfied)
   filter.set_vehicle_info(vehicle_info);
 
   FilterContext context;  // Empty context for now
-  auto result = filter.is_feasible(traj_points, context);
+  CandidateTrajectory candidate_trajectory;
+  candidate_trajectory.points = traj_points;
+  auto result = filter.is_feasible(candidate_trajectory, context);
 
   ASSERT_TRUE(result.has_value());
   EXPECT_TRUE(result.value().is_feasible);
@@ -86,7 +88,9 @@ TEST(VehicleConstraintFilterTest, InfeasibleWhenSpeedExceedsMax)
   filter.set_vehicle_info(vehicle_info);
 
   FilterContext context;  // Empty context for now
-  auto result = filter.is_feasible(traj_points, context);
+  CandidateTrajectory candidate_trajectory;
+  candidate_trajectory.points = traj_points;
+  auto result = filter.is_feasible(candidate_trajectory, context);
 
   ASSERT_TRUE(result.has_value());
   EXPECT_FALSE(result.value().is_feasible);
@@ -111,7 +115,9 @@ TEST(VehicleConstraintFilterTest, InfeasibleWhenAccelerationExceedsMax)
   filter.set_vehicle_info(vehicle_info);
 
   FilterContext context;  // Empty context for now
-  auto result = filter.is_feasible(traj_points, context);
+  CandidateTrajectory candidate_trajectory;
+  candidate_trajectory.points = traj_points;
+  auto result = filter.is_feasible(candidate_trajectory, context);
 
   ASSERT_TRUE(result.has_value());
   EXPECT_FALSE(result.value().is_feasible);
@@ -137,7 +143,9 @@ TEST(VehicleConstraintFilterTest, InfeasibleWhenDecelerationExceedsMax)
   filter.set_vehicle_info(vehicle_info);
 
   FilterContext context;  // Empty context for now
-  auto result = filter.is_feasible(traj_points, context);
+  CandidateTrajectory candidate_trajectory;
+  candidate_trajectory.points = traj_points;
+  auto result = filter.is_feasible(candidate_trajectory, context);
 
   ASSERT_TRUE(result.has_value());
   EXPECT_FALSE(result.value().is_feasible);
@@ -166,7 +174,9 @@ TEST(VehicleConstraintFilterTest, InfeasibleWhenSteeringAngleExceedsMax)
   filter.set_vehicle_info(vehicle_info);
 
   FilterContext context;  // Empty context for now
-  auto result = filter.is_feasible(traj_points, context);
+  CandidateTrajectory candidate_trajectory;
+  candidate_trajectory.points = traj_points;
+  auto result = filter.is_feasible(candidate_trajectory, context);
 
   ASSERT_TRUE(result.has_value());
   EXPECT_FALSE(result.value().is_feasible);
@@ -197,7 +207,9 @@ TEST(VehicleConstraintFilterTest, InfeasibleWhenSteeringRateExceedsMax)
   filter.set_vehicle_info(vehicle_info);
 
   FilterContext context;  // Empty context for now
-  auto result = filter.is_feasible(traj_points, context);
+  CandidateTrajectory candidate_trajectory;
+  candidate_trajectory.points = traj_points;
+  auto result = filter.is_feasible(candidate_trajectory, context);
 
   ASSERT_TRUE(result.has_value());
   EXPECT_FALSE(result.value().is_feasible);


### PR DESCRIPTION
## Description

Replacing `is_feasible` input from `TrajectoryPoints` to `CandidateTrajectory`. The reasons are:
1. We will include `TurnSignal` information into CandidateTrajectory in the future.
2. To have generator name context.

## Related links

**Parent Issue:**

- [TIER IV internal link](https://tier4.atlassian.net/browse/PDDP-324)

## How was this PR tested?

Run autoware without any issues.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
