### PR TITLE
feat(diffusion_planner): `ego_snap_to_prev_trajectory`

### DIFF
--- a/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
+++ b/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
@@ -35,6 +35,9 @@
     delay_step: 0
     line_string_max_step_m: 5.0
     use_time_interpolation: false
+    ego_snap_to_prev_trajectory: true
+    ego_snap_max_position_error_m: 0.3
+    ego_snap_max_yaw_error_deg: 5.0
     planning_factor:
       enable_stop: true
       enable_slowdown: false

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_core.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_core.hpp
@@ -106,6 +106,11 @@ struct FrameContext
   Eigen::Matrix4d ego_to_map_transform;
   std::vector<AgentHistory> ego_centric_neighbor_histories;
   rclcpp::Time frame_time;
+  // Ego pose snapped onto the previous planning trajectory (map frame) and the interpolation time
+  // of the snapped foot along that trajectory. Set only when ego_snap_to_prev_trajectory actually
+  // snapped this frame; nullopt otherwise.
+  std::optional<Eigen::Matrix4d> snapped_pose;
+  std::optional<double> snapped_interpolation_time_s;
 };
 
 struct DiffusionPlannerParams
@@ -134,6 +139,9 @@ struct DiffusionPlannerParams
   int64_t delay_step;
   double line_string_max_step_m;
   bool use_time_interpolation;
+  bool ego_snap_to_prev_trajectory;
+  double ego_snap_max_position_error_m;
+  double ego_snap_max_yaw_error_deg;
   int dpm_solver_steps;
   double start_guidance_reference_distance_m;
   double start_guidance_max_scale;
@@ -336,6 +344,7 @@ private:
   AgentData agent_data_;
   std::map<lanelet::Id, TrafficSignalStamped> traffic_light_id_map_;
   std::vector<std::vector<std::vector<Eigen::Matrix4d>>> last_agent_poses_map_;
+  std::optional<Eigen::Matrix4d> last_ego_to_map_transform_;
 
   // Lanelet map
   LaneletRoute::ConstSharedPtr route_ptr_;

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_node.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_node.hpp
@@ -39,6 +39,7 @@
 #include <autoware_perception_msgs/msg/traffic_light_group.hpp>
 #include <autoware_planning_msgs/msg/trajectory.hpp>
 #include <autoware_vehicle_msgs/msg/turn_indicators_command.hpp>
+#include <geometry_msgs/msg/pose_stamped.hpp>
 #include <std_msgs/msg/float32_multi_array.hpp>
 #include <std_msgs/msg/float64.hpp>
 #include <std_srvs/srv/set_bool.hpp>
@@ -165,6 +166,15 @@ private:
   void publish_first_traffic_light_on_route(const FrameContext & frame_context) const;
 
   /**
+   * @brief Publish the ego pose snapped onto the previous trajectory and the interpolation time
+   *        used to compute it. Does nothing when the frame did not snap the ego pose.
+   * @param frame_context Context of the current frame.
+   * @param timestamp Timestamp of the current frame.
+   */
+  void publish_snapped_pose(
+    const FrameContext & frame_context, const rclcpp::Time & timestamp) const;
+
+  /**
    * @brief Publish planning factors (stop/slowdown) derived from the trajectory.
    * @param trajectory The planned trajectory.
    */
@@ -227,6 +237,9 @@ private:
   rclcpp::Publisher<TurnIndicatorsCommand>::SharedPtr pub_turn_indicators_{nullptr};
   rclcpp::Publisher<autoware_perception_msgs::msg::TrafficLightGroup>::SharedPtr
     pub_traffic_signal_{nullptr};
