### PR TITLE
refactor(autoware_pid_longitudinal_controller): prepare for decoupling from rclcpp::Node

### DIFF
--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
@@ -25,19 +25,12 @@
 #include "autoware_vehicle_info_utils/vehicle_info_utils.hpp"
 #include "diagnostic_updater/diagnostic_updater.hpp"
 #include "rclcpp/rclcpp.hpp"
-#include "tf2_ros/buffer.h"
-#include "tf2_ros/transform_listener.h"
-
-#include <Eigen/Core>
-#include <Eigen/Geometry>
-#include <tf2/utils.hpp>
 
 #include "autoware_adapi_v1_msgs/msg/operation_mode_state.hpp"
 #include "autoware_control_msgs/msg/longitudinal.hpp"
 #include "autoware_internal_debug_msgs/msg/float32_multi_array_stamped.hpp"
 #include "autoware_planning_msgs/msg/trajectory.hpp"
-#include "geometry_msgs/msg/pose_stamped.hpp"
-#include "tf2_msgs/msg/tf_message.hpp"
+#include "geometry_msgs/msg/pose.hpp"
 #include "visualization_msgs/msg/marker.hpp"
 
 #include <deque>

--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
@@ -97,11 +97,7 @@ private:
     double slope_angle{0.0};
     double dt{0.0};
     double temporal_predicted_time{std::numeric_limits<double>::quiet_NaN()};
-    double temporal_observed_time{std::numeric_limits<double>::quiet_NaN()};
     double temporal_fused_time{std::numeric_limits<double>::quiet_NaN()};
-    double temporal_window_min{std::numeric_limits<double>::quiet_NaN()};
-    double temporal_window_max{std::numeric_limits<double>::quiet_NaN()};
-    bool temporal_observation_used{false};
   };
   rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters_;
   rclcpp::Clock::SharedPtr clock_;

--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
@@ -56,6 +56,8 @@ using visualization_msgs::msg::MarkerArray;
 
 namespace trajectory_follower = ::autoware::motion::control::trajectory_follower;
 
+enum class ControlState { DRIVE = 0, STOPPING, STOPPED, EMERGENCY };
+
 /// \class PidLongitudinalController
 /// \brief The node class used for generating longitudinal control commands (velocity/acceleration)
 class PidLongitudinalController : public trajectory_follower::LongitudinalControllerBase
@@ -123,16 +125,7 @@ private:
   std::shared_ptr<rclcpp::Time> m_under_control_starting_time{nullptr};
 
   // control state
-  enum class ControlState { DRIVE = 0, STOPPING, STOPPED, EMERGENCY };
   ControlState m_control_state{ControlState::STOPPED};
-  std::string toStr(const ControlState s)
-  {
-    if (s == ControlState::DRIVE) return "DRIVE";
-    if (s == ControlState::STOPPING) return "STOPPING";
-    if (s == ControlState::STOPPED) return "STOPPED";
-    if (s == ControlState::EMERGENCY) return "EMERGENCY";
-    return "UNDEFINED";
-  };
 
   // control period
   double m_longitudinal_ctrl_period;

--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
@@ -110,6 +110,7 @@ private:
   rclcpp::Publisher<autoware_internal_debug_msgs::msg::Float32MultiArrayStamped>::SharedPtr
     m_pub_debug;
   rclcpp::Publisher<MarkerArray>::SharedPtr m_pub_virtual_wall_marker;
