### PR TITLE
refactor(autoware_traffic_light_classifier): extract a Node-free CnnLampRecognizerCore

### DIFF
--- a/perception/autoware_traffic_light_classifier/src/classifier/cnn_lamp_recognizer.cpp
+++ b/perception/autoware_traffic_light_classifier/src/classifier/cnn_lamp_recognizer.cpp
@@ -113,188 +113,28 @@ static void convertBBoxInfoToLampElement(const BBoxInfo & box_info, LampElement 
   }
 }
 
-static void updateTrafficSignals(
-  const std::vector<LampElement> & unique_elements,
-  tier4_perception_msgs::msg::TrafficLight & traffic_signal)
-{
-  traffic_signal.elements.clear();
-  bool is_pedestrian = traffic_signal.traffic_light_type == 1;
-  if (unique_elements.empty()) {
-    MsgTE unknown_elem;
-    unknown_elem.color = MsgTE::UNKNOWN;
-    unknown_elem.shape = MsgTE::UNKNOWN;
-    unknown_elem.confidence = 0.0;
-    traffic_signal.elements.push_back(unknown_elem);
-    return;
-  }
-  for (const auto & e : unique_elements) {
-    MsgTE element;
-    element.confidence = e.confidence;
-    switch (e.color) {
-      case Color::GREEN:
-        element.color = MsgTE::GREEN;
-        break;
-      case Color::AMBER:
-        element.color = MsgTE::AMBER;
-        break;
-      case Color::RED:
-        element.color = MsgTE::RED;
-        break;
-      default:
-        element.color = MsgTE::UNKNOWN;
-        break;
-    }
-    if (is_pedestrian || e.shape == Shape::PED) {
-      element.shape = MsgTE::CIRCLE;
-      traffic_signal.elements.push_back(element);
-      continue;
-    }
-    switch (e.shape) {
-      case Shape::CIRCLE:
-        element.shape = MsgTE::CIRCLE;
-        break;
-      case Shape::ARROW:
-        switch (e.arrow_direction) {
-          case ArrowDirection::UP_ARROW:
-            element.shape = MsgTE::UP_ARROW;
-            break;
-          case ArrowDirection::DOWN_ARROW:
-            element.shape = MsgTE::DOWN_ARROW;
-            break;
-          case ArrowDirection::LEFT_ARROW:
-            element.shape = MsgTE::LEFT_ARROW;
-            break;
-          case ArrowDirection::RIGHT_ARROW:
-            element.shape = MsgTE::RIGHT_ARROW;
-            break;
-          case ArrowDirection::UP_LEFT_ARROW:
-            element.shape = MsgTE::UP_LEFT_ARROW;
-            break;
-          case ArrowDirection::UP_RIGHT_ARROW:
-            element.shape = MsgTE::UP_RIGHT_ARROW;
-            break;
-          case ArrowDirection::DOWN_LEFT_ARROW:
-            element.shape = MsgTE::DOWN_LEFT_ARROW;
-            break;
-          case ArrowDirection::DOWN_RIGHT_ARROW:
-            element.shape = MsgTE::DOWN_RIGHT_ARROW;
-            break;
-          default:
-            element.shape = MsgTE::UNKNOWN;
-            element.confidence = 0.0;
-            break;
-        }
-        break;
-      case Shape::PED:
-        element.shape = MsgTE::CIRCLE;
-        break;
-      case Shape::CROSS:
-        element.shape = MsgTE::CROSS;
-        break;
-      // TODO(badai-nguyen): update u-turn, number when msgs are updated
-      default:
-        element.shape = MsgTE::UNKNOWN;
-        element.confidence = 0.0;
-        break;
-    }
-    traffic_signal.elements.push_back(element);
-  }
-}
-
-static void outputDebugImage(
-  cv::Mat & debug_image, const tier4_perception_msgs::msg::TrafficLight & traffic_signal,
-  const std::vector<LampElement> * elements)
-{
-  const int img_w = debug_image.cols;
-  const int img_h = debug_image.rows;
-
-  if (elements && !elements->empty()) {
-    static const cv::Scalar colors[] = {
-      cv::Scalar(0, 255, 0),    // green  (R, G, B)
-      cv::Scalar(255, 255, 0),  // yellow/amber
-      cv::Scalar(255, 0, 0),    // red
-    };
-    for (const auto & d : *elements) {
-      const int x1 = static_cast<int>(d.box.x1 * img_w);
-      const int y1 = static_cast<int>(d.box.y1 * img_h);
-      const int x2 = static_cast<int>(d.box.x2 * img_w);
-      const int y2 = static_cast<int>(d.box.y2 * img_h);
-      const int color_idx = std::min(2, std::max(0, static_cast<int>(d.color)));
-      cv::rectangle(debug_image, cv::Point(x1, y1), cv::Point(x2, y2), colors[color_idx], 2);
-    }
-  }
-
-  float probability = 0.0f;
-  std::string label;
-  for (std::size_t i = 0; i < traffic_signal.elements.size(); i++) {
-    auto light = traffic_signal.elements.at(i);
-    const auto light_label =
-      utils::convertColorT4toString(light.color) + "-" + utils::convertShapeT4toString(light.shape);
-    label += light_label;
-    // all lamp confidence are the same
-    probability = light.confidence;
-    if (i < traffic_signal.elements.size() - 1) {
-      label += ",";
-    }
-  }
-  const std::string text = label + " " + std::to_string(probability);
-  const int expand_h =
-    std::max(static_cast<int>((kDebugImageWidth * debug_image.rows) / debug_image.cols), 1);
-  cv::resize(debug_image, debug_image, cv::Size(kDebugImageWidth, expand_h));
-  cv::Mat text_img(cv::Size(kDebugImageWidth, kDebugTextHeight), CV_8UC3, cv::Scalar(0, 0, 0));
-  cv::putText(
-    text_img, text, cv::Point(5, 25), cv::FONT_HERSHEY_COMPLEX, 0.5, cv::Scalar(0, 255, 0), 1);
-  cv::vconcat(debug_image, text_img, debug_image);
-}
-
 }  // namespace
 