+  rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr pub_snapped_pose_{nullptr};
+  rclcpp::Publisher<autoware_internal_debug_msgs::msg::Float64Stamped>::SharedPtr
+    pub_snap_interpolation_time_{nullptr};
   rclcpp::Publisher<std_msgs::msg::Float64>::SharedPtr pub_inference_time_{nullptr};
   rclcpp::Publisher<std_msgs::msg::Float32MultiArray>::SharedPtr pub_denoising_steps_{nullptr};
   rclcpp::Publisher<autoware_internal_debug_msgs::msg::StringStamped>::SharedPtr

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/utils/utils.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/utils/utils.hpp
@@ -70,6 +70,37 @@ std::pair<float, float> rotation_matrix_to_cos_sin(const Eigen::Matrix3d & rotat
 geometry_msgs::msg::Pose shift_x(const geometry_msgs::msg::Pose & pose, const double shift_length);
 
 /**
+ * @brief Result of projecting a query point onto a polyline.
+ */
+struct PolylineProjection
+{
+  //! Projected pose (foot of the perpendicular) as a 4x4 transformation matrix.
+  Eigen::Matrix4d pose;
+  //! Position of the foot along the polyline, expressed as (closest segment index +
+  //! intra-segment ratio in [0, 1]). Multiplying by the per-segment time step yields the
+  //! interpolation time of the foot along the polyline.
+  double interpolation_index;
+};
+
+/**
+ * @brief Projects a 2D query point onto a polyline and returns the pose at the foot of the
+ *        perpendicular to the closest line segment.
+ *
+ * The polyline is treated as (polyline.size() - 1) line segments in the xy-plane. For each
+ * segment, the foot of the perpendicular from the query point (clamped to the segment endpoints)
+ * is computed, and the segment with the smallest distance is selected. The returned pose has the
+ * foot position as (x, y) and an orientation obtained by spherically interpolating (slerp) the two
+ * endpoint orientations by the projection ratio. The z component is left at 0.
+ *
+ * @param query_x X coordinate of the query point.
+ * @param query_y Y coordinate of the query point.
+ * @param polyline Sequence of poses (must contain at least two elements) forming the polyline.
+ * @return The projected pose together with the interpolation index of the foot along the polyline.
+ */
+PolylineProjection project_pose_onto_polyline(
+  double query_x, double query_y, const std::vector<Eigen::Matrix4d> & polyline);
+
+/**
  * @brief Computes the inverse of a 4x4 transformation matrix.
  * @note This function assumes that the matrix represents a rigid transformation and uses the
  * properties of Eigen::Isometry3d internally instead of a general 4x4 matrix inversion for better

--- a/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
+++ b/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
@@ -176,6 +176,21 @@
           "default": false,
           "description": "Whether to interpolate ego past trajectory at regular time intervals"
         },
+        "ego_snap_to_prev_trajectory": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether to snap the ego pose onto the previous planning trajectory. When enabled, the ego pose is replaced by the foot of the perpendicular to the closest segment of the previous planning trajectory (planning start pose + previous prediction)."
+        },
+        "ego_snap_max_position_error_m": {
+          "type": "number",
+          "default": 0.3,
+          "description": "Maximum allowed position distance [m] between the actual ego pose and the snapped pose. If the distance exceeds this value the snap is skipped and the raw ego pose is kept."
+        },
+        "ego_snap_max_yaw_error_deg": {
+          "type": "number",
+          "default": 5.0,
+          "description": "Maximum allowed heading difference [deg] between the actual ego pose and the snapped pose. If the difference exceeds this value the snap is skipped and the raw ego pose is kept."
+        },
         "guidance": {
           "type": "object",
           "properties": {

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
@@ -14,6 +14,7 @@
 
 #include "autoware/diffusion_planner/diffusion_planner_core.hpp"
 
+#include "autoware/diffusion_planner/constants.hpp"
 #include "autoware/diffusion_planner/conversion/agent.hpp"
 #include "autoware/diffusion_planner/dimensions.hpp"
 #include "autoware/diffusion_planner/inference/guidance/centerline_guidance.hpp"
@@ -84,6 +85,7 @@ DiffusionPlannerCore::DiffusionPlannerCore(
 void DiffusionPlannerCore::load_model()
 {
   last_agent_poses_map_.clear();
+  last_ego_to_map_transform_.reset();
   diffusion_planner_inference_.reset();
   utils::check_weight_version(params_.args_path);
   observation_normalization_ = utils::load_observation_normalization(params_.args_path);
@@ -260,6 +262,88 @@ std::optional<FrameContext> DiffusionPlannerCore::create_frame_context(
       utils::shift_x(kinematic_state.pose.pose, vehicle_spec_.base_link_to_center);
   }
 
+  // Snap the ego pose onto the previous planning trajectory. The previous trajectory is the
+  // polyline formed by the previous planning start pose (last_ego_to_map_transform_) followed by
+  // the previous prediction (last_agent_poses_map_[0][0]), i.e. OUTPUT_T + 1 points forming
+  // OUTPUT_T segments. The foot of the perpendicular to the closest segment becomes the next ego
+  // pose. Note that kinematic_state here is already in the model frame (center frame when shift_x
+  // is enabled), which matches the frame the previous trajectory was generated in.
+  std::optional<Eigen::Matrix4d> snapped_pose_opt;
+  std::optional<double> snapped_interpolation_time_s_opt;
+  if (
+    params_.ego_snap_to_prev_trajectory && last_ego_to_map_transform_.has_value() &&
+    !last_agent_poses_map_.empty() && !last_agent_poses_map_[0].empty() &&
+    !last_agent_poses_map_[0][0].empty()) {
+    constexpr int64_t batch_idx = 0;
+    constexpr int64_t agent_idx = 0;
+    const auto & prev_poses = last_agent_poses_map_[batch_idx][agent_idx];
+
+    std::vector<Eigen::Matrix4d> prev_trajectory;
+    prev_trajectory.reserve(prev_poses.size() + 1);
+    prev_trajectory.push_back(last_ego_to_map_transform_.value());
+    prev_trajectory.insert(prev_trajectory.end(), prev_poses.begin(), prev_poses.end());
+
+    // If the first few points of the previous trajectory are very close together, the projection
+    // can be unstable. If so, force them to be the same point to avoid this issue.
+    bool all_close = true;
+    constexpr int64_t num_check = 10;
+    for (int64_t i = 0; i < num_check; ++i) {
+      const auto p0 = prev_trajectory[i];
+      const auto p1 = prev_trajectory[i + 1];
+      const auto dist = std::hypot(p1(0, 3) - p0(0, 3), p1(1, 3) - p0(1, 3));
+      if (dist > 1.0) {
+        all_close = false;
+        break;
+      }
+    }
+    if (all_close) {
+      for (int64_t i = 0; i < num_check; ++i) {
+        prev_trajectory[i + 1](0, 3) = prev_trajectory[i](0, 3);
+      }
+    }
+
+    const utils::PolylineProjection projection = utils::project_pose_onto_polyline(
+      kinematic_state.pose.pose.position.x, kinematic_state.pose.pose.position.y, prev_trajectory);
+    const Eigen::Matrix4d & snapped_pose = projection.pose;
+
+    // Reject the snap when the actual ego pose is too far (in position or heading) from the
+    // snapped pose. In that case the previous planning trajectory no longer reflects reality
+    // (e.g. large tracking error or a disturbance), so keeping the raw ego pose is safer than
+    // forcing it onto a stale trajectory.
+    const double position_error_m = std::hypot(
+      kinematic_state.pose.pose.position.x - snapped_pose(0, 3),
+      kinematic_state.pose.pose.position.y - snapped_pose(1, 3));
+    const Eigen::Quaterniond current_q(
+      kinematic_state.pose.pose.orientation.w, kinematic_state.pose.pose.orientation.x,
+      kinematic_state.pose.pose.orientation.y, kinematic_state.pose.pose.orientation.z);
+    const double current_yaw =
+      std::atan2(current_q.toRotationMatrix()(1, 0), current_q.toRotationMatrix()(0, 0));
+    const double snapped_yaw = std::atan2(snapped_pose(1, 0), snapped_pose(0, 0));
+    const double yaw_error_rad = std::abs(
+      std::atan2(std::sin(current_yaw - snapped_yaw), std::cos(current_yaw - snapped_yaw)));
+
+    const double yaw_error_deg = yaw_error_rad * 180.0 / M_PI;
+
+    if (
+      position_error_m <= params_.ego_snap_max_position_error_m &&
+      yaw_error_deg <= params_.ego_snap_max_yaw_error_deg) {
+      kinematic_state.pose.pose.position.x = snapped_pose(0, 3);
+      kinematic_state.pose.pose.position.y = snapped_pose(1, 3);
+      const Eigen::Quaterniond q(snapped_pose.block<3, 3>(0, 0));
+      kinematic_state.pose.pose.orientation.x = q.x();
+      kinematic_state.pose.pose.orientation.y = q.y();
+      kinematic_state.pose.pose.orientation.z = q.z();
+      kinematic_state.pose.pose.orientation.w = q.w();
+
+      // The polyline's first vertex is the previous planning start (t = 0) and each subsequent
+      // vertex advances by one prediction time step, so the interpolation index (segment index +
+      // intra-segment ratio) maps to time via the per-step duration.
+      snapped_pose_opt = snapped_pose;
+      snapped_interpolation_time_s_opt =
+        projection.interpolation_index * constants::PREDICTION_TIME_STEP_S;
+    }
+  }
+
   // Get transforms
   const geometry_msgs::msg::Pose & pose_base_link = kinematic_state.pose.pose;
   const Eigen::Matrix4d ego_to_map_transform = utils::pose_to_matrix4d(pose_base_link);
@@ -287,11 +371,20 @@ std::optional<FrameContext> DiffusionPlannerCore::create_frame_context(
   preprocess::process_traffic_signals(
     traffic_signals, traffic_light_id_map_, current_time, traffic_light_msg_timeout_s);
 
-  // Create frame context
+  // Create frame context. create_input_data re-applies shift_x to
+  // frame_context.ego_kinematic_state, so store the base_link-frame pose (undo the shift applied
+  // above) to keep the (possibly snapped) pose consistent across the whole frame.
+  Odometry frame_kinematic_state = kinematic_state;
+  if (params_.shift_x) {
+    frame_kinematic_state.pose.pose =
+      utils::shift_x(kinematic_state.pose.pose, -vehicle_spec_.base_link_to_center);
+  }
+
   const rclcpp::Time frame_time(ego_kinematic_state->header.stamp);
   const FrameContext frame_context{
-    *ego_kinematic_state, *ego_acceleration, ego_to_map_transform, processed_neighbor_histories,
-    frame_time};
+    frame_kinematic_state,           *ego_acceleration, ego_to_map_transform,
+    processed_neighbor_histories,    frame_time,        snapped_pose_opt,
+    snapped_interpolation_time_s_opt};
 
   return frame_context;
 }
@@ -508,6 +601,7 @@ PlannerOutput DiffusionPlannerCore::create_planner_output(
   const auto agent_poses =
     postprocess::parse_predictions(denormalized_predictions, frame_context.ego_to_map_transform);
   last_agent_poses_map_ = agent_poses;
+  last_ego_to_map_transform_ = frame_context.ego_to_map_transform;
 
   const bool enable_force_stop =
     frame_context.ego_kinematic_state.twist.twist.linear.x > std::numeric_limits<double>::epsilon();

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
@@ -283,25 +283,6 @@ std::optional<FrameContext> DiffusionPlannerCore::create_frame_context(
     prev_trajectory.push_back(last_ego_to_map_transform_.value());
     prev_trajectory.insert(prev_trajectory.end(), prev_poses.begin(), prev_poses.end());
 
-    // If the first few points of the previous trajectory are very close together, the projection
-    // can be unstable. If so, force them to be the same point to avoid this issue.
-    bool all_close = true;
-    constexpr int64_t num_check = 10;
-    for (int64_t i = 0; i < num_check; ++i) {
-      const auto p0 = prev_trajectory[i];
-      const auto p1 = prev_trajectory[i + 1];
-      const auto dist = std::hypot(p1(0, 3) - p0(0, 3), p1(1, 3) - p0(1, 3));
-      if (dist > 1.0) {
-        all_close = false;
-        break;
-      }
-    }
-    if (all_close) {
-      for (int64_t i = 0; i < num_check; ++i) {
-        prev_trajectory[i + 1](0, 3) = prev_trajectory[i](0, 3);
-      }
-    }
-
     const utils::PolylineProjection projection = utils::project_pose_onto_polyline(
       kinematic_state.pose.pose.position.x, kinematic_state.pose.pose.position.y, prev_trajectory);
     const Eigen::Matrix4d & snapped_pose = projection.pose;

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
@@ -84,6 +84,11 @@ DiffusionPlanner::DiffusionPlanner(const rclcpp::NodeOptions & options)
     this->create_publisher<TurnIndicatorsCommand>("~/output/turn_indicators", 1);
   pub_traffic_signal_ = this->create_publisher<autoware_perception_msgs::msg::TrafficLightGroup>(
     "~/output/debug/traffic_signal", 1);
+  pub_snapped_pose_ =
+    this->create_publisher<geometry_msgs::msg::PoseStamped>("~/debug/snapped_pose", 1);
+  pub_snap_interpolation_time_ =
+    this->create_publisher<autoware_internal_debug_msgs::msg::Float64Stamped>(
+      "~/debug/snap_interpolation_time", 1);
   debug_processing_time_detail_pub_ = this->create_publisher<autoware_utils::ProcessingTimeDetail>(
     "~/debug/processing_time_detail_ms", 1);
   debug_processing_time_pub_ =
@@ -199,6 +204,12 @@ void DiffusionPlanner::set_up_params()
   params_.delay_step = this->declare_parameter<int64_t>("delay_step", 0);
   params_.line_string_max_step_m = this->declare_parameter<double>("line_string_max_step_m", 5.0);
   params_.use_time_interpolation = this->declare_parameter<bool>("use_time_interpolation", false);
+  params_.ego_snap_to_prev_trajectory =
+    this->declare_parameter<bool>("ego_snap_to_prev_trajectory", true);
+  params_.ego_snap_max_position_error_m =
+    this->declare_parameter<double>("ego_snap_max_position_error_m", 0.3);
+  params_.ego_snap_max_yaw_error_deg =
+    this->declare_parameter<double>("ego_snap_max_yaw_error_deg", 5.0);
   params_.start_guidance_reference_distance_m =
     this->declare_parameter<double>("guidance.start_guidance.reference_distance_m", 10.0);
   params_.start_guidance_max_scale =
@@ -312,6 +323,12 @@ SetParametersResult DiffusionPlanner::on_parameter(
     update_param<int64_t>(parameters, "delay_step", temp_params.delay_step);
     update_param<double>(parameters, "line_string_max_step_m", temp_params.line_string_max_step_m);
     update_param<bool>(parameters, "use_time_interpolation", temp_params.use_time_interpolation);
+    update_param<bool>(
+      parameters, "ego_snap_to_prev_trajectory", temp_params.ego_snap_to_prev_trajectory);
+    update_param<double>(
+      parameters, "ego_snap_max_position_error_m", temp_params.ego_snap_max_position_error_m);
+    update_param<double>(
+      parameters, "ego_snap_max_yaw_error_deg", temp_params.ego_snap_max_yaw_error_deg);
     update_param<double>(
       parameters, "guidance.start_guidance.reference_distance_m",
       temp_params.start_guidance_reference_distance_m);
@@ -436,6 +453,33 @@ void DiffusionPlanner::publish_first_traffic_light_on_route(
   pub_traffic_signal_->publish(msg);
 }
 
+void DiffusionPlanner::publish_snapped_pose(
+  const FrameContext & frame_context, const rclcpp::Time & timestamp) const
+{
+  if (!frame_context.snapped_pose || !frame_context.snapped_interpolation_time_s) {
+    return;
+  }
+
+  const Eigen::Matrix4d & snapped_pose = frame_context.snapped_pose.value();
+  geometry_msgs::msg::PoseStamped pose_msg;
+  pose_msg.header.stamp = timestamp;
+  pose_msg.header.frame_id = "map";
+  pose_msg.pose.position.x = snapped_pose(0, 3);
+  pose_msg.pose.position.y = snapped_pose(1, 3);
+  pose_msg.pose.position.z = snapped_pose(2, 3);
+  const Eigen::Quaterniond q(snapped_pose.block<3, 3>(0, 0));
+  pose_msg.pose.orientation.x = q.x();
+  pose_msg.pose.orientation.y = q.y();
+  pose_msg.pose.orientation.z = q.z();
+  pose_msg.pose.orientation.w = q.w();
+  pub_snapped_pose_->publish(pose_msg);
+
+  autoware_internal_debug_msgs::msg::Float64Stamped interpolation_time_msg;
+  interpolation_time_msg.stamp = timestamp;
+  interpolation_time_msg.data = frame_context.snapped_interpolation_time_s.value();
+  pub_snap_interpolation_time_->publish(interpolation_time_msg);
+}
+
 void DiffusionPlanner::publish_debug_markers(
   const InputDataMap & input_data_map, const Eigen::Matrix4d & ego_to_map_transform,
   const rclcpp::Time & timestamp) const
@@ -537,6 +581,8 @@ void DiffusionPlanner::on_timer()
   publish_debug_markers(input_data_map, frame_context->ego_to_map_transform, frame_time);
 
   publish_first_traffic_light_on_route(*frame_context);
+
+  publish_snapped_pose(*frame_context, frame_time);
 
   // Calculate and record metrics for diagnostics using core
   diagnostics_inference_->add_key_value(

--- a/planning/autoware_diffusion_planner/src/utils/utils.cpp
+++ b/planning/autoware_diffusion_planner/src/utils/utils.cpp
@@ -18,6 +18,7 @@
 #include <cmath>
 #include <iostream>
 #include <limits>
+#include <stdexcept>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -121,6 +122,71 @@ geometry_msgs::msg::Pose shift_x(const geometry_msgs::msg::Pose & pose, const do
   shifted_pose.position.z += shift_global.z();
 
   return shifted_pose;
+}
+
+PolylineProjection project_pose_onto_polyline(
+  const double query_x, const double query_y, const std::vector<Eigen::Matrix4d> & polyline)
+{
+  if (polyline.size() < 2) {
+    throw std::runtime_error("project_pose_onto_polyline requires at least two poses");
+  }
+
+  const Eigen::Vector2d query(query_x, query_y);
+
+  double best_dist_sq = std::numeric_limits<double>::max();
+  Eigen::Vector2d best_foot = query;
+  Eigen::Quaterniond best_orientation = Eigen::Quaterniond::Identity();
+  // (closest segment index + intra-segment ratio); position of the foot along the polyline.
+  double best_interpolation_index = 0.0;
+
+  // Because the diffusion planner runs at 10Hz, we only need to consider the first few segments of
+  // the polyline for snapping.
+  const size_t max_index = 5;
+
+  for (size_t i = 0; i + 1 <= max_index && i + 1 < polyline.size(); ++i) {
+    // Endpoints of the i-th line segment in the xy-plane.
+    const Eigen::Vector2d segment_start(polyline[i](0, 3), polyline[i](1, 3));
+    const Eigen::Vector2d segment_end(polyline[i + 1](0, 3), polyline[i + 1](1, 3));
+
+    // Direction vector of the segment (start -> end) and the vector from the start to the query.
+    const Eigen::Vector2d segment_vector = segment_end - segment_start;
+    const Eigen::Vector2d start_to_query = query - segment_start;
+
+    // Squared length of the segment. Also used to guard against a degenerate (zero-length) segment.
+    const double segment_length_sq = segment_vector.squaredNorm();
+
+    // Projection ratio of the query point onto the infinite line through the segment:
+    //   raw_ratio = dot(start_to_query, segment_vector) / |segment_vector|^2
+    // raw_ratio == 0 -> foot at segment_start, raw_ratio == 1 -> foot at segment_end.
+    // Clamping to [0, 1] keeps the foot ON the segment: if the perpendicular foot would land beyond
+    // an endpoint (raw_ratio < 0 or > 1), it is pulled back to the nearest endpoint.
+    constexpr double eps = 1e-9;
+    double ratio = 0.0;
+    if (segment_length_sq >= eps) {
+      const double projection = start_to_query.dot(segment_vector);
+      const double raw_ratio = projection / segment_length_sq;
+      ratio = std::clamp(raw_ratio, 0.0, 1.0);
+    }
+
+    // Foot of the perpendicular (already clamped onto the segment) and its distance to the query.
+    const Eigen::Vector2d foot = segment_start + ratio * segment_vector;
+    const double dist_sq = (query - foot).squaredNorm();
+
+    if (dist_sq < best_dist_sq) {
+      best_dist_sq = dist_sq;
+      best_foot = foot;
+      const Eigen::Quaterniond start_orientation(polyline[i].block<3, 3>(0, 0));
+      const Eigen::Quaterniond end_orientation(polyline[i + 1].block<3, 3>(0, 0));
+      best_orientation = start_orientation.slerp(ratio, end_orientation);
+      best_interpolation_index = static_cast<double>(i) + ratio;
+    }
+  }
+
+  Eigen::Matrix4d projected = Eigen::Matrix4d::Identity();
+  projected.block<3, 3>(0, 0) = best_orientation.normalized().toRotationMatrix();
+  projected(0, 3) = best_foot.x();
+  projected(1, 3) = best_foot.y();
+  return PolylineProjection{projected, best_interpolation_index};
 }
 
 Eigen::Matrix4d inverse(const Eigen::Matrix4d & mat)

--- a/planning/autoware_diffusion_planner/test/utils_test.cpp
+++ b/planning/autoware_diffusion_planner/test/utils_test.cpp
@@ -18,6 +18,7 @@
 
 #include <cmath>
 #include <limits>
+#include <stdexcept>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -164,6 +165,100 @@ TEST_F(UtilsTest, CheckInputMapEmpty)
 {
   std::unordered_map<std::string, std::vector<float>> input_map;
   EXPECT_TRUE(utils::check_input_map(input_map));
+}
+
+namespace
+{
+Eigen::Matrix4d make_pose(const double x, const double y, const double yaw)
+{
+  Eigen::Matrix4d pose = Eigen::Matrix4d::Identity();
+  pose(0, 0) = std::cos(yaw);
+  pose(0, 1) = -std::sin(yaw);
+  pose(1, 0) = std::sin(yaw);
+  pose(1, 1) = std::cos(yaw);
+  pose(0, 3) = x;
+  pose(1, 3) = y;
+  return pose;
+}
+
+double yaw_of(const Eigen::Matrix4d & pose)
+{
+  return std::atan2(pose(1, 0), pose(0, 0));
+}
+}  // namespace
+
+// A query point lying exactly on a vertex of the polyline must be a no-op: the returned pose
+// equals that vertex (position and heading). This mirrors the Perfect-Tracker invariant where the
+// ego lands exactly on the previous prediction.
+TEST_F(UtilsTest, ProjectPoseOntoPolylineOnVertexIsNoOp)
+{
+  const std::vector<Eigen::Matrix4d> polyline{
+    make_pose(0.0, 0.0, 0.0), make_pose(1.0, 0.0, 0.0), make_pose(2.0, 0.0, 0.0)};
+
+  const Eigen::Matrix4d projected = utils::project_pose_onto_polyline(1.0, 0.0, polyline).pose;
+
+  EXPECT_NEAR(projected(0, 3), 1.0, 1e-9);
+  EXPECT_NEAR(projected(1, 3), 0.0, 1e-9);
+  EXPECT_NEAR(yaw_of(projected), 0.0, 1e-9);
+}
+
+// A query point offset laterally from a straight polyline snaps to the foot of the perpendicular.
+TEST_F(UtilsTest, ProjectPoseOntoPolylineLateralOffset)
+{
+  const std::vector<Eigen::Matrix4d> polyline{
+    make_pose(0.0, 0.0, 0.0), make_pose(10.0, 0.0, 0.0)};
+
+  const Eigen::Matrix4d projected = utils::project_pose_onto_polyline(3.0, 2.0, polyline).pose;
+
+  EXPECT_NEAR(projected(0, 3), 3.0, 1e-9);
+  EXPECT_NEAR(projected(1, 3), 0.0, 1e-9);
+  EXPECT_NEAR(yaw_of(projected), 0.0, 1e-9);
+}
+
+// A query point past the end of the polyline is clamped to the closest endpoint.
+TEST_F(UtilsTest, ProjectPoseOntoPolylineClampsToEndpoint)
+{
+  const std::vector<Eigen::Matrix4d> polyline{
+    make_pose(0.0, 0.0, 0.0), make_pose(10.0, 0.0, 0.0)};
+
+  const Eigen::Matrix4d projected = utils::project_pose_onto_polyline(15.0, 5.0, polyline).pose;
+
+  EXPECT_NEAR(projected(0, 3), 10.0, 1e-9);
+  EXPECT_NEAR(projected(1, 3), 0.0, 1e-9);
+}
+
+// The heading is slerp-interpolated between the endpoints of the closest segment. Projecting the
+// midpoint of a segment whose endpoints face 0 and pi/2 yields a heading of pi/4.
+TEST_F(UtilsTest, ProjectPoseOntoPolylineSlerpsHeading)
+{
+  const std::vector<Eigen::Matrix4d> polyline{
+    make_pose(0.0, 0.0, 0.0), make_pose(2.0, 0.0, M_PI_2)};
+
+  const Eigen::Matrix4d projected = utils::project_pose_onto_polyline(1.0, 0.0, polyline).pose;
+
+  EXPECT_NEAR(projected(0, 3), 1.0, 1e-9);
+  EXPECT_NEAR(projected(1, 3), 0.0, 1e-9);
+  EXPECT_NEAR(yaw_of(projected), M_PI_4, 1e-9);
+}
+
+// The closest segment is selected among all segments of the polyline.
+TEST_F(UtilsTest, ProjectPoseOntoPolylineSelectsClosestSegment)
+{
+  const std::vector<Eigen::Matrix4d> polyline{
+    make_pose(0.0, 0.0, 0.0), make_pose(1.0, 0.0, 0.0), make_pose(1.0, 5.0, M_PI_2)};
+
+  // Closest to the second (vertical) segment.
+  const Eigen::Matrix4d projected = utils::project_pose_onto_polyline(1.3, 3.0, polyline).pose;
+
+  EXPECT_NEAR(projected(0, 3), 1.0, 1e-9);
+  EXPECT_NEAR(projected(1, 3), 3.0, 1e-9);
+  EXPECT_NEAR(yaw_of(projected), M_PI_2, 1e-9);
+}
+
+TEST_F(UtilsTest, ProjectPoseOntoPolylineThrowsOnTooFewPoints)
+{
+  const std::vector<Eigen::Matrix4d> polyline{make_pose(0.0, 0.0, 0.0)};
+  EXPECT_THROW(utils::project_pose_onto_polyline(0.0, 0.0, polyline), std::runtime_error);
 }
 
 }  // namespace autoware::diffusion_planner::test

--- a/planning/autoware_diffusion_planner/test/utils_test.cpp
+++ b/planning/autoware_diffusion_planner/test/utils_test.cpp
@@ -205,8 +205,7 @@ TEST_F(UtilsTest, ProjectPoseOntoPolylineOnVertexIsNoOp)
 // A query point offset laterally from a straight polyline snaps to the foot of the perpendicular.
 TEST_F(UtilsTest, ProjectPoseOntoPolylineLateralOffset)
 {
-  const std::vector<Eigen::Matrix4d> polyline{
-    make_pose(0.0, 0.0, 0.0), make_pose(10.0, 0.0, 0.0)};
+  const std::vector<Eigen::Matrix4d> polyline{make_pose(0.0, 0.0, 0.0), make_pose(10.0, 0.0, 0.0)};
 
   const Eigen::Matrix4d projected = utils::project_pose_onto_polyline(3.0, 2.0, polyline).pose;
 
@@ -218,8 +217,7 @@ TEST_F(UtilsTest, ProjectPoseOntoPolylineLateralOffset)
 // A query point past the end of the polyline is clamped to the closest endpoint.
 TEST_F(UtilsTest, ProjectPoseOntoPolylineClampsToEndpoint)
 {
-  const std::vector<Eigen::Matrix4d> polyline{
-    make_pose(0.0, 0.0, 0.0), make_pose(10.0, 0.0, 0.0)};
+  const std::vector<Eigen::Matrix4d> polyline{make_pose(0.0, 0.0, 0.0), make_pose(10.0, 0.0, 0.0)};
 
   const Eigen::Matrix4d projected = utils::project_pose_onto_polyline(15.0, 5.0, polyline).pose;
 

--- a/vehicle/autoware_accel_brake_map_calibrator/README.md
+++ b/vehicle/autoware_accel_brake_map_calibrator/README.md
@@ -21,7 +21,7 @@ ros2 launch autoware_accel_brake_map_calibrator accel_brake_map_calibrator.launc
 ros2 bag play <rosbag_file> --clock
 ```
 
-During the calibration with setting the parameter `progress_file_output` to true, the log file is output in [directory of _autoware_accel_brake_map_calibrator_]/config/ . You can also see accel and brake maps in [directory of _autoware_accel_brake_map_calibrator_]/config/accel_map.csv and [directory of _autoware_accel_brake_map_calibrator_]/config/brake_map.csv after calibration.
+During the calibration with setting the parameter `progress_file_output` to true, the log file is output in [directory of _autoware_accel_brake_map_calibrator_]/config/ . You can also see accel and brake maps in [directory of _autoware_accel_brake_map_calibrator_]/config/accel*map.csv and [directory of \_autoware_accel_brake_map_calibrator*]/config/brake_map.csv after calibration.
 
 ### Calibration plugin
 


### PR DESCRIPTION
## Description

Adds `ego_snap_to_prev_trajectory` to snap the ego pose onto the previous planning trajectory (foot of the perpendicular to the closest segment) before inference, stabilizing the planning start point. The snap is skipped when the position/heading error exceeds the configured limits.

## Related links

- https://github.com/autowarefoundation/autoware_launch/pull/1918

## How was this PR tested?

In progress

## Notes for reviewers

None.

## Interface changes

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added | Pub | `~/debug/snapped_pose` | `geometry_msgs::msg::PoseStamped`   | Snapped pose |
| Added | Pub | `~/debug/snap_interpolation_time` | `autoware_internal_debug_msgs::msg::Float64Stamped`   | Snap interpolation time |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added | `ego_snap_to_prev_trajectory`   | `boolean` | `true`         | Whether to snap the ego pose onto the previous planning trajectory. When enabled, the ego pose is replaced by the foot of the perpendicular to the closest segment of the previous planning trajectory (planning start pose + previous prediction). |
| Added | `ego_snap_max_position_error_m`   | `float` | `0.3`         | Maximum allowed position distance [m] between the actual ego pose and the snapped pose. If the distance exceeds this value the snap is skipped and the raw ego pose is kept. |
| Added | `ego_snap_max_yaw_error_deg`   | `float` | `5.0`         | Maximum allowed heading difference [deg] between the actual ego pose and the snapped pose. If the difference exceeds this value the snap is skipped and the raw ego pose is kept. |

## Effects on system behavior

The planning of the diffusion planner will be changed.