### PR TITLE
fix(boundary_departure): separate hysteresis state

### DIFF
--- a/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/uncrossable_boundary_checker.hpp
+++ b/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/uncrossable_boundary_checker.hpp
@@ -52,16 +52,18 @@ public:
    * @brief Update departure status along a predicted trajectory.
    * @param[in] predicted_traj predicted trajectory
    * @param[in] ego_state current ego dynamic state
+   * @param[in,out] state hysteresis state to evaluate against and update in place. The caller
+   *   owns this state, allowing independent hysteresis per trajectory/generator.
    * @return departure result
    */
   DepartureResult update_departure_status(
-    const TrajectoryPoints & predicted_traj, const EgoDynamicState & ego_state);
+    const TrajectoryPoints & predicted_traj, const EgoDynamicState & ego_state,
+    HysteresisState & state);
 
 private:
   UncrossableBoundaryDepartureParam param_;
   VehicleInfo vehicle_info_;
   std::unique_ptr<BoundaryDepartureEvaluator> evaluator_ptr_;
-  HysteresisState hysteresis_state_;
 
   mutable std::shared_ptr<autoware_utils_debug::TimeKeeper> time_keeper_ =
     std::make_shared<autoware_utils_debug::TimeKeeper>();

--- a/common/autoware_boundary_departure_checker/src/uncrossable_boundary_checker.cpp
+++ b/common/autoware_boundary_departure_checker/src/uncrossable_boundary_checker.cpp
@@ -38,7 +38,8 @@ void UncrossableBoundaryChecker::update_parameters(const UncrossableBoundaryDepa
 }
 
 DepartureResult UncrossableBoundaryChecker::update_departure_status(
-  const TrajectoryPoints & predicted_traj, const EgoDynamicState & ego_state)
+  const TrajectoryPoints & predicted_traj, const EgoDynamicState & ego_state,
+  HysteresisState & state)
 {
   autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
 
@@ -55,13 +56,13 @@ DepartureResult UncrossableBoundaryChecker::update_departure_status(
     evaluator_ptr_->evaluate(predicted_traj, footprints_sides, ego_state);
 
   const auto hysteresis_result =
-    update_and_judge(hysteresis_state_, evaluation_result, param_, ego_state.current_time_s);
+    update_and_judge(state, evaluation_result, param_, ego_state.current_time_s);
 
-  hysteresis_state_ = hysteresis_result.updated_state;
+  state = hysteresis_result.updated_state;
 
   result.status = hysteresis_result.status;
-  result.debug_markers = debug::create_debug_markers(
-    hysteresis_state_, footprints, ego_state, param_.enable_developer_marker);
+  result.debug_markers =
+    debug::create_debug_markers(state, footprints, ego_state, param_.enable_developer_marker);
   return result;
 }
 

--- a/common/autoware_boundary_departure_checker/test/test_uncrossable_boundary_checker.cpp
+++ b/common/autoware_boundary_departure_checker/test/test_uncrossable_boundary_checker.cpp
@@ -106,7 +106,8 @@ TEST(UncrossableBoundaryCheckerTest, TestCheckDepartureEmptyTrajectory)
 
   // Act:
   auto checker = create_default_checker();
-  auto result = checker.update_departure_status(empty_traj, ego_state);
+  HysteresisState state;
+  auto result = checker.update_departure_status(empty_traj, ego_state, state);
 
   // Assert:
   EXPECT_TRUE(result.status == DepartureType::NONE);
@@ -121,7 +122,8 @@ TEST(UncrossableBoundaryCheckerTest, TestCheckDepartureZeroVelocity)
 
   // Act:
   auto checker = create_default_checker();
-  auto result = checker.update_departure_status(traj, ego_state);
+  HysteresisState state;
+  auto result = checker.update_departure_status(traj, ego_state, state);
 
   // Assert:
   EXPECT_TRUE(result.status == DepartureType::NONE);
@@ -166,7 +168,8 @@ TEST(UncrossableBoundaryCheckerTest, TestTimeBufferingHysteresis)
 
   // Act:
   auto checker = create_default_checker();
-  auto res1 = checker.update_departure_status(traj_safe, state_safe);
+  HysteresisState state;
+  auto res1 = checker.update_departure_status(traj_safe, state_safe, state);
 
   // Assert:
   EXPECT_TRUE(res1.status == DepartureType::NONE) << "Should be NONE when far from boundary.";
@@ -179,15 +182,15 @@ TEST(UncrossableBoundaryCheckerTest, TestTimeBufferingHysteresis)
   auto state_danger = create_ego_state(traj_danger, test_velocity, 0.1);
 
   // Act:
-  auto res2 = checker.update_departure_status(traj_danger, state_danger);
+  auto res2 = checker.update_departure_status(traj_danger, state_danger, state);
 
   // Assert:
   EXPECT_TRUE(res2.status == DepartureType::NONE) << "Should be NONE due to ON time buffer.";
 
   // STEP 3: Wait for ON buffer to expire. Time increases by 0.2 seconds.
   // Act:
-  auto res3 =
-    checker.update_departure_status(traj_danger, create_ego_state(traj_danger, test_velocity, 0.2));
+  auto res3 = checker.update_departure_status(
+    traj_danger, create_ego_state(traj_danger, test_velocity, 0.2), state);
 
   // Assert:
   EXPECT_TRUE(res3.status == DepartureType::CRITICAL)
@@ -195,8 +198,8 @@ TEST(UncrossableBoundaryCheckerTest, TestTimeBufferingHysteresis)
 
   // STEP 4: Instantly teleport back to Safe Trajectory
   // Act:
-  auto res4 =
-    checker.update_departure_status(traj_safe, create_ego_state(traj_safe, test_velocity, 0.3));
+  auto res4 = checker.update_departure_status(
+    traj_safe, create_ego_state(traj_safe, test_velocity, 0.3), state);
 
   // Assert:
   EXPECT_TRUE(res4.status == DepartureType::CRITICAL)
@@ -204,11 +207,56 @@ TEST(UncrossableBoundaryCheckerTest, TestTimeBufferingHysteresis)
 
   // STEP 5: Wait for OFF buffer to expire (Safety is continuous)
   // Act:
-  auto res5 =
-    checker.update_departure_status(traj_safe, create_ego_state(traj_safe, test_velocity, 0.6));
+  auto res5 = checker.update_departure_status(
+    traj_safe, create_ego_state(traj_safe, test_velocity, 0.6), state);
 
   // Assert:
   EXPECT_TRUE(res5.status == DepartureType::NONE)
     << "Should return to NONE after OFF buffer expires.";
+}
+
+// clang-format off
+/**
+ * TestIndependentHysteresisStates:
+ *
+ * Verifies that two hysteresis states evaluated by the SAME checker do not contaminate each
+ * other. This mirrors the validator evaluating multiple candidate trajectories (one per
+ * generator) in a single frame: a CRITICAL verdict held in one state's OFF-buffer must not
+ * leak into another state evaluated for a safe trajectory at the same time.
+ */
+// clang-format on
+TEST(UncrossableBoundaryCheckerTest, TestIndependentHysteresisStates)
+{
+  // Arrange:
+  double safe_y = -2.5;
+  double danger_yaw = 0.2;
+  double test_velocity = 10.0;
+
+  auto traj_safe = create_trajectory(0.0, safe_y, test_velocity, 0.0);
+  auto traj_danger = create_trajectory(0.0, safe_y, test_velocity, danger_yaw);
+
+  auto checker = create_default_checker();
+
+  // Drive state_a to CRITICAL: safe baseline, then continuous danger until ON buffer expires.
+  HysteresisState state_a;
+  checker.update_departure_status(
+    traj_safe, create_ego_state(traj_safe, test_velocity, 0.0), state_a);
+  checker.update_departure_status(
+    traj_danger, create_ego_state(traj_danger, test_velocity, 0.1), state_a);
+  auto res_a = checker.update_departure_status(
+    traj_danger, create_ego_state(traj_danger, test_velocity, 0.2), state_a);
+
+  // Assert state_a is CRITICAL.
+  EXPECT_TRUE(res_a.status == DepartureType::CRITICAL)
+    << "state_a should be CRITICAL after the ON buffer expires.";
+
+  // Act: evaluate a SAFE trajectory against a fresh, independent state_b at the same time.
+  HysteresisState state_b;
+  auto res_b = checker.update_departure_status(
+    traj_safe, create_ego_state(traj_safe, test_velocity, 0.2), state_b);
+
+  // Assert: state_b is unaffected by state_a's critical history.
+  EXPECT_TRUE(res_b.status == DepartureType::NONE)
+    << "Independent state_b must stay NONE and not inherit state_a's CRITICAL holdover.";
 }
 }  // namespace autoware::boundary_departure_checker

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/detail/uuid_hash.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/detail/uuid_hash.hpp
@@ -1,0 +1,44 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__TRAJECTORY_VALIDATOR__DETAIL__UUID_HASH_HPP_
+#define AUTOWARE__TRAJECTORY_VALIDATOR__DETAIL__UUID_HASH_HPP_
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+namespace autoware::trajectory_validator
+{
+/**
+ * @brief Hashes a raw 16-byte UUID (FNV-1a) without allocating an intermediate string.
+ *
+ * Use as the hash policy for an std::unordered_map keyed on a UUID's raw bytes
+ * (e.g. unique_identifier_msgs::msg::UUID::uuid), avoiding a per-lookup hex-string conversion.
+ */
+struct UuidHash
+{
+  std::size_t operator()(const std::array<uint8_t, 16> & uuid) const noexcept
+  {
+    std::size_t hash = 14695981039346656037ULL;  // FNV-1a offset basis
+    for (const auto byte : uuid) {
+      hash ^= static_cast<std::size_t>(byte);
+      hash *= 1099511628211ULL;  // FNV-1a prime
+    }
+    return hash;
+  }
+};
+}  // namespace autoware::trajectory_validator
+
+#endif  // AUTOWARE__TRAJECTORY_VALIDATOR__DETAIL__UUID_HASH_HPP_

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/safety/uncrossable_boundary_departure.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/safety/uncrossable_boundary_departure.hpp
@@ -15,13 +15,17 @@
 #ifndef AUTOWARE__TRAJECTORY_VALIDATOR__FILTERS__SAFETY__UNCROSSABLE_BOUNDARY_DEPARTURE_HPP_
 #define AUTOWARE__TRAJECTORY_VALIDATOR__FILTERS__SAFETY__UNCROSSABLE_BOUNDARY_DEPARTURE_HPP_
 