-CnnLampRecognizer::CnnLampRecognizer(rclcpp::Node * node_ptr) : node_ptr_(node_ptr)
+// ============================= CnnLampRecognizerCore =============================
+// Node-free YOLO-style lamp recognition core (TensorRT).
+
+CnnLampRecognizerCore::CnnLampRecognizerCore(const CnnLampRecognizerConfig & config)
+: max_batch_size_(config.max_batch_size),
+  score_threshold_(config.score_threshold),
+  nms_threshold_(config.nms_threshold),
+  model_params_(config.model_params)
 {
-  image_pub_ = image_transport::create_publisher(
-    node_ptr_, "~/output/debug/image", rclcpp::QoS{1}.get_rmw_qos_profile());
-
-  const std::string model_path = node_ptr_->declare_parameter<std::string>("model_path");
-  const std::string precision = node_ptr_->declare_parameter<std::string>("precision");
-  score_threshold_ = static_cast<float>(node_ptr_->declare_parameter<double>("score_threshold"));
-  nms_threshold_ = static_cast<float>(node_ptr_->declare_parameter<double>("nms_threshold"));
-  max_batch_size_ = node_ptr_->declare_parameter<int>("max_batch_size");
-
-  model_params_.num_anchors = node_ptr_->declare_parameter<int>("model_params.num_anchors");
-  model_params_.chans_per_anchor =
-    node_ptr_->declare_parameter<int>("model_params.chans_per_anchor");
-  model_params_.x_index = node_ptr_->declare_parameter<int>("model_params.x_index");
-  model_params_.y_index = node_ptr_->declare_parameter<int>("model_params.y_index");
-  model_params_.w_index = node_ptr_->declare_parameter<int>("model_params.w_index");
-  model_params_.h_index = node_ptr_->declare_parameter<int>("model_params.h_index");
-  model_params_.obj_index = node_ptr_->declare_parameter<int>("model_params.obj_index");
-  model_params_.color_start = node_ptr_->declare_parameter<int>("model_params.color_start");
-  model_params_.type_start = node_ptr_->declare_parameter<int>("model_params.type_start");
-  model_params_.num_types = node_ptr_->declare_parameter<int>("model_params.num_types");
-  model_params_.num_colors = node_ptr_->declare_parameter<int>("model_params.num_colors");
-  model_params_.cos_index = node_ptr_->declare_parameter<int>("model_params.cos_index");
-  model_params_.sin_index = node_ptr_->declare_parameter<int>("model_params.sin_index");
-  model_params_.scale_x_y =
-    static_cast<float>(node_ptr_->declare_parameter<double>("model_params.scale_x_y"));
-  model_params_.bbox_offset = 0.5f * (model_params_.scale_x_y - 1.0f);
-  {
-    const auto anchors_param =
-      node_ptr_->declare_parameter<std::vector<double>>("model_params.anchors");
-    model_params_.anchors.clear();
-    model_params_.anchors.reserve(anchors_param.size());
-    for (double v : anchors_param) {
-      model_params_.anchors.push_back(static_cast<float>(v));
-    }
-    if (static_cast<int>(model_params_.anchors.size()) != 2 * model_params_.num_anchors) {
-      throw std::runtime_error(
-        "CnnLampRecognizer: model_params.anchors must contain 2 * model_params.num_anchors "
-        "values (w,h per anchor)");
-    }
+  // The core owns its decode invariants (so a directly-built core is correct): anchors carry (w,h)
+  // per anchor, bbox_offset derives from scale_x_y. Checked before the engine build -> fail fast.
+  if (static_cast<int>(model_params_.anchors.size()) != 2 * model_params_.num_anchors) {
+    throw std::runtime_error(
+      "CnnLampRecognizerCore: anchors must contain 2 * num_anchors values (w,h per anchor)");
   }
+  model_params_.bbox_offset = 0.5f * (model_params_.scale_x_y - 1.0f);
 
-  autoware::tensorrt_common::TrtCommonConfig config(
-    model_path, precision, "", (1ULL << 30U), -1, false);
-  trt_common_ = std::make_unique<autoware::tensorrt_common::TrtCommon>(config);
+  autoware::tensorrt_common::TrtCommonConfig trt_config(
+    config.model_path, config.precision, "", (1ULL << 30U), -1, false);
+  trt_common_ = std::make_unique<autoware::tensorrt_common::TrtCommon>(trt_config);
 
   nvinfer1::Dims input_dims = trt_common_->getInputDims(0);
   input_c_ = input_dims.d[1] > 0 ? input_dims.d[1] : 3;
@@ -370,7 +210,7 @@ CnnLampRecognizer::CnnLampRecognizer(rclcpp::Node * node_ptr) : node_ptr_(node_p
   input_d_ = autoware::cuda_utils::make_unique<float[]>(input_vol);
 }
 
-void CnnLampRecognizer::preprocess(const std::vector<cv::Mat> & images)
+void CnnLampRecognizerCore::preprocess(const std::vector<cv::Mat> & images)
 {
   const float scale = 1.0f / 255.0f;
   const cv::Size input_size(input_width_, input_height_);
@@ -384,12 +224,11 @@ void CnnLampRecognizer::preprocess(const std::vector<cv::Mat> & images)
     input_d_.get(), blob.ptr<float>(), copy_size, cudaMemcpyHostToDevice, *stream_));
 }
 