+  std::optional<MarkerArray> m_virtual_wall_marker{std::nullopt};
 
   rclcpp::Node::OnSetParametersCallbackHandle::SharedPtr m_set_param_res;
   rcl_interfaces::msg::SetParametersResult paramCallback(
@@ -311,6 +312,11 @@ private:
    * @param [in] control_data data for control calculation
    */
   void publishDebugData(const Motion & ctrl_cmd, const ControlData & control_data);
+
+  /**
+   * @brief publish the virtual wall marker created during this cycle, if any
+   */
+  void publishVirtualWallMarker();
 
   /**
    * @brief calculate time between current and previous one

--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
@@ -119,7 +119,7 @@ private:
   // pointers for ros topic
   nav_msgs::msg::Odometry m_current_kinematic_state;
   geometry_msgs::msg::AccelWithCovarianceStamped m_current_accel;
-  autoware_planning_msgs::msg::Trajectory m_trajectory;
+  autoware_planning_msgs::msg::Trajectory m_last_valid_trajectory;
   OperationModeState m_current_operation_mode;
 
   // vehicle info

--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
@@ -118,7 +118,6 @@ private:
 
   // vehicle info
   double m_wheel_base{0.0};
-  double m_vehicle_width{0.0};
   double m_front_overhang{0.0};
   bool m_prev_vehicle_is_under_control{false};
   std::shared_ptr<rclcpp::Time> m_under_control_starting_time{nullptr};

--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
@@ -37,7 +37,6 @@
 #include "autoware_internal_debug_msgs/msg/float32_multi_array_stamped.hpp"
 #include "autoware_planning_msgs/msg/trajectory.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
-#include "nav_msgs/msg/odometry.hpp"
 #include "tf2_msgs/msg/tf_message.hpp"
 #include "visualization_msgs/msg/marker.hpp"
 
@@ -91,6 +90,8 @@ private:
     size_t target_idx{0};
     StateAfterDelay state_after_delay{0.0, 0.0, 0.0};
     Motion current_motion{};
+    geometry_msgs::msg::Pose current_pose{};
+    OperationModeState operation_mode{};
     Shift shift{Shift::Forward};  // shift is used only to calculate the sign of pitch compensation
     double stop_dist{0.0};  // signed distance that is positive when car is before the stopline
     double slope_angle{0.0};
@@ -117,10 +118,7 @@ private:
     const std::vector<rclcpp::Parameter> & parameters);
 
   // pointers for ros topic
-  nav_msgs::msg::Odometry m_current_kinematic_state;
-  geometry_msgs::msg::AccelWithCovarianceStamped m_current_accel;
   autoware_planning_msgs::msg::Trajectory m_last_valid_trajectory;
-  OperationModeState m_current_operation_mode;
 
   // vehicle info
   double m_wheel_base{0.0};
@@ -268,24 +266,6 @@ private:
   };
 
   /**
-   * @brief set current and previous velocity with received message
-   * @param [in] msg current state message
-   */
-  void setKinematicState(const nav_msgs::msg::Odometry & msg);
-
-  /**
-   * @brief set current acceleration with received message
-   * @param [in] msg trajectory message
-   */
-  void setCurrentAcceleration(const geometry_msgs::msg::AccelWithCovarianceStamped & msg);
-
-  /**
-   * @brief set current operation mode with received message
-   * @param [in] msg operation mode report message
-   */
-  void setCurrentOperationMode(const OperationModeState & msg);
-
-  /**
    * @brief set reference trajectory with received message
    * @param [in] msg trajectory message
    */
@@ -301,15 +281,16 @@ private:
 
   /**
    * @brief calculate data for controllers whose type is ControlData
-   * @param [in] current_pose current ego pose
+   * @param [in] input_data input data containing current odometry, acceleration, and operation
+   * mode
    */
-  ControlData getControlData(const geometry_msgs::msg::Pose & current_pose);
+  ControlData getControlData(const trajectory_follower::InputData & input_data);
 
   /**
    * @brief calculate control command in emergency state
-   * @param [in] dt time between previous and current one
+   * @param [in] control_data data for control calculation
    */
-  Motion calcEmergencyCtrlCmd(const double dt);
+  Motion calcEmergencyCtrlCmd(const ControlData & control_data);
 
   /**
    * @brief change control state
@@ -402,11 +383,11 @@ private:
 
   /**
    * @brief calculate predicted velocity after time delay based on past control commands
-   * @param [in] current_motion current velocity and acceleration of the vehicle
+   * @param [in] control_data data for control calculation
    * @param [in] delay_compensation_time predicted time delay
    */
   StateAfterDelay predictedStateAfterDelay(
-    const Motion current_motion, const double delay_compensation_time) const;
+    const ControlData & control_data, const double delay_compensation_time) const;
 
   /**
    * @brief calculate velocity feedback with feed forward and pid controller

--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -990,16 +990,14 @@ void PidLongitudinalController::publishDebugData(
   m_debug_values.setValues(
     DebugValues::TYPE::TEMPORAL_PREDICTED_TIME, control_data.temporal_predicted_time);
   m_debug_values.setValues(
-    DebugValues::TYPE::TEMPORAL_OBSERVED_TIME, control_data.temporal_observed_time);
+    DebugValues::TYPE::TEMPORAL_OBSERVED_TIME, std::numeric_limits<double>::quiet_NaN());
   m_debug_values.setValues(
     DebugValues::TYPE::TEMPORAL_FUSED_TIME, control_data.temporal_fused_time);
+  m_debug_values.setValues(DebugValues::TYPE::TEMPORAL_OBSERVATION_USED, 0.0);
   m_debug_values.setValues(
-    DebugValues::TYPE::TEMPORAL_OBSERVATION_USED,
-    control_data.temporal_observation_used ? 1.0 : 0.0);
+    DebugValues::TYPE::TEMPORAL_WINDOW_MIN, std::numeric_limits<double>::quiet_NaN());
   m_debug_values.setValues(
-    DebugValues::TYPE::TEMPORAL_WINDOW_MIN, control_data.temporal_window_min);
-  m_debug_values.setValues(
-    DebugValues::TYPE::TEMPORAL_WINDOW_MAX, control_data.temporal_window_max);
+    DebugValues::TYPE::TEMPORAL_WINDOW_MAX, std::numeric_limits<double>::quiet_NaN());
 
   // publish debug values
   autoware_internal_debug_msgs::msg::Float32MultiArrayStamped debug_msg{};

--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -273,7 +273,7 @@ void PidLongitudinalController::setTrajectory(const autoware_planning_msgs::msg:
     return;
   }
 
-  m_trajectory = msg;
+  m_last_valid_trajectory = msg;
 }
 
 rcl_interfaces::msg::SetParametersResult PidLongitudinalController::paramCallback(
@@ -472,7 +472,7 @@ PidLongitudinalController::ControlData PidLongitudinalController::getControlData
   // current velocity and acceleration
   control_data.current_motion.vel = m_current_kinematic_state.twist.twist.linear.x;
   control_data.current_motion.acc = m_current_accel.accel.accel.linear.x;
-  control_data.interpolated_traj = m_trajectory;
+  control_data.interpolated_traj = m_last_valid_trajectory;
   if (control_data.interpolated_traj.points.size() < 2) {
     RCLCPP_ERROR_THROTTLE(
       logger_, *clock_, 3000, "Trajectory size is less than 2. Cannot calculate control data.");
@@ -487,7 +487,7 @@ PidLongitudinalController::ControlData PidLongitudinalController::getControlData
   autoware_planning_msgs::msg::TrajectoryPoint target_point;
 
   if (m_use_temporal_trajectory) {
-    const rclcpp::Time traj_stamp(m_trajectory.header.stamp);
+    const rclcpp::Time traj_stamp(m_last_valid_trajectory.header.stamp);
     const double elapsed_time = (clock_->now() - traj_stamp).seconds();
     const double nearest_time = std::clamp(elapsed_time, traj_start_time, traj_end_time);
     control_data.temporal_predicted_time = nearest_time;
@@ -714,7 +714,7 @@ void PidLongitudinalController::updateControlState(const ControlData & control_d
       : false;
 
   // ==========================================================================================
-  // NOTE: due to removeOverlapPoints() in getControlData() m_trajectory and
+  // NOTE: due to removeOverlapPoints() in getControlData() m_last_valid_trajectory and
   // control_data.interpolated_traj have different size.
   // ==========================================================================================
   const double current_vel_cmd = std::fabs(

--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -31,6 +31,18 @@
 
 namespace autoware::motion::control::pid_longitudinal_controller
 {
+namespace
+{
+std::string toStr(const ControlState state)
+{
+  if (state == ControlState::DRIVE) return "DRIVE";
+  if (state == ControlState::STOPPING) return "STOPPING";
+  if (state == ControlState::STOPPED) return "STOPPED";
+  if (state == ControlState::EMERGENCY) return "EMERGENCY";
+  return "UNDEFINED";
+}
+}  // namespace
+
 PidLongitudinalController::PidLongitudinalController(
   rclcpp::Node & node, std::shared_ptr<diagnostic_updater::Updater> diag_updater)
 : node_parameters_(node.get_node_parameters_interface()),

--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -58,8 +58,6 @@ PidLongitudinalController::PidLongitudinalController(
   }
 
   m_wheel_base = autoware::vehicle_info_utils::VehicleInfoUtils(node).getVehicleInfo().wheel_base_m;
-  m_vehicle_width =
-    autoware::vehicle_info_utils::VehicleInfoUtils(node).getVehicleInfo().vehicle_width_m;
   m_front_overhang =
     autoware::vehicle_info_utils::VehicleInfoUtils(node).getVehicleInfo().front_overhang_m;
 

--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -245,22 +245,6 @@ PidLongitudinalController::PidLongitudinalController(
   setupDiagnosticUpdater();
 }
 
-void PidLongitudinalController::setKinematicState(const nav_msgs::msg::Odometry & msg)
-{
-  m_current_kinematic_state = msg;
-}
-
-void PidLongitudinalController::setCurrentAcceleration(
-  const geometry_msgs::msg::AccelWithCovarianceStamped & msg)
-{
-  m_current_accel = msg;
-}
-
-void PidLongitudinalController::setCurrentOperationMode(const OperationModeState & msg)
-{
-  m_current_operation_mode = msg;
-}
-
 void PidLongitudinalController::setTrajectory(const autoware_planning_msgs::msg::Trajectory & msg)
 {
   if (!longitudinal_utils::isValidTrajectory(msg, m_use_temporal_trajectory)) {
@@ -431,14 +415,9 @@ trajectory_follower::LongitudinalOutput PidLongitudinalController::run(
 {
   // set input data
   setTrajectory(input_data.current_trajectory);
-  setKinematicState(input_data.current_odometry);
-  setCurrentAcceleration(input_data.current_accel);
-  setCurrentOperationMode(input_data.current_operation_mode);
 
-  // calculate current pose and control data
-  geometry_msgs::msg::Pose current_pose = m_current_kinematic_state.pose.pose;
-
-  const auto control_data = getControlData(current_pose);
+  // calculate control data
+  const auto control_data = getControlData(input_data);
 
   // update control state
   updateControlState(control_data);
@@ -462,16 +441,20 @@ trajectory_follower::LongitudinalOutput PidLongitudinalController::run(
 }
 
 PidLongitudinalController::ControlData PidLongitudinalController::getControlData(
-  const geometry_msgs::msg::Pose & current_pose)
+  const trajectory_follower::InputData & input_data)
 {
   ControlData control_data{};
+
+  const geometry_msgs::msg::Pose & current_pose = input_data.current_odometry.pose.pose;
 
   // dt
   control_data.dt = getDt();
 
   // current velocity and acceleration
-  control_data.current_motion.vel = m_current_kinematic_state.twist.twist.linear.x;
-  control_data.current_motion.acc = m_current_accel.accel.accel.linear.x;
+  control_data.current_motion.vel = input_data.current_odometry.twist.twist.linear.x;
+  control_data.current_motion.acc = input_data.current_accel.accel.accel.linear.x;
+  control_data.current_pose = current_pose;
+  control_data.operation_mode = input_data.current_operation_mode;
   control_data.interpolated_traj = m_last_valid_trajectory;
   if (control_data.interpolated_traj.points.size() < 2) {
     RCLCPP_ERROR_THROTTLE(
@@ -521,7 +504,7 @@ PidLongitudinalController::ControlData PidLongitudinalController::getControlData
   // Delay compensation - Calculate the distance we got, predicted velocity and predicted
   // acceleration after delay
   control_data.state_after_delay =
-    predictedStateAfterDelay(control_data.current_motion, m_delay_compensation_time);
+    predictedStateAfterDelay(control_data, m_delay_compensation_time);
 
   // calculate the target motion for delay compensation
   constexpr double min_running_dist = 0.01;
@@ -634,8 +617,11 @@ PidLongitudinalController::ControlData PidLongitudinalController::getControlData
   return control_data;
 }
 
-PidLongitudinalController::Motion PidLongitudinalController::calcEmergencyCtrlCmd(const double dt)
+PidLongitudinalController::Motion PidLongitudinalController::calcEmergencyCtrlCmd(
+  const ControlData & control_data)
 {
+  const double dt = control_data.dt;
+
   // These accelerations are without slope compensation
   const auto & p = m_emergency_state_params;
   Motion raw_ctrl_cmd{p.vel, p.acc};
@@ -649,7 +635,7 @@ PidLongitudinalController::Motion PidLongitudinalController::calcEmergencyCtrlCm
   m_debug_values.setValues(DebugValues::TYPE::ACC_CMD_JERK_LIMITED, raw_ctrl_cmd.acc);
 
   const auto virtual_wall_marker = autoware::motion_utils::createStopVirtualWallMarker(
-    m_current_kinematic_state.pose.pose, "velocity control\n (emergency)", clock_->now(), 0,
+    control_data.current_pose, "velocity control\n (emergency)", clock_->now(), 0,
     m_wheel_base + m_front_overhang);
   m_pub_virtual_wall_marker->publish(virtual_wall_marker);
 
@@ -732,8 +718,8 @@ void PidLongitudinalController::updateControlState(const ControlData & control_d
 
   const auto debug_msg_once = [this](const auto & s) { RCLCPP_DEBUG_ONCE(logger_, "%s", s); };
 
-  const bool is_under_control = m_current_operation_mode.is_autoware_control_enabled &&
-                                m_current_operation_mode.mode == OperationModeState::AUTONOMOUS;
+  const bool is_under_control = control_data.operation_mode.is_autoware_control_enabled &&
+                                control_data.operation_mode.mode == OperationModeState::AUTONOMOUS;
 
   if (is_under_control != m_prev_vehicle_is_under_control) {
     m_prev_vehicle_is_under_control = is_under_control;
@@ -822,8 +808,8 @@ void PidLongitudinalController::updateControlState(const ControlData & control_d
         // publish debug marker
         if (is_under_control) {
           const auto virtual_wall_marker = autoware::motion_utils::createStopVirtualWallMarker(
-            m_current_kinematic_state.pose.pose, "velocity control\n(steering not converged)",
-            clock_->now(), 0, m_wheel_base + m_front_overhang);
+            control_data.current_pose, "velocity control\n(steering not converged)", clock_->now(),
+            0, m_wheel_base + m_front_overhang);
           m_pub_virtual_wall_marker->publish(virtual_wall_marker);
         }
 
@@ -900,7 +886,7 @@ PidLongitudinalController::Motion PidLongitudinalController::calcCtrlCmd(
       control_data.interpolated_traj.points.at(target_idx).longitudinal_velocity_mps,
       control_data.interpolated_traj.points.at(target_idx).acceleration_mps2};
     if (m_control_state == ControlState::EMERGENCY) {
-      raw_ctrl_cmd = calcEmergencyCtrlCmd(control_data.dt);
+      raw_ctrl_cmd = calcEmergencyCtrlCmd(control_data);
     } else {
       if (m_control_state == ControlState::DRIVE) {
         raw_ctrl_cmd.vel = control_data.interpolated_traj.points.at(control_data.target_idx)
@@ -1149,15 +1135,16 @@ PidLongitudinalController::calcInterpolatedTrajPointAndSegment(
 }
 
 PidLongitudinalController::StateAfterDelay PidLongitudinalController::predictedStateAfterDelay(
-  const Motion current_motion, const double delay_compensation_time) const
+  const ControlData & control_data, const double delay_compensation_time) const
 {
-  const double current_vel = current_motion.vel;
-  const double current_acc = current_motion.acc;
+  const double current_vel = control_data.current_motion.vel;
+  const double current_acc = control_data.current_motion.acc;
   double running_distance = 0.0;
   double pred_vel = current_vel;
   double pred_acc = current_acc;
 
-  if (m_ctrl_cmd_vec.empty() || m_current_operation_mode.mode != OperationModeState::AUTONOMOUS) {
+  if (
+    m_ctrl_cmd_vec.empty() || control_data.operation_mode.mode != OperationModeState::AUTONOMOUS) {
     // check time to stop
     const double time_to_stop = -current_vel / current_acc;
     const double delay_time_calculation =
@@ -1212,8 +1199,8 @@ double PidLongitudinalController::applyVelocityFeedback(const ControlData & cont
     control_data.interpolated_traj.points.at(control_data.target_idx).longitudinal_velocity_mps,
     control_data.interpolated_traj.points.at(control_data.target_idx).acceleration_mps2};
   const double diff_vel = (target_motion.vel - current_vel) * vel_sign;
-  const bool is_under_control = m_current_operation_mode.is_autoware_control_enabled &&
-                                m_current_operation_mode.mode == OperationModeState::AUTONOMOUS;
+  const bool is_under_control = control_data.operation_mode.is_autoware_control_enabled &&
+                                control_data.operation_mode.mode == OperationModeState::AUTONOMOUS;
 
   const bool vehicle_is_moving = std::abs(current_vel) > m_current_vel_threshold_pid_integrate;
   const double time_under_control = getTimeUnderControl();

--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -447,6 +447,9 @@ trajectory_follower::LongitudinalOutput PidLongitudinalController::run(
   // publish debug data
   publishDebugData(ctrl_cmd, control_data);
 
+  // publish virtual wall marker if created during this cycle
+  publishVirtualWallMarker();
+
   return output;
 }
 
@@ -644,10 +647,9 @@ PidLongitudinalController::Motion PidLongitudinalController::calcEmergencyCtrlCm
     longitudinal_utils::applyDiffLimitFilter(raw_ctrl_cmd.acc, m_prev_raw_ctrl_cmd.acc, dt, p.jerk);
   m_debug_values.setValues(DebugValues::TYPE::ACC_CMD_JERK_LIMITED, raw_ctrl_cmd.acc);
 
-  const auto virtual_wall_marker = autoware::motion_utils::createStopVirtualWallMarker(
+  m_virtual_wall_marker = autoware::motion_utils::createStopVirtualWallMarker(
     control_data.current_pose, "velocity control\n (emergency)", clock_->now(), 0,
     m_wheel_base + m_front_overhang);
-  m_pub_virtual_wall_marker->publish(virtual_wall_marker);
 
   return raw_ctrl_cmd;
 }
@@ -815,12 +817,11 @@ void PidLongitudinalController::updateControlState(const ControlData & control_d
           debug_msg_once("target speed > 0, but keep stop condition is met. Keep STOPPED.");
         }
 
-        // publish debug marker
+        // create debug marker
         if (is_under_control) {
-          const auto virtual_wall_marker = autoware::motion_utils::createStopVirtualWallMarker(
+          m_virtual_wall_marker = autoware::motion_utils::createStopVirtualWallMarker(
             control_data.current_pose, "velocity control\n(steering not converged)", clock_->now(),
             0, m_wheel_base + m_front_overhang);
-          m_pub_virtual_wall_marker->publish(virtual_wall_marker);
         }
 
         // keep STOPPED
@@ -1023,6 +1024,15 @@ void PidLongitudinalController::publishDebugData(
   slope_msg.data.push_back(
     static_cast<decltype(slope_msg.data)::value_type>(control_data.slope_angle));
   m_pub_slope->publish(slope_msg);
+}
+
+void PidLongitudinalController::publishVirtualWallMarker()
+{
+  if (!m_virtual_wall_marker) {
+    return;
+  }
+  m_pub_virtual_wall_marker->publish(*m_virtual_wall_marker);
+  m_virtual_wall_marker.reset();
 }
 
 double PidLongitudinalController::getDt()


### PR DESCRIPTION
## Description

This PR contains a series of small, independent refactoring steps for `autoware_pid_longitudinal_controller` that prepare the class for decoupling from `rclcpp::Node`. 

Commit-by-commit breakdown:

- `cbc2639b36` - refactor(autoware_pid_longitudinal_controller): rename m_trajectory to m_last_valid_trajectory
  Renames the member for clarity; no behavior change.

- `f9b2457f24` - refactor(autoware_pid_longitudinal_controller): fetch current state from ControlData
  Removes the `m_current_kinematic_state`, `m_current_accel`, and `m_current_operation_mode` member variables. These values are now carried in `ControlData` and passed explicitly through the call chain instead of being cached as node-level state.

- `ecfff954af` - refactor(autoware_pid_longitudinal_controller): remove unused temporal fields from ControlData
  Removes never written fields

- `dababfe0db` - refactor(autoware_pid_longitudinal_controller): remove unused m_vehicle_width member
  Removes the unused `m_vehicle_width` member.

- `dc76fd22dd` - refactor(autoware_pid_longitudinal_controller): move toStr to a free function
  Moves `toStr` out of the class into a free helper function, since it does not depend on any member state.

- `530b7a301e` - refactor(autoware_pid_longitudinal_controller): move virtual wall marker publish to run()
  Stores the marker created in `calcEmergencyCtrlCmd()` / `updateControlState()` into `m_virtual_wall_marker` and publishes it once from `run()` via `publishVirtualWallMarker()`, removing the publisher call from the control logic to prepare for decoupling from `rclcpp::Node`.

- `195a35ad91` - refactor(autoware_pid_longitudinal_controller): remove unused includes
  Removes unused includes.


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

```bash
PACKAGE_NAME=autoware_pid_longitudinal_controller && colcon build --packages-select $PACKAGE_NAME && colcon test --packages-select $PACKAGE_NAME --event-handlers console_cohesion+
```

All existing unit and integration tests pass with no behavior changes intended.

Evaluator links
https://evaluation.tier4.jp/evaluation/reports/76df5c75-2022-5c3c-9a68-b7b85dcc3987/?project_id=autoware_dev
https://evaluation.tier4.jp/evaluation/reports/7486bfb9-73e0-5a83-aa02-a1fa27a60245/?project_id=autoware_dev
https://evaluation.tier4.jp/evaluation/reports/df93f1e5-782d-5c12-bfbb-23e6fd97e22a/?project_id=autoware_dev

## Notes for reviewers

This PR is a stack of small, self-contained refactoring commits rather than one large change. **Please review each commit individually** rather than the squashed diff — each commit is scoped to a single, easily verifiable change

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
