### PR TITLE
fix: use highest probability classification (#3173)

### DIFF
--- a/control/autoware_collision_detector/package.xml
+++ b/control/autoware_collision_detector/package.xml
@@ -20,6 +20,7 @@
 
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_motion_utils</depend>
+  <depend>autoware_object_recognition_utils</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_utils</depend>
   <depend>autoware_vehicle_info_utils</depend>

--- a/control/autoware_collision_detector/src/node.cpp
+++ b/control/autoware_collision_detector/src/node.cpp
@@ -16,6 +16,7 @@
 
 #include "autoware/collision_detector/debug.hpp"
 
+#include <autoware/object_recognition_utils/object_classification.hpp>
 #include <autoware_utils/geometry/geometry.hpp>
 #include <autoware_utils/ros/uuid_helper.hpp>
 #include <autoware_utils_geometry/boost_geometry.hpp>
@@ -222,9 +223,10 @@ PredictedObjects CollisionDetectorNode::filterObjects(const PredictedObjects & i
     const bool is_within_range = (object_distance <= node_param_.nearby_filter_radius);
 
     // Determine if the object should be excluded based on its classification
-    const auto classification = object.classification.empty()
-                                  ? autoware_perception_msgs::msg::ObjectClassification::UNKNOWN
-                                  : object.classification.front().label;
+    const auto classification =
+      object.classification.empty()
+        ? autoware_perception_msgs::msg::ObjectClassification::UNKNOWN
+        : autoware::object_recognition_utils::getHighestProbLabel(object.classification);
     bool should_be_excluded = shouldBeExcluded(classification);
 
     const bool is_within_range_and_filtering_class = is_within_range && should_be_excluded;

--- a/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp
+++ b/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp
@@ -15,6 +15,7 @@
 #ifndef AUTOWARE__TRAJECTORY_PROCESSOR__TRAJECTORY_MODIFIER_UTILS__OBSTACLE_STOP_UTILS_HPP_
 #define AUTOWARE__TRAJECTORY_PROCESSOR__TRAJECTORY_MODIFIER_UTILS__OBSTACLE_STOP_UTILS_HPP_
 
+#include <autoware/object_recognition_utils/object_classification.hpp>
 #include <autoware_utils_geometry/boost_geometry.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info.hpp>
 #include <rclcpp/time.hpp>
@@ -288,8 +289,10 @@ struct ObjectFilter
         [&](const auto & object) {
           if (object.kinematics.initial_twist_with_covariance.twist.linear.x > max_velocity_th_)
             return true;
-          const auto & label = object.classification.empty() ? ObjectClassification::UNKNOWN
-                                                             : object.classification.front().label;
+          const auto label =
+            object.classification.empty()
+              ? ObjectClassification::UNKNOWN
+              : autoware::object_recognition_utils::getHighestProbLabel(object.classification);
           if (classification_to_object_type.count(label) == 0) return true;
           return object_types_.count(classification_to_object_type.at(label)) == 0;
         }),

--- a/planning/autoware_trajectory_processor/package.xml
+++ b/planning/autoware_trajectory_processor/package.xml
@@ -21,6 +21,7 @@
   <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_motion_utils</depend>
+  <depend>autoware_object_recognition_utils</depend>
   <depend>autoware_obstacle_proximity_checker</depend>
   <depend>autoware_osqp_interface</depend>
   <depend>autoware_path_optimizer</depend>

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -364,8 +364,11 @@ std::optional<CollisionPoint> get_nearest_object_collision(
   auto is_safe = [&](
                    const auto & object, const double obj_arc_length, const double obj_lon_vel,
                    const double ego_arc_length, const double ego_vel) -> std::pair<bool, bool> {
-    if (object.classification.empty()) return {false, false};
-    const auto obj_type = classification_to_object_type.at(object.classification.front().label);
+    const auto label =
+      object.classification.empty()
+        ? ObjectClassification::UNKNOWN
+        : autoware::object_recognition_utils::getHighestProbLabel(object.classification);
+    const auto obj_type = classification_to_object_type.at(label);
     if (!object_decel_map.count(obj_type)) return {false, false};
     const auto obj_decel = object_decel_map.at(obj_type);
     if (obj_lon_vel < stopped_vel_th) return {false, false};
@@ -573,9 +576,12 @@ void ObstacleTracker::update_objects(
     for (const auto & [uuid, existing_object] : persistent_objects_map_) {
       const auto existing_obj_label = existing_object.object.classification.empty()
                                         ? ObjectClassification::UNKNOWN
-                                        : existing_object.object.classification.front().label;
-      const auto obj_label = object.classification.empty() ? ObjectClassification::UNKNOWN
-                                                           : object.classification.front().label;
+                                        : autoware::object_recognition_utils::getHighestProbLabel(
+                                            existing_object.object.classification);
+      const auto obj_label =
+        object.classification.empty()
+          ? ObjectClassification::UNKNOWN
+          : autoware::object_recognition_utils::getHighestProbLabel(object.classification);
       if (existing_obj_label != obj_label) continue;
       const auto distance = autoware_utils::calc_distance2d(
         object.kinematics.initial_pose_with_covariance.pose.position,


### PR DESCRIPTION
## Description

  This PR fixes object classification handling to use the highest-probability classification label instead of the first element in the classification array.

  - Updated `autoware_collision_detector` object filtering.
  - Updated `autoware_trajectory_processor` obstacle stop object filtering, collision safety check, and obstacle tracking.
  - Explicitly keeps `UNKNOWN` handling for empty classification arrays.
  - Added `autoware_object_recognition_utils` as a package dependency where needed.

  ## Related links

  **Parent Issue:**

  - Link: N/A

## How was this PR tested?

- [x] https://evaluation.ci.tier4.jp/evaluation/reports/436c6f9b-63d9-5372-ad28-594d8c3517d4?project_id=autoware_dev
- [x] https://evaluation.ci.tier4.jp/evaluation/reports/b44fd248-3783-506c-a629-d89cd7e90f7e?project_id=autoware_dev
- [x] https://evaluation.ci.tier4.jp/evaluation/reports/a5c7ad77-1ff3-5ddc-a44b-9b7966538a0e?project_id=autoware_dev

## Notes for reviewers

  None.

## Interface changes

  None.

## Effects on system behavior

Objects with multiple classification candidates are now handled using the label with the highest probability. This affects collision detector filtering and trajectory processor obstacle stop behavior when classification arrays are not ordered by probability.