### PR TITLE
test(pid_longitudinal_controller): split smooth stop tests

### DIFF
--- a/control/autoware_pid_longitudinal_controller/test/test_smooth_stop.cpp
+++ b/control/autoware_pid_longitudinal_controller/test/test_smooth_stop.cpp
@@ -17,106 +17,226 @@
 #include "rclcpp/rclcpp.hpp"
 
 #include <chrono>
+#include <cmath>
 
-TEST(TestSmoothStop, calculate_stopping_acceleration)
+namespace
 {
-  using ::autoware::motion::control::pid_longitudinal_controller::SmoothStop;
-  using rclcpp::Time;
+using ::autoware::motion::control::pid_longitudinal_controller::SmoothStop;
+using rclcpp::Time;
 
-  const double max_strong_acc = -0.5;
-  const double min_strong_acc = -1.0;
-  const double weak_acc = -0.3;
-  const double weak_stop_acc = -0.8;
-  const double strong_stop_acc = -3.4;
-  const double max_fast_vel = 0.5;
-  const double min_running_vel = 0.01;
-  const double min_running_acc = 0.01;
-  const double weak_stop_time = 0.8;
-  const double weak_stop_dist = -0.3;
-  const double strong_stop_dist = -0.5;
+constexpr double max_strong_acc = -0.5;
+constexpr double min_strong_acc = -1.0;
+constexpr double weak_acc = -0.3;
+constexpr double weak_stop_acc = -0.8;
+constexpr double strong_stop_acc = -3.4;
+constexpr double min_fast_vel = 0.5;
+constexpr double min_running_vel = 0.01;
+constexpr double min_running_acc = 0.01;
+constexpr double weak_stop_time = 0.8;
+constexpr double weak_stop_dist = -0.3;
+constexpr double strong_stop_dist = -0.5;
+constexpr double delay_time = 0.17;
 
-  const double delay_time = 0.17;
+SmoothStop::Params makeDefaultParams()
+{
+  return SmoothStop::Params{max_strong_acc,  min_strong_acc, weak_acc,        weak_stop_acc,
+                            strong_stop_acc, min_fast_vel,   min_running_vel, min_running_acc,
+                            weak_stop_time,  weak_stop_dist, strong_stop_dist};
+}
 
-  SmoothStop ss{SmoothStop::Params{
-    max_strong_acc, min_strong_acc, weak_acc, weak_stop_acc, strong_stop_acc, max_fast_vel,
-    min_running_vel, min_running_acc, weak_stop_time, weak_stop_dist, strong_stop_dist}};
+// calculate() reads the current velocity, acceleration and time from the latest sample
+// recorded via recordMotion(), so every test below must call it at least once beforehand.
+// A zero time window keeps only that latest sample.
+constexpr double vel_hist_time_window = 0.0;
+}  // namespace
 
-  double vel_in_target;
-  double stop_dist;
-  double current_vel;
-  double current_acc = 0.0;
-  Time now(0, 0, RCL_ROS_TIME);
-  // calculate() reads the current velocity, acceleration and time from the latest recorded
-  // motion sample, so record one before every call below. A zero time window keeps only that
-  // latest sample, which is enough to exercise every branch under test.
-  const double vel_hist_time_window = 0.0;
-  SmoothStop::Result result;
+TEST(SmoothStopTest, ReturnsStrongStopAccelerationWhenStopDistanceBelowStrongStopThreshold)
+{
+  // Arrange
+  SmoothStop smooth_stop{makeDefaultParams()};
+  const Time now(0, 0, RCL_ROS_TIME);
+  const double stop_dist = strong_stop_dist - 0.1;
+  smooth_stop.init(/*pred_vel_in_target=*/5.0, stop_dist, now);
+  smooth_stop.recordMotion(now, /*vel=*/2.0, /*acc=*/0.0, vel_hist_time_window);
 
-  // strong stop when the stop distance is below the threshold
-  vel_in_target = 5.0;
-  stop_dist = strong_stop_dist - 0.1;
-  current_vel = 2.0;
-  ss.init(vel_in_target, stop_dist, now);
-  ss.recordMotion(now, current_vel, current_acc, vel_hist_time_window);
-  result = ss.calculate(stop_dist, delay_time);
-  EXPECT_EQ(result.acc, strong_stop_acc);
+  // Act
+  const SmoothStop::Result result = smooth_stop.calculate(stop_dist, delay_time);
+
+  // Assert
+  EXPECT_DOUBLE_EQ(result.acc, strong_stop_acc);
   EXPECT_EQ(result.mode, SmoothStop::Mode::STRONG_STOP);
+}
 