+#include "autoware/trajectory_validator/detail/uuid_hash.hpp"
 #include "autoware/trajectory_validator/validator_interface.hpp"
 
 #include <autoware/boundary_departure_checker/uncrossable_boundary_checker.hpp>
 #include <rclcpp/rclcpp.hpp>
 
+#include <array>
+#include <cstdint>
 #include <memory>
 #include <string>
+#include <unordered_map>
 namespace autoware::trajectory_validator::plugin::safety
 {
 class UncrossableBoundaryDepartureFilter : public plugin::ValidatorInterface
@@ -39,6 +43,12 @@ public:
 private:
   std::unique_ptr<boundary_departure_checker::UncrossableBoundaryChecker> checker_;
   boundary_departure_checker::UncrossableBoundaryDepartureParam params_;
+
+  // Per-generator hysteresis state, keyed by the generator UUID's raw 16 bytes. Each generator's
+  // trajectory keeps its own hysteresis so one trajectory cannot remove another via the
+  // shared ON/OFF time buffers.
+  std::unordered_map<std::array<uint8_t, 16>, boundary_departure_checker::HysteresisState, UuidHash>
+    hysteresis_states_;
 
   tl::expected<void, std::string> validate_filter_context(const FilterContext & context) const;
 };

--- a/planning/autoware_trajectory_validator/src/filters/safety/uncrossable_boundary_departure.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/uncrossable_boundary_departure.cpp
@@ -40,7 +40,11 @@ UncrossableBoundaryDepartureFilter::result_t UncrossableBoundaryDepartureFilter:
   ego_state.acceleration = context.acceleration->accel.accel.linear.x;
   ego_state.current_time_s = rclcpp::Time(context.odometry->header.stamp).seconds();
 