-bool CnnLampRecognizer::doInference(size_t batch_size)
+bool CnnLampRecognizerCore::doInference(size_t batch_size)
 {
   nvinfer1::Dims input_dims = trt_common_->getInputDims(0);
   input_dims.d[0] = static_cast<int32_t>(batch_size);
   if (!trt_common_->setInputShape(0, input_dims)) {
-    RCLCPP_ERROR(node_ptr_->get_logger(), "LampRecognizer: setInputShape failed");
     return false;
   }
 
@@ -420,7 +259,7 @@ bool CnnLampRecognizer::doInference(size_t batch_size)
   return true;
 }
 
-void CnnLampRecognizer::decodeTlrOutput(
+void CnnLampRecognizerCore::decodeTlrOutput(
   size_t batch_size, std::vector<std::vector<BBoxInfo>> & detections_per_roi)
 {
   const auto & ml_params = model_params_;
@@ -517,21 +356,13 @@ void CnnLampRecognizer::decodeTlrOutput(
   }
 }
 
-bool CnnLampRecognizer::getTrafficSignals(
-  const std::vector<cv::Mat> & images,
-  tier4_perception_msgs::msg::TrafficLightArray & traffic_signals)
+CnnLampRecognizerCore::DetectionResult CnnLampRecognizerCore::classify(
+  const std::vector<cv::Mat> & images)
 {
-  if (images.size() != traffic_signals.signals.size()) {
-    RCLCPP_WARN(
-      node_ptr_->get_logger(), "LampRecognizer: image count (%zu) != signal count (%zu)",
-      images.size(), traffic_signals.signals.size());
-    return false;
-  }
+  DetectionResult result;
+  result.lamps_per_image.reserve(images.size());
 
-  size_t signal_i = 0;
   std::vector<cv::Mat> batch;
-  std::vector<std::vector<LampElement>> unique_lamps_per_image;
-
   for (size_t image_i = 0; image_i < images.size(); image_i++) {
     batch.push_back(images[image_i]);
     const size_t current_batch_size = batch.size();
@@ -542,15 +373,13 @@ bool CnnLampRecognizer::getTrafficSignals(
 
     preprocess(batch);
     if (!doInference(current_batch_size)) {
-      RCLCPP_ERROR(node_ptr_->get_logger(), "LampRecognizer: inference failed");
-      return false;
+      result.success = false;
+      return result;
     }
 
     std::vector<std::vector<BBoxInfo>> detections_per_roi;
     decodeTlrOutput(current_batch_size, detections_per_roi);
     for (size_t i = 0; i < current_batch_size; ++i) {
-      const size_t sig_idx = signal_i + i;
-
       std::vector<LampElement> traffic_lamps;
       for (const auto & d : detections_per_roi[i]) {
         LampElement element;
@@ -572,12 +401,222 @@ bool CnnLampRecognizer::getTrafficSignals(
         }
       }
 
-      updateTrafficSignals(unique_lamps, traffic_signals.signals[sig_idx]);
-      unique_lamps_per_image.push_back(unique_lamps);
+      result.lamps_per_image.push_back(unique_lamps);
     }
-    signal_i += current_batch_size;
     batch.clear();
   }
+  result.success = true;
+  return result;
+}
+
+void CnnLampRecognizerCore::updateTrafficSignals(
+  const std::vector<LampElement> & unique_elements,
+  tier4_perception_msgs::msg::TrafficLight & traffic_signal)
+{
+  traffic_signal.elements.clear();
+  bool is_pedestrian = traffic_signal.traffic_light_type == 1;
+  if (unique_elements.empty()) {
+    MsgTE unknown_elem;
+    unknown_elem.color = MsgTE::UNKNOWN;
+    unknown_elem.shape = MsgTE::UNKNOWN;
+    unknown_elem.confidence = 0.0;
+    traffic_signal.elements.push_back(unknown_elem);
+    return;
+  }
+  for (const auto & e : unique_elements) {
+    MsgTE element;
+    element.confidence = e.confidence;
+    switch (e.color) {
+      case Color::GREEN:
+        element.color = MsgTE::GREEN;
+        break;
+      case Color::AMBER:
+        element.color = MsgTE::AMBER;
+        break;
+      case Color::RED:
+        element.color = MsgTE::RED;
+        break;
+      default:
+        element.color = MsgTE::UNKNOWN;
+        break;
+    }
+    if (is_pedestrian || e.shape == Shape::PED) {
+      element.shape = MsgTE::CIRCLE;
+      traffic_signal.elements.push_back(element);
+      continue;
+    }
+    switch (e.shape) {
+      case Shape::CIRCLE:
+        element.shape = MsgTE::CIRCLE;
+        break;
+      case Shape::ARROW:
+        switch (e.arrow_direction) {
+          case ArrowDirection::UP_ARROW:
+            element.shape = MsgTE::UP_ARROW;
+            break;
+          case ArrowDirection::DOWN_ARROW:
+            element.shape = MsgTE::DOWN_ARROW;
+            break;
+          case ArrowDirection::LEFT_ARROW:
+            element.shape = MsgTE::LEFT_ARROW;
+            break;
+          case ArrowDirection::RIGHT_ARROW:
+            element.shape = MsgTE::RIGHT_ARROW;
+            break;
+          case ArrowDirection::UP_LEFT_ARROW:
+            element.shape = MsgTE::UP_LEFT_ARROW;
+            break;
+          case ArrowDirection::UP_RIGHT_ARROW:
+            element.shape = MsgTE::UP_RIGHT_ARROW;
+            break;
+          case ArrowDirection::DOWN_LEFT_ARROW:
+            element.shape = MsgTE::DOWN_LEFT_ARROW;
+            break;
+          case ArrowDirection::DOWN_RIGHT_ARROW:
+            element.shape = MsgTE::DOWN_RIGHT_ARROW;
+            break;
+          default:
+            element.shape = MsgTE::UNKNOWN;
+            element.confidence = 0.0;
+            break;
+        }
+        break;
+      case Shape::PED:
+        element.shape = MsgTE::CIRCLE;
+        break;
+      case Shape::CROSS:
+        element.shape = MsgTE::CROSS;
+        break;
+      // TODO(badai-nguyen): update u-turn, number when msgs are updated
+      default:
+        element.shape = MsgTE::UNKNOWN;
+        element.confidence = 0.0;
+        break;
+    }
+    traffic_signal.elements.push_back(element);
+  }
+}
+
+void CnnLampRecognizerCore::outputDebugImage(
+  cv::Mat & debug_image, const tier4_perception_msgs::msg::TrafficLight & traffic_signal,
+  const std::vector<LampElement> * elements)
+{
+  const int img_w = debug_image.cols;
+  const int img_h = debug_image.rows;
+
+  if (elements && !elements->empty()) {
+    static const cv::Scalar colors[] = {
+      cv::Scalar(0, 255, 0),    // green  (R, G, B)
+      cv::Scalar(255, 255, 0),  // yellow/amber
+      cv::Scalar(255, 0, 0),    // red
+    };
+    for (const auto & d : *elements) {
+      const int x1 = static_cast<int>(d.box.x1 * img_w);
+      const int y1 = static_cast<int>(d.box.y1 * img_h);
+      const int x2 = static_cast<int>(d.box.x2 * img_w);
+      const int y2 = static_cast<int>(d.box.y2 * img_h);
+      const int color_idx = std::min(2, std::max(0, static_cast<int>(d.color)));
+      cv::rectangle(debug_image, cv::Point(x1, y1), cv::Point(x2, y2), colors[color_idx], 2);
+    }
+  }
+
+  float probability = 0.0f;
+  std::string label;
+  for (std::size_t i = 0; i < traffic_signal.elements.size(); i++) {
+    auto light = traffic_signal.elements.at(i);
+    const auto light_label =
+      utils::convertColorT4toString(light.color) + "-" + utils::convertShapeT4toString(light.shape);
+    label += light_label;
+    // all lamp confidence are the same
+    probability = light.confidence;
+    if (i < traffic_signal.elements.size() - 1) {
+      label += ",";
+    }
+  }
+  const std::string text = label + " " + std::to_string(probability);
+  const int expand_h =
+    std::max(static_cast<int>((kDebugImageWidth * debug_image.rows) / debug_image.cols), 1);
+  cv::resize(debug_image, debug_image, cv::Size(kDebugImageWidth, expand_h));
+  cv::Mat text_img(cv::Size(kDebugImageWidth, kDebugTextHeight), CV_8UC3, cv::Scalar(0, 0, 0));
+  cv::putText(
+    text_img, text, cv::Point(5, 25), cv::FONT_HERSHEY_COMPLEX, 0.5, cv::Scalar(0, 255, 0), 1);
+  cv::vconcat(debug_image, text_img, debug_image);
+}
+
+// ============================== CnnLampRecognizer ==============================
+// ROS adapter: declares parameters, publishes debug images, and delegates recognition to the
+// Node-free core.
+
+namespace
+{
+// Declare the lamp recognizer parameters on `node` and return the config. Anchors are narrowed
+// double->float here (a ROS quirk); config-data invariants live in the core ctor, not here.
+CnnLampRecognizerConfig declare_lamp_config(rclcpp::Node * node)
+{
+  CnnLampRecognizerConfig config;
+  config.model_path = node->declare_parameter<std::string>("model_path");
+  config.precision = node->declare_parameter<std::string>("precision");
+  config.score_threshold = static_cast<float>(node->declare_parameter<double>("score_threshold"));
+  config.nms_threshold = static_cast<float>(node->declare_parameter<double>("nms_threshold"));
+  config.max_batch_size = node->declare_parameter<int>("max_batch_size");
+
+  auto & model_params = config.model_params;
+  model_params.num_anchors = node->declare_parameter<int>("model_params.num_anchors");
+  model_params.chans_per_anchor = node->declare_parameter<int>("model_params.chans_per_anchor");
+  model_params.x_index = node->declare_parameter<int>("model_params.x_index");
+  model_params.y_index = node->declare_parameter<int>("model_params.y_index");
+  model_params.w_index = node->declare_parameter<int>("model_params.w_index");
+  model_params.h_index = node->declare_parameter<int>("model_params.h_index");
+  model_params.obj_index = node->declare_parameter<int>("model_params.obj_index");
+  model_params.color_start = node->declare_parameter<int>("model_params.color_start");
+  model_params.type_start = node->declare_parameter<int>("model_params.type_start");
+  model_params.num_types = node->declare_parameter<int>("model_params.num_types");
+  model_params.num_colors = node->declare_parameter<int>("model_params.num_colors");
+  model_params.cos_index = node->declare_parameter<int>("model_params.cos_index");
+  model_params.sin_index = node->declare_parameter<int>("model_params.sin_index");
+  model_params.scale_x_y =
+    static_cast<float>(node->declare_parameter<double>("model_params.scale_x_y"));
+
+  const auto anchors_param = node->declare_parameter<std::vector<double>>("model_params.anchors");
+  model_params.anchors.clear();
+  model_params.anchors.reserve(anchors_param.size());
+  for (double v : anchors_param) {
+    model_params.anchors.push_back(static_cast<float>(v));
+  }
+
+  return config;
+}
+}  // namespace
+
+CnnLampRecognizer::CnnLampRecognizer(rclcpp::Node * node_ptr)
+: node_ptr_(node_ptr), core_(declare_lamp_config(node_ptr))
+{
+  image_pub_ = image_transport::create_publisher(
+    node_ptr_, "~/output/debug/image", rclcpp::QoS{1}.get_rmw_qos_profile());
+}
+
+bool CnnLampRecognizer::getTrafficSignals(
+  const std::vector<cv::Mat> & images,
+  tier4_perception_msgs::msg::TrafficLightArray & traffic_signals)
+{
+  if (images.size() != traffic_signals.signals.size()) {
+    RCLCPP_WARN(
+      node_ptr_->get_logger(), "LampRecognizer: image count (%zu) != signal count (%zu)",
+      images.size(), traffic_signals.signals.size());
+    return false;
+  }
+
+  const CnnLampRecognizerCore::DetectionResult result = core_.classify(images);
+  if (!result.success) {
+    RCLCPP_ERROR(node_ptr_->get_logger(), "LampRecognizer: inference failed");
+    return false;
+  }
+
+  for (size_t i = 0; i < traffic_signals.signals.size(); ++i) {
+    CnnLampRecognizerCore::updateTrafficSignals(
+      result.lamps_per_image[i], traffic_signals.signals[i]);
+  }
+
   if (image_pub_.getNumSubscribers() > 0 && !images.empty()) {
     // build debug image by vertically concatenating each image's debug view
     const int strip_width = 200;
@@ -585,7 +624,8 @@ bool CnnLampRecognizer::getTrafficSignals(
     cv::Mat debug_img;
     for (size_t i = 0; i < images.size(); i++) {
       cv::Mat debug_img_i = images[i].clone();
-      outputDebugImage(debug_img_i, traffic_signals.signals[i], &unique_lamps_per_image[i]);
+      CnnLampRecognizerCore::outputDebugImage(
+        debug_img_i, traffic_signals.signals[i], &result.lamps_per_image[i]);
       cv::resize(debug_img_i, debug_img_i, cv::Size(strip_width, strip_height));
       if (i == 0) {
         debug_img = debug_img_i;

--- a/perception/autoware_traffic_light_classifier/src/classifier/cnn_lamp_recognizer.hpp
+++ b/perception/autoware_traffic_light_classifier/src/classifier/cnn_lamp_recognizer.hpp
@@ -117,30 +117,62 @@ struct LampRegressionArchitecture
   int cos_index{14};
   int sin_index{15};
   float scale_x_y{2.0f};
-  /// YOLO center decode: 0.5f * (scale_x_y - 1.0f), set when loading parameters.
+  /// YOLO center decode offset; derived by CnnLampRecognizerCore from scale_x_y.
   float bbox_offset{0.5f};
   std::vector<float> anchors;
 };
 
-/**
- * @brief Lamp recognizer: per-lamp bbox + color + type + angle (ONNX/TensorRT).
- */
-class CnnLampRecognizer : public ClassifierInterface
+// Plain config for CnnLampRecognizerCore (the core does no ROS parameter reading of its own).
+// The core ctor validates the anchors size and derives bbox_offset, so it owns those invariants.
+struct CnnLampRecognizerConfig
+{
+  std::string model_path;
+  std::string precision;
+  float score_threshold{0.f};
+  float nms_threshold{0.f};
+  int max_batch_size{0};
+  LampRegressionArchitecture model_params;
+};
+
+// Node-free lamp recognition core (ONNX/TensorRT): per-lamp bbox + color + type + angle. The
+// ctor builds a TensorRT engine (needs a GPU + model); the static helpers need neither.
+class CnnLampRecognizerCore
 {
 public:
-  explicit CnnLampRecognizer(rclcpp::Node * node_ptr);
-  ~CnnLampRecognizer() override = default;
+  // One entry per input image: the deduplicated lamp detections (geometry + color + shape +
+  // arrow direction). An empty inner vector means nothing passed the thresholds.
+  struct DetectionResult
+  {
+    std::vector<std::vector<LampElement>> lamps_per_image;
+    bool success = false;
+  };
 
-  bool getTrafficSignals(
-    const std::vector<cv::Mat> & images,
-    tier4_perception_msgs::msg::TrafficLightArray & traffic_signals) override;
+  // Builds the TensorRT engine from config.model_path and stores the decode parameters. Throws
+  // std::runtime_error if the engine setup fails or its output channels do not match model_params.
+  explicit CnnLampRecognizerCore(const CnnLampRecognizerConfig & config);
+
+  // Detect lamps in each ROI image, batching up to max_batch_size. NON-const: TensorRT
+  // inference mutates the engine's internal buffers.
+  DetectionResult classify(const std::vector<cv::Mat> & images);
+
+  // Map the deduplicated lamp detections into a TrafficLight's elements, honoring its
+  // traffic_light_type (pedestrian forces CIRCLE). Emits a single UNKNOWN placeholder element
+  // with zero confidence when unique_elements is empty.
+  static void updateTrafficSignals(
+    const std::vector<LampElement> & unique_elements,
+    tier4_perception_msgs::msg::TrafficLight & traffic_signal);
+
+  // Render one debug view onto debug_image: bounding boxes for each lamp plus a label /
+  // confidence text strip below. Mutates debug_image in place.
+  static void outputDebugImage(
+    cv::Mat & debug_image, const tier4_perception_msgs::msg::TrafficLight & traffic_signal,
+    const std::vector<LampElement> * elements);
 
 private:
   void preprocess(const std::vector<cv::Mat> & images);
   bool doInference(size_t batch_size);
   void decodeTlrOutput(size_t batch_size, std::vector<std::vector<BBoxInfo>> & detections_per_roi);
 
-  rclcpp::Node * node_ptr_;
   std::unique_ptr<autoware::tensorrt_common::TrtCommon> trt_common_;
   StreamUniquePtr stream_{makeCudaStream()};
 
@@ -159,8 +191,25 @@ private:
   float nms_threshold_;
 
   LampRegressionArchitecture model_params_;
+};
 
+// Thin ROS adapter around CnnLampRecognizerCore. Owns the node-facing concerns (parameter
+// declaration, debug-image publishing, logging) and delegates recognition to the core. Public
+// API is unchanged.
+class CnnLampRecognizer : public ClassifierInterface
+{
+public:
+  explicit CnnLampRecognizer(rclcpp::Node * node_ptr);
+  ~CnnLampRecognizer() override = default;
+
+  bool getTrafficSignals(
+    const std::vector<cv::Mat> & images,
+    tier4_perception_msgs::msg::TrafficLightArray & traffic_signals) override;
+
+private:
+  rclcpp::Node * node_ptr_;
   image_transport::Publisher image_pub_;
+  CnnLampRecognizerCore core_;
 };
 
 }  // namespace autoware::traffic_light


### PR DESCRIPTION
## Description

Splits `CnnLampRecognizer` into a **Node-free `CnnLampRecognizerCore`** plus a thin `CnnLampRecognizer : ClassifierInterface` **ROS adapter**, as well as permed in #12967. Both classes stay in the same
`cnn_lamp_recognizer.{hpp,cpp}` pair (no new files), matching `cnn_classifier.{hpp,cpp}`.

This is part of the ongoing effort to make the traffic-light classifiers callable as Node-free
core libraries (Color and CNN are already done: #12916, #12967).

## What changed

- **`CnnLampRecognizerCore`** (Node-free): owns the TensorRT engine and the whole recognition
  pipeline — `preprocess` / `doInference` / `decodeTlrOutput`, NMS and per-image dedup.
  `classify(images)` returns `DetectionResult{ lamps_per_image, success }`.
  `updateTrafficSignals` and `outputDebugImage` become `static` core helpers (pure logic, like
  `CNNClassifierCore::decode_label` / `make_debug_image`). The core references no `rclcpp` /
  node / `image_transport`.
- **`CnnLampRecognizer`** (adapter): keeps only `node_ptr_`, `image_pub_`, and `core_`.
  `declare_lamp_config(node)` reads the ROS parameters and narrows the anchors
  `double`→`float` (a ROS-param quirk). It declares the same parameter names as before.
- **Invariant ownership**: the `anchors.size() == 2 * num_anchors` validation and the
  `bbox_offset = 0.5 * (scale_x_y - 1)` derivation move from the adapter into the **core ctor**
  (before the engine build, fail-fast). The core is what actually indexes `anchors[...]` and
  uses `bbox_offset` in `decodeTlrOutput`, so a directly-constructed core is now correct on its
  own — mirroring how `CNNClassifierCore` validates its own `mean`/`std` sizes.

The public API — `CnnLampRecognizer(rclcpp::Node*)` + `getTrafficSignals(images, signals)` — is
**unchanged**, so the node/single-image construction sites are untouched.

## Effects on system behavior

Behavior is preserved on the normal path. Two deliberate, non-regressing deltas on the failure path:

1. **On inference failure the output `traffic_signals` is left untouched (all-or-nothing)**
   instead of partially mutated. This mirrors the behavior the CNN core extraction (#12967)
   already introduced (its `getTrafficSignals` likewise moved from per-batch in-place writes to
   build-fresh-then-merge-on-success). It is not a regression: `doInference` failures are
   infrastructure-level (`setInputShape` / `setTensorsAddresses` / `enqueueV3` bool returns, or
   CUDA errors that throw via `CHECK_CUDA_ERROR`) and are not data-dependent, so no meaningful
   "partial success" state exists — a healthy engine processes every batch; a broken one fails
   on the first.
2. `doInference` no longer logs `setInputShape` failures directly; the single adapter-level
   `RCLCPP_ERROR("inference failed")` covers it (same as the CNN core).

## How was this PR tested?

```
colcon build --packages-select autoware_traffic_light_classifier
colcon test  --packages-select autoware_traffic_light_classifier
```

All tests pass, including the `test_cnn_lamp_recognizer` characterization test (#12974).

## Notes for reviewers

- The core's result type is `DetectionResult{ lamps_per_image, success }` rather than the
  family's `ClassifierResult{ TrafficLightArray signals, success }`: the lamp core returns
  geometric detections (the adapter applies `updateTrafficSignals` per signal because it needs
  the caller's `traffic_light_type`), so a distinct name avoids implying it carries built signals.
- Scope is source-only. Deferred to follow-ups (kept out to minimize review surface): a GPU-free
  `CnnLampRecognizerCore` unit test for the decode branches the characterization test cannot
  cover, and trimming the now-unused `<opencv2/highgui/highgui.hpp>` include (as done for the CNN
  classifier).