-  // weak stop when the stop distance is below the threshold (but not bellow the strong_stop_dist)
-  stop_dist = weak_stop_dist - 0.1;
-  current_vel = 2.0;
-  ss.init(vel_in_target, stop_dist, now);
-  ss.recordMotion(now, current_vel, current_acc, vel_hist_time_window);
-  result = ss.calculate(stop_dist, delay_time);
-  EXPECT_EQ(result.acc, weak_stop_acc);
+TEST(SmoothStopTest, ReturnsWeakStopAccelerationWhenStopDistanceBelowWeakStopThreshold)
+{
+  // Arrange
+  SmoothStop smooth_stop{makeDefaultParams()};
+  const Time now(0, 0, RCL_ROS_TIME);
+  const double stop_dist = weak_stop_dist - 0.1;  // still above strong_stop_dist
+  smooth_stop.init(/*pred_vel_in_target=*/5.0, stop_dist, now);
+  smooth_stop.recordMotion(now, /*vel=*/2.0, /*acc=*/0.0, vel_hist_time_window);
+
+  // Act
+  const SmoothStop::Result result = smooth_stop.calculate(stop_dist, delay_time);
+
+  // Assert
+  EXPECT_DOUBLE_EQ(result.acc, weak_stop_acc);
   EXPECT_EQ(result.mode, SmoothStop::Mode::WEAK_STOP);
+}
 
-  // if not running, weak accel for 0.5 seconds after the previous init or previous weak_acc
-  stop_dist = 0.0;
-  current_vel = 0.0;
-  ss.recordMotion(now, current_vel, current_acc, vel_hist_time_window);
-  result = ss.calculate(stop_dist, delay_time);
-  EXPECT_EQ(result.acc, weak_acc);
-  EXPECT_EQ(result.mode, SmoothStop::Mode::WEAK);
-  now = now + std::chrono::milliseconds(250);
-  ss.recordMotion(now, current_vel, current_acc, vel_hist_time_window);
-  result = ss.calculate(stop_dist, delay_time);
-  EXPECT_EQ(result.acc, weak_acc);
-  EXPECT_EQ(result.mode, SmoothStop::Mode::WEAK);
-  now = now + std::chrono::milliseconds(500);
-  ss.recordMotion(now, current_vel, current_acc, vel_hist_time_window);
-  result = ss.calculate(stop_dist, delay_time);
-  EXPECT_NE(result.acc, weak_acc);
-  EXPECT_NE(result.mode, SmoothStop::Mode::WEAK);
+TEST(SmoothStopTest, ReturnsWeakAccelerationWhenStoppedRightAfterInit)
+{
+  // Arrange
+  SmoothStop smooth_stop{makeDefaultParams()};
+  const Time now(0, 0, RCL_ROS_TIME);
+  const double stop_dist = 0.0;
+  smooth_stop.init(/*pred_vel_in_target=*/5.0, stop_dist, now);
+  smooth_stop.recordMotion(now, /*vel=*/0.0, /*acc=*/0.0, vel_hist_time_window);
 
-  // strong stop when the car is not running (and is at least 0.5seconds after initialization)
-  result = ss.calculate(stop_dist, delay_time);
-  EXPECT_EQ(result.acc, strong_stop_acc);
+  // Act
+  const SmoothStop::Result result = smooth_stop.calculate(stop_dist, delay_time);
+
+  // Assert
+  EXPECT_DOUBLE_EQ(result.acc, weak_acc);
+  EXPECT_EQ(result.mode, SmoothStop::Mode::WEAK);
+}
+
+TEST(SmoothStopTest, ReturnsWeakAccelerationWhileStoppedWithinHalfSecondOfInit)
+{
+  // Arrange
+  SmoothStop smooth_stop{makeDefaultParams()};
+  const Time init_time(0, 0, RCL_ROS_TIME);
+  const double stop_dist = 0.0;
+  smooth_stop.init(/*pred_vel_in_target=*/5.0, stop_dist, init_time);
+  const Time now = init_time + std::chrono::milliseconds(250);
+  smooth_stop.recordMotion(now, /*vel=*/0.0, /*acc=*/0.0, vel_hist_time_window);
+
+  // Act
+  const SmoothStop::Result result = smooth_stop.calculate(stop_dist, delay_time);
+
+  // Assert
+  EXPECT_DOUBLE_EQ(result.acc, weak_acc);
+  EXPECT_EQ(result.mode, SmoothStop::Mode::WEAK);
+}
+
+TEST(SmoothStopTest, ReturnsStrongStopAccelerationWhenStoppedForMoreThanHalfSecondSinceInit)
+{
+  // Arrange
+  SmoothStop smooth_stop{makeDefaultParams()};
+  const Time init_time(0, 0, RCL_ROS_TIME);
+  const double stop_dist = 0.0;
+  smooth_stop.init(/*pred_vel_in_target=*/5.0, stop_dist, init_time);
+  const Time now = init_time + std::chrono::milliseconds(750);  // exceeds the 0.5s weak window
+  smooth_stop.recordMotion(now, /*vel=*/0.0, /*acc=*/0.0, vel_hist_time_window);
+
+  // Act
+  const SmoothStop::Result result = smooth_stop.calculate(stop_dist, delay_time);
+
+  // Assert
+  EXPECT_DOUBLE_EQ(result.acc, strong_stop_acc);
   EXPECT_EQ(result.mode, SmoothStop::Mode::STRONG_STOP);
+}
 