-  auto status = checker_->update_departure_status(traj_points, ego_state);
+  // Evaluate each generator's trajectory against its own hysteresis state so that a critical
+  // verdict for one trajectory does not bleed into another through the shared ON/OFF buffers.
+  auto & hysteresis_state = hysteresis_states_[candidate_trajectory.generator_id.uuid];
+
+  auto status = checker_->update_departure_status(traj_points, ego_state, hysteresis_state);
 
   const bool is_feasible = status.status != boundary_departure_checker::DepartureType::CRITICAL;
 


### PR DESCRIPTION
## Description

Cherry-pick of https://github.com/tier4/autoware_universe/pull/3116

`UncrossableBoundaryChecker` held a **single** internal `hysteresis_state_` member and reused it across every trajectory it evaluated. The `UncrossableBoundaryDepartureFilter` runs the checker over **multiple candidate trajectories per frame** (one per generator), so they all shared one ON/OFF time-buffer. As a result, a `CRITICAL` verdict held in the buffer for one generator's trajectory bled into the verdict of a different, *safe* trajectory evaluated in the same frame — one trajectory could effectively suppress or alter another through state it shouldn't touch.

This PR makes the hysteresis state **caller-owned** so each generator gets its own independent buffer:

- `UncrossableBoundaryChecker::update_departure_status()` now takes a `HysteresisState & state` in/out parameter instead of mutating a private member; the `hysteresis_state_` member is removed.
- `UncrossableBoundaryDepartureFilter` keeps a per-generator map of hysteresis states, keyed on the generator UUID's raw 16 bytes (`std::array<uint8_t, 16>` + a small FNV-1a hash), and looks up / default-creates the entry for `candidate_trajectory.generator_id` on each call. Keying on the raw bytes avoids a per-call `std::string` hex conversion (heap allocation + formatting) on the hot path.

