### PR TITLE
fix(autoware_multi_object_tracker): lock wheelbase length in partial wheel update to stabilize stationary vehicles

### DIFF
--- a/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
@@ -645,9 +645,6 @@ bool BicycleMotionModel::getPredictedState(
   const double wheel_base_inv_sq = wheel_base_inv * wheel_base_inv;
   const double sin_yaw = (X(IDX::Y2) - X(IDX::Y1)) * wheel_base_inv;
   const double cos_yaw = (X(IDX::X2) - X(IDX::X1)) * wheel_base_inv;
-  const double sin_yaw_sq = sin_yaw * sin_yaw;
-  const double cos_yaw_sq = cos_yaw * cos_yaw;
-  const double sin_cos_yaw = sin_yaw * cos_yaw;
 
   // set position
   pose.position.x = (X(IDX::X1) * motion_params_.lf_ratio + X(IDX::X2) * motion_params_.lr_ratio) *
@@ -674,19 +671,31 @@ bool BicycleMotionModel::getPredictedState(
 
   constexpr double default_cov = 0.1 * 0.1;
   // set pose covariance
-  pose_cov[XYZRPY_COV_IDX::X_X] = P(IDX::X1, IDX::X1);
-  pose_cov[XYZRPY_COV_IDX::X_Y] = P(IDX::X1, IDX::Y1);
-  pose_cov[XYZRPY_COV_IDX::Y_X] = P(IDX::Y1, IDX::X1);
-  pose_cov[XYZRPY_COV_IDX::Y_Y] = P(IDX::Y1, IDX::Y1);
-  // Jacobian: d(yaw)/d[X1,Y1,X2,Y2] = (1/L)*[sin_yaw, -cos_yaw, -sin_yaw, cos_yaw]
-  // YAW_YAW = J * P_sub * J^T (full 4x4 block, P symmetric so off-diag terms double)
-  pose_cov[XYZRPY_COV_IDX::YAW_YAW] =
-    wheel_base_inv_sq *
-    (sin_yaw_sq * P(IDX::X1, IDX::X1) - 2.0 * sin_cos_yaw * P(IDX::X1, IDX::Y1) -
-     2.0 * sin_yaw_sq * P(IDX::X1, IDX::X2) + 2.0 * sin_cos_yaw * P(IDX::X1, IDX::Y2) +
-     cos_yaw_sq * P(IDX::Y1, IDX::Y1) + 2.0 * sin_cos_yaw * P(IDX::Y1, IDX::X2) -
-     2.0 * cos_yaw_sq * P(IDX::Y1, IDX::Y2) + sin_yaw_sq * P(IDX::X2, IDX::X2) -
-     2.0 * sin_cos_yaw * P(IDX::X2, IDX::Y2) + cos_yaw_sq * P(IDX::Y2, IDX::Y2));
+  // The exported pose (center position + yaw) is a smooth function of the four axle coordinates
+  // [X1, Y1, X2, Y2]. Propagate their covariance block through a single Jacobian G so the whole
+  // (x, y, yaw) block is mutually consistent, correctly correlated, and PSD by construction:
+  //   center = w_rear * p1 + w_front * p2   (w_rear + w_front = 1)
+  //   yaw    = atan2(Y2 - Y1, X2 - X1),  d(yaw)/d[X1,Y1,X2,Y2] = (1/L)*[sin, -cos, -sin, cos]
+  // M = G * P_sub * G^T reproduces the exact linearized YAW_YAW and adds the position<->yaw
+  // cross-covariance that a single-axle-point copy dropped.
+  const double w_rear = motion_params_.lf_ratio * motion_params_.wheel_base_ratio_inv;
+  const double w_front = motion_params_.lr_ratio * motion_params_.wheel_base_ratio_inv;
+  Eigen::Matrix<double, 3, 4> G;
+  G << w_rear, 0.0, w_front, 0.0,  // center_x
+    0.0, w_rear, 0.0, w_front,     // center_y
+    sin_yaw * wheel_base_inv, -cos_yaw * wheel_base_inv, -sin_yaw * wheel_base_inv,
+    cos_yaw * wheel_base_inv;  // yaw
+  const Eigen::Matrix3d M = G * P.topLeftCorner<4, 4>() * G.transpose();
+
+  pose_cov[XYZRPY_COV_IDX::X_X] = M(0, 0);
+  pose_cov[XYZRPY_COV_IDX::X_Y] = M(0, 1);
+  pose_cov[XYZRPY_COV_IDX::Y_X] = M(1, 0);
+  pose_cov[XYZRPY_COV_IDX::Y_Y] = M(1, 1);
+  pose_cov[XYZRPY_COV_IDX::X_YAW] = M(0, 2);
+  pose_cov[XYZRPY_COV_IDX::YAW_X] = M(2, 0);
+  pose_cov[XYZRPY_COV_IDX::Y_YAW] = M(1, 2);
+  pose_cov[XYZRPY_COV_IDX::YAW_Y] = M(2, 1);
+  pose_cov[XYZRPY_COV_IDX::YAW_YAW] = M(2, 2);
   pose_cov[XYZRPY_COV_IDX::Z_Z] = default_cov;
   pose_cov[XYZRPY_COV_IDX::ROLL_ROLL] = default_cov;
   pose_cov[XYZRPY_COV_IDX::PITCH_PITCH] = default_cov;

--- a/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
@@ -253,12 +253,22 @@ bool BicycleMotionModel::updateStatePoseWheel(
   // check if the state is initialized
   if (!checkInitialized()) return false;
 
-  constexpr int DIM_Y = 2;
-  Eigen::Matrix<double, DIM_Y, 1> Y;
-  Y << x, y;
+  // Derive the pre-update wheelbase and heading straight from the axle points (one hypot, no trig):
+  // t_hat = (p2 - p1) / wheelbase.
+  const double dx = getStateElement(IDX::X2) - getStateElement(IDX::X1);
+  const double dy = getStateElement(IDX::Y2) - getStateElement(IDX::Y1);
+  const double wheel_base = std::hypot(dx, dy);
+  const double cos_yaw = dx / wheel_base;
+  const double sin_yaw = dy / wheel_base;
 
-  // Measure the edge face center as an exact linear blend of the two endpoints:
-  // face = (1 + gamma) * p_near - gamma * p_far
+  // Measure the edge face center as an exact linear blend of the two endpoints, plus a wheelbase-
+  // lock row that pins the length to its current value:
+  //   row 0,1: face = (1 + gamma) * p_near - gamma * p_far
+  //   row 2:   wheelbase = (p2 - p1) . t_hat  ->  current value
+  constexpr int DIM_Y = 3;
+  Eigen::Matrix<double, DIM_Y, 1> Y;
+  Y << x, y, wheel_base;
+
   Eigen::Matrix<double, DIM_Y, DIM> C = Eigen::Matrix<double, DIM_Y, DIM>::Zero();
   if (measure_front) {
     // The front face anchors on p2 = (X2, Y2) with gamma_front
@@ -275,12 +285,20 @@ bool BicycleMotionModel::updateStatePoseWheel(
     C(1, IDX::Y1) = 1.0 + gamma;
     C(1, IDX::Y2) = -gamma;
   }
+  // wheelbase-lock row: holds the length so a partial cluster cannot stretch the body (which the
+  // wheel-base lever would otherwise turn into yaw).
+  C(2, IDX::X1) = -cos_yaw;
+  C(2, IDX::Y1) = -sin_yaw;
+  C(2, IDX::X2) = cos_yaw;
+  C(2, IDX::Y2) = sin_yaw;
 
   Eigen::Matrix<double, DIM_Y, DIM_Y> R = Eigen::Matrix<double, DIM_Y, DIM_Y>::Zero();
   R(0, 0) = pose_cov[XYZRPY_COV_IDX::X_X];
   R(0, 1) = pose_cov[XYZRPY_COV_IDX::X_Y];
   R(1, 0) = pose_cov[XYZRPY_COV_IDX::Y_X];
   R(1, 1) = pose_cov[XYZRPY_COV_IDX::Y_Y];
+  constexpr double length_lock_var = 1.0e-4;  // [m^2] ~1 cm std: hold the wheelbase near-constant
+  R(2, 2) = length_lock_var;
 
   return ekf_.update(Y, C, R);
 }

--- a/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
@@ -700,8 +700,8 @@ bool BicycleMotionModel::getPredictedState(
   Eigen::Matrix<double, 3, 4> G;
   G << w_rear, 0.0, w_front, 0.0,  // center_x
     0.0, w_rear, 0.0, w_front,     // center_y
-    sin_yaw * wheel_base_inv, -cos_yaw * wheel_base_inv,
-   -sin_yaw * wheel_base_inv,  cos_yaw * wheel_base_inv;  // yaw
+    sin_yaw * wheel_base_inv, -cos_yaw * wheel_base_inv, -sin_yaw * wheel_base_inv,
+    cos_yaw * wheel_base_inv;  // yaw
   const Eigen::Matrix3d M = G * P.topLeftCorner<4, 4>() * G.transpose();
 
   pose_cov[XYZRPY_COV_IDX::X_X] = M(0, 0);

--- a/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
@@ -688,10 +688,9 @@ bool BicycleMotionModel::getPredictedState(
   twist.angular.z = X(IDX::V) * wheel_base_inv;
 
   constexpr double default_cov = 0.1 * 0.1;
-  // set pose covariance
-  // The exported pose (center position + yaw) is a smooth function of the four axle coordinates
-  // [X1, Y1, X2, Y2]. Propagate their covariance block through a single Jacobian G so the whole
-  // (x, y, yaw) block is mutually consistent, correctly correlated, and PSD by construction:
+  // Set pose covariance
+  // Propagate the axle-coordinate covariance [X1, Y1, X2, Y2] through a single Jacobian G so the
+  // exported (x, y, yaw) block stays consistent, correctly correlated, and PSD by construction:
   //   center = w_rear * p1 + w_front * p2   (w_rear + w_front = 1)
   //   yaw    = atan2(Y2 - Y1, X2 - X1),  d(yaw)/d[X1,Y1,X2,Y2] = (1/L)*[sin, -cos, -sin, cos]
   // M = G * P_sub * G^T reproduces the exact linearized YAW_YAW and adds the position<->yaw
@@ -701,8 +700,8 @@ bool BicycleMotionModel::getPredictedState(
   Eigen::Matrix<double, 3, 4> G;
   G << w_rear, 0.0, w_front, 0.0,  // center_x
     0.0, w_rear, 0.0, w_front,     // center_y
-    sin_yaw * wheel_base_inv, -cos_yaw * wheel_base_inv, -sin_yaw * wheel_base_inv,
-    cos_yaw * wheel_base_inv;  // yaw
+    sin_yaw * wheel_base_inv, -cos_yaw * wheel_base_inv,
+   -sin_yaw * wheel_base_inv,  cos_yaw * wheel_base_inv;  // yaw
   const Eigen::Matrix3d M = G * P.topLeftCorner<4, 4>() * G.transpose();
 
   pose_cov[XYZRPY_COV_IDX::X_X] = M(0, 0);

--- a/perception/autoware_multi_object_tracker/test/test_vehicle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/test/test_vehicle_tracker.cpp
@@ -361,8 +361,9 @@ TEST(ExportedPoseCovariance, MatchesJacobianPropagation)
   const double cos_yaw = dx / wheel_base;
 
   // normal_vehicle axle ratios (wheel_pos_ratio_front / _rear)
-  constexpr double lf_ratio = 0.3;
-  constexpr double lr_ratio = 0.25;
+  const auto & bicycle_state = object_model::normal_vehicle.bicycle_state;
+  const double lf_ratio = bicycle_state.wheel_pos_ratio_front;
+  const double lr_ratio = bicycle_state.wheel_pos_ratio_rear;
   const double inv_wheel_base_ratio = 1.0 / (lf_ratio + lr_ratio);
   const double w_rear = lf_ratio * inv_wheel_base_ratio;
   const double w_front = lr_ratio * inv_wheel_base_ratio;

--- a/perception/autoware_multi_object_tracker/test/test_vehicle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/test/test_vehicle_tracker.cpp
@@ -314,4 +314,90 @@ TEST(ProcessNoiseAxleStructure, PositiveSemiDefinite)
   }
 }
 
+// ---------------------------------------------------------------------------------------------
+// BicycleMotionModel::getPredictedState — exported pose covariance conversion.
+// The exported (x, y, yaw) block is the axle covariance propagated through the single Jacobian G of
+// [center, yaw] = f(X1, Y1, X2, Y2). It must use the center blend for position (not one axle
+// point), carry the position<->yaw cross-covariance, and stay symmetric and PSD.
+// ---------------------------------------------------------------------------------------------
+namespace
+{
+std::array<double, 36> exportedPoseCov(const BicycleMotionModel & model)
+{
+  geometry_msgs::msg::Pose pose;
+  geometry_msgs::msg::Twist twist;
+  std::array<double, 36> pose_cov{};
+  std::array<double, 36> twist_cov{};
+  model.getPredictedState(evolvedTime(), pose, pose_cov, twist, twist_cov);
+  return pose_cov;
+}
+
+// Exported 3x3 (x, y, yaw) block as an Eigen matrix.
+Eigen::Matrix3d exportedPoseBlock(const BicycleMotionModel & model)
+{
+  const auto c = exportedPoseCov(model);
+  Eigen::Matrix3d block;
+  block << c[XYZRPY_COV_IDX::X_X], c[XYZRPY_COV_IDX::X_Y], c[XYZRPY_COV_IDX::X_YAW],
+    c[XYZRPY_COV_IDX::Y_X], c[XYZRPY_COV_IDX::Y_Y], c[XYZRPY_COV_IDX::Y_YAW],
+    c[XYZRPY_COV_IDX::YAW_X], c[XYZRPY_COV_IDX::YAW_Y], c[XYZRPY_COV_IDX::YAW_YAW];
+  return block;
+}
+}  // namespace
+
+// End-to-end: the exported block equals G * P_sub * G^T rebuilt from the raw axle covariance, so
+// position rides the center blend and yaw the difference vector, from one consistent Jacobian.
+TEST(ExportedPoseCovariance, MatchesJacobianPropagation)
+{
+  const BicycleMotionModel model = makeEvolvedVehicle();
+
+  BicycleMotionModel::StateVec x;
+  BicycleMotionModel::StateMat p;
+  model.MotionModel<6>::getPredictedState(evolvedTime(), x, p);
+
+  const double dx = x(BicycleMotionModel::X2) - x(BicycleMotionModel::X1);
+  const double dy = x(BicycleMotionModel::Y2) - x(BicycleMotionModel::Y1);
+  const double wheel_base = std::hypot(dx, dy);
+  const double sin_yaw = dy / wheel_base;
+  const double cos_yaw = dx / wheel_base;
+
+  // normal_vehicle axle ratios (wheel_pos_ratio_front / _rear)
+  constexpr double lf_ratio = 0.3;
+  constexpr double lr_ratio = 0.25;
+  const double wbri = 1.0 / (lf_ratio + lr_ratio);
+  const double w_rear = lf_ratio * wbri;
+  const double w_front = lr_ratio * wbri;
+
+  Eigen::Matrix<double, 3, 4> g;
+  g << w_rear, 0.0, w_front, 0.0, 0.0, w_rear, 0.0, w_front, sin_yaw / wheel_base,
+    -cos_yaw / wheel_base, -sin_yaw / wheel_base, cos_yaw / wheel_base;
+  const Eigen::Matrix3d expected = g * p.topLeftCorner<4, 4>() * g.transpose();
+
+  EXPECT_TRUE(exportedPoseBlock(model).isApprox(expected, 1e-12))
+    << "exported:\n"
+    << exportedPoseBlock(model) << "\nexpected:\n"
+    << expected;
+}
+
+// Position <-> yaw is genuinely correlated once the front/rear covariance is asymmetric (it was
+// hard-coded to zero before), and the exported block is symmetric. For straight motion at yaw = 0
+// the coupling lives in the lateral (y) <-> yaw term.
+TEST(ExportedPoseCovariance, PositionYawCorrelated)
+{
+  const auto c = exportedPoseCov(makeEvolvedVehicle());
+
+  EXPECT_GT(std::abs(c[XYZRPY_COV_IDX::X_YAW]) + std::abs(c[XYZRPY_COV_IDX::Y_YAW]), 1e-6);
+
+  EXPECT_DOUBLE_EQ(c[XYZRPY_COV_IDX::X_YAW], c[XYZRPY_COV_IDX::YAW_X]);
+  EXPECT_DOUBLE_EQ(c[XYZRPY_COV_IDX::Y_YAW], c[XYZRPY_COV_IDX::YAW_Y]);
+  EXPECT_DOUBLE_EQ(c[XYZRPY_COV_IDX::X_Y], c[XYZRPY_COV_IDX::Y_X]);
+}
+
+// The assembled (x, y, yaw) block is positive semi-definite: G * P_sub * G^T with P_sub PSD.
+TEST(ExportedPoseCovariance, PositiveSemiDefinite)
+{
+  Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> solver(exportedPoseBlock(makeEvolvedVehicle()));
+  ASSERT_EQ(solver.info(), Eigen::Success);
+  EXPECT_GE(solver.eigenvalues().minCoeff(), -1e-12);
+}
+
 }  // namespace autoware::multi_object_tracker

--- a/perception/autoware_multi_object_tracker/test/test_vehicle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/test/test_vehicle_tracker.cpp
@@ -363,9 +363,9 @@ TEST(ExportedPoseCovariance, MatchesJacobianPropagation)
   // normal_vehicle axle ratios (wheel_pos_ratio_front / _rear)
   constexpr double lf_ratio = 0.3;
   constexpr double lr_ratio = 0.25;
-  const double wbri = 1.0 / (lf_ratio + lr_ratio);
-  const double w_rear = lf_ratio * wbri;
-  const double w_front = lr_ratio * wbri;
+  const double inv_wheel_base_ratio = 1.0 / (lf_ratio + lr_ratio);
+  const double w_rear = lf_ratio * inv_wheel_base_ratio;
+  const double w_front = lr_ratio * inv_wheel_base_ratio;
 
   Eigen::Matrix<double, 3, 4> g;
   g << w_rear, 0.0, w_front, 0.0, 0.0, w_rear, 0.0, w_front, sin_yaw / wheel_base,


### PR DESCRIPTION
## Description

Stationary vehicles can spin up a spurious yaw when only a **partial cluster** is observed
(e.g. the bbox detection channel drops and only one axle face is seen). The wheel/axle-anchor
update in `BicycleMotionModel::updateStatePoseWheel` measures only the `(x, y)` of a single axle
face center. A partial cluster that overshoots that face **stretches the body length** — the
distance between the two axle points (`X1,Y1` ↔ `X2,Y2`).

Because the bicycle model derives yaw from the axle difference vector

```
yaw = atan2(Y2 - Y1, X2 - X1)
```

a stretched wheelbase acts as a lever: the "enlarged front wheel" is converted into rotation
instead of length. This **bypasses the bicycle motion model's length constraint** and rotates an
otherwise static vehicle.

This PR enforces the object length during the partial update and cleans up the covariance export
so the two axle points stay consistent.

**1. Wheelbase-lock row in the partial wheel update** (primary fix)

`updateStatePoseWheel` gains a third measurement row (`DIM_Y` 2 → 3) that pins the wheelbase to
its current value:

- rows 0,1 — unchanged: face center as the exact linear blend of the two endpoints
  (`face = (1 + γ)·p_near − γ·p_far`)
- row 2 — **wheelbase lock**: projects `(p2 − p1)` onto the current heading `t̂ = (p2 − p1)/L`
  and measures it back to its current value, with a tight `R = 1e-4 m²` (~1 cm std).

The pre-update wheelbase and heading are derived straight from the axle points with a single
`hypot` (no trig). With the length held near-constant, a partial cluster can no longer stretch the
body, so it cannot leak into yaw through the wheelbase lever.

**2. Jacobian-based pose covariance export** in `getPredictedState`

The exported `(x, y, yaw)` covariance block is now the axle covariance `[X1,Y1,X2,Y2]` propagated
through a single `3×4` Jacobian `G` of `[center, yaw] = f(X1,Y1,X2,Y2)`:

- position rides the **center blend** `w_rear·p1 + w_front·p2` instead of copying a single axle
  point;
- yaw uses the difference-vector Jacobian `d(yaw)/d[X1,Y1,X2,Y2] = (1/L)·[sin, −cos, −sin, cos]`.

`M = G · P_sub · Gᵀ` reproduces the exact linearized `YAW_YAW`, restores the position↔yaw
cross-covariance that the previous single-axle-point copy dropped, and is PSD by construction.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Adds `ExportedPoseCovariance` cases in `test/test_vehicle_tracker.cpp`:

- `MatchesJacobianPropagation` — exported block equals `G · P_sub · Gᵀ` rebuilt from the raw axle
  covariance;
- `PositionYawCorrelated` — position↔yaw coupling is non-zero and the block is symmetric;
- `PositiveSemiDefinite` — exported block is PSD.

* before

https://github.com/user-attachments/assets/bcbd40a9-bdad-4e2a-a0aa-5bc664d9abb6

* after

https://github.com/user-attachments/assets/61b46e7c-090c-4b24-a1f6-c024729bd5ec


## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

Stationary vehicles observed as a partial cluster (single axle face, e.g. when the bbox detection
channel drops) no longer accumulate a spurious yaw rotation. The wheelbase lock keeps the tracked
body length near-constant during partial updates, and the Jacobian-based covariance export
restores the position↔yaw cross-covariance for downstream consumers.