-  // accel between min/max_strong_acc when the car is running:
-  // not predicted to exceed the stop line and is predicted to stop after weak_stop_time + delay
-  stop_dist = 1.0;
-  current_vel = 1.0;
-  vel_in_target = 1.0;
-  ss.init(vel_in_target, stop_dist, now);
-  ss.recordMotion(now, current_vel, current_acc, vel_hist_time_window);
-  result = ss.calculate(stop_dist, delay_time);
-  EXPECT_EQ(result.acc, max_strong_acc);
+TEST(SmoothStopTest, ReturnsMaxStrongAccelerationWhenPredictedStopMatchesUpperLimit)
+{
+  // Arrange: pred_vel_in_target^2 / (2 * stop_dist) == |max_strong_acc|
+  SmoothStop smooth_stop{makeDefaultParams()};
+  const Time now(0, 0, RCL_ROS_TIME);
+  const double stop_dist = 1.0;
+  const double vel_in_target = 1.0;
+  smooth_stop.init(vel_in_target, stop_dist, now);
+  smooth_stop.recordMotion(now, /*vel=*/1.0, /*acc=*/0.0, vel_hist_time_window);
+
+  // Act
+  const SmoothStop::Result result = smooth_stop.calculate(stop_dist, delay_time);
+
+  // Assert
+  EXPECT_DOUBLE_EQ(result.acc, max_strong_acc);
   EXPECT_EQ(result.mode, SmoothStop::Mode::STRONG);
+}
 
-  vel_in_target = std::sqrt(2.0);
-  ss.init(vel_in_target, stop_dist, now);
-  ss.recordMotion(now, current_vel, current_acc, vel_hist_time_window);
-  result = ss.calculate(stop_dist, delay_time);
-  EXPECT_EQ(result.acc, min_strong_acc);
+TEST(SmoothStopTest, ReturnsMinStrongAccelerationWhenPredictedStopExceedsLowerLimit)
+{
+  // Arrange: pred_vel_in_target^2 / (2 * stop_dist) == |min_strong_acc|
+  SmoothStop smooth_stop{makeDefaultParams()};
+  const Time now(0, 0, RCL_ROS_TIME);
+  const double stop_dist = 1.0;
+  const double vel_in_target = std::sqrt(2.0);
+  smooth_stop.init(vel_in_target, stop_dist, now);
+  smooth_stop.recordMotion(now, /*vel=*/1.0, /*acc=*/0.0, vel_hist_time_window);
+
+  // Act
+  const SmoothStop::Result result = smooth_stop.calculate(stop_dist, delay_time);
+
+  // Assert
+  EXPECT_DOUBLE_EQ(result.acc, min_strong_acc);
   EXPECT_EQ(result.mode, SmoothStop::Mode::STRONG);
+}
 