https://github.com/user-attachments/assets/b1464bee-ed56-48f8-923b-47a994bb3b86

⚠️  Requires https://github.com/autowarefoundation/autoware_universe/pull/12985

## Related links

**Parent Issue:**

- [TIER IV Internal ticket 1](https://tier4.atlassian.net/browse/PDDP-129)

## How was this PR tested?

- Added `TestIndependentHysteresisStates` to `test_uncrossable_boundary_checker.cpp`: drives one state to `CRITICAL`, then evaluates a safe trajectory against a fresh, independent state at the same timestamp and asserts it stays `NONE` (no cross-contamination).
- Updated existing checker tests for the new signature.
- `colcon test --packages-select autoware_trajectory_validator` — all 10 tests pass (6 gtest + linters).

## Notes for reviewers

The UUID-keyed map currently grows unbounded — one entry per generator ID seen, never evicted. Not a concern for the current fixed set of generators, but worth flagging if generator IDs churn over long runs.

**On the FNV-1a hash choice:** `std::unordered_map` needs a hash functor for its key, and the standard library provides none for `std::array<uint8_t, 16>`, so a custom one is required. FNV-1a (Fowler–Noll–Vo, XOR-then-multiply variant) was chosen as the smallest, dependency-free option that satisfies this — ~6 lines, no external library, and it avoids the `reinterpret_cast` that a `string_view`-based hash would need (clang-tidy flags it here). It is deliberately *not* picked for being the fastest or best-distributed hash: faster options exist (e.g. reading the 16 bytes as two 64-bit words, or xxHash/wyhash), but the map holds only one entry per trajectory generator — a handful — so hash speed and distribution are irrelevant and collisions are effectively impossible at that size. The trade chosen is simplicity + zero dependencies + no UB for a container where hash performance does not matter.


## Interface changes

`autoware::boundary_departure_checker::UncrossableBoundaryChecker::update_departure_status()` signature changed — it now takes an additional `HysteresisState & state` in/out argument, and the class no longer owns the hysteresis state internally. Callers must supply and persist their own `HysteresisState`.

## Effects on system behavior

Per-trajectory boundary-departure verdicts are no longer contaminated by other trajectories' hysteresis history within the same frame, so trajectory filtering reflects each candidate's own departure timeline. No parameter or topic changes.