-  for (double vel_in_target = 1.1; vel_in_target < std::sqrt(2.0); vel_in_target += 0.1) {
-    ss.init(vel_in_target, stop_dist, now);
-    ss.recordMotion(now, current_vel, current_acc, vel_hist_time_window);
-    result = ss.calculate(stop_dist, delay_time);
-    EXPECT_GT(result.acc, min_strong_acc);
-    EXPECT_LT(result.acc, max_strong_acc);
-  }
+TEST(
+  SmoothStopTest, ReturnsStrongAccelerationInterpolatedBetweenLimitsForIntermediateTargetVelocity)
+{
+  // Arrange: pick a target velocity strictly between the two limit cases above, so the
+  // resulting acceleration should fall strictly between min_strong_acc and max_strong_acc
+  // without being clamped to either.
+  SmoothStop smooth_stop{makeDefaultParams()};
+  const Time now(0, 0, RCL_ROS_TIME);
+  const double stop_dist = 1.0;
+  const double vel_in_target = 1.2;
+  smooth_stop.init(vel_in_target, stop_dist, now);
+  smooth_stop.recordMotion(now, /*vel=*/1.0, /*acc=*/0.0, vel_hist_time_window);
+
+  // Act
+  const SmoothStop::Result result = smooth_stop.calculate(stop_dist, delay_time);
+
+  // Assert
+  EXPECT_GT(result.acc, min_strong_acc);
+  EXPECT_LT(result.acc, max_strong_acc);
+  EXPECT_EQ(result.mode, SmoothStop::Mode::STRONG);
+}
+
+TEST(SmoothStopTest, ReturnsStrongAccelerationWhenRunningAndPredictedTimeToStopExceedsWeakStopTime)
+{
+  // Arrange: two motion samples 1.0s apart, decelerating from 2.0 to 1.0 m/s, fit a line
+  // predicting the car reaches 0 m/s in 1.0s, which exceeds weak_stop_time + delay_time
+  // (0.8 + 0.17 = 0.97s).
+  SmoothStop smooth_stop{makeDefaultParams()};
+  const Time init_time(0, 0, RCL_ROS_TIME);
+  const double stop_dist = 1.0;
+  const double vel_in_target =
+    1.0;  // matches the max_strong_acc case, m_strong_acc == max_strong_acc
+  smooth_stop.init(vel_in_target, stop_dist, init_time);
+  const double time_window = 1.1;  // wide enough to keep both samples 1.0s apart
+  smooth_stop.recordMotion(init_time, /*vel=*/2.0, /*acc=*/0.0, time_window);
+  const Time now = init_time + std::chrono::seconds(1);
+  smooth_stop.recordMotion(now, /*vel=*/1.0, /*acc=*/0.0, time_window);
+
+  // Act
+  const SmoothStop::Result result = smooth_stop.calculate(stop_dist, delay_time);
+
+  // Assert
+  EXPECT_DOUBLE_EQ(result.acc, max_strong_acc);
+  EXPECT_EQ(result.mode, SmoothStop::Mode::STRONG);
+}
+
+TEST(SmoothStopTest, ReturnsWeakAccelerationWhenRunningAndPredictedTimeToStopWithinWeakStopTime)
+{
+  // Arrange: two motion samples 0.5s apart, decelerating from 2.0 to 1.0 m/s, fit a line
+  // predicting the car reaches 0 m/s in 0.5s, which is within weak_stop_time + delay_time
+  // (0.8 + 0.17 = 0.97s), so braking can ease off even though the car is still running.
+  SmoothStop smooth_stop{makeDefaultParams()};
+  const Time init_time(0, 0, RCL_ROS_TIME);
+  const double stop_dist = 1.0;
+  smooth_stop.init(/*pred_vel_in_target=*/1.0, stop_dist, init_time);
+  const double time_window = 0.6;  // wide enough to keep both samples 0.5s apart
+  smooth_stop.recordMotion(init_time, /*vel=*/2.0, /*acc=*/0.0, time_window);
+  const Time now = init_time + std::chrono::milliseconds(500);
+  smooth_stop.recordMotion(now, /*vel=*/1.0, /*acc=*/0.0, time_window);
+
+  // Act
+  const SmoothStop::Result result = smooth_stop.calculate(stop_dist, delay_time);
+
+  // Assert
+  EXPECT_DOUBLE_EQ(result.acc, weak_acc);
+  EXPECT_EQ(result.mode, SmoothStop::Mode::WEAK);
 }

--- a/control/autoware_pid_longitudinal_controller/test/test_smooth_stop.cpp
+++ b/control/autoware_pid_longitudinal_controller/test/test_smooth_stop.cpp
@@ -14,7 +14,7 @@
 
 #include "autoware/pid_longitudinal_controller/smooth_stop.hpp"
 #include "gtest/gtest.h"
-#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/time.hpp"
 
 #include <chrono>
 #include <cmath>


### PR DESCRIPTION
## Description

Split the single monolithic `TestSmoothStop.calculate_stopping_acceleration` test into independent, per-scenario `TEST` cases for `SmoothStop::calculate()`

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

```bash
PACKAGE_NAME=autoware_pid_longitudinal_controller && colcon build --packages-select $PACKAGE_NAME && colcon test --packages-select $PACKAGE_NAME --event-handlers console_cohesion+
```

All `test_longitudinal_controller` gtest cases pass, including the new `SmoothStopTest` scenarios.


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
