### PR TITLE
fix(autoware_multi_object_tracker): make axle covariance blend inflate-only

### DIFF
--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/motion_model/bicycle_motion_model.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/motion_model/bicycle_motion_model.hpp
@@ -122,7 +122,7 @@ public:
 
   // cspell:ignore Persymmetrize
   // Persymmetrize the rear/front axle position covariance to weaken the coupling that levers a
-  // common-mode lateral error into yaw. blend_ratio in [0,1]: 0 is a no-op, 1 fully decouples.
+  // common-mode lateral error into yaw. Variances only inflate.
   bool blendAxleCovariance(const double blend_ratio);
 
   bool limitStates();

--- a/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
@@ -474,9 +474,11 @@ bool BicycleMotionModel::blendAxleCovariance(const double blend_ratio)
   P_swapped.col(IDX::X1).swap(P_swapped.col(IDX::X2));
   P_swapped.col(IDX::Y1).swap(P_swapped.col(IDX::Y2));
 
-  // Convex combination toward the persymmetric average: PSD-preserving, leaves the center-position
-  // and yaw marginals unchanged, scales the mean<->difference coupling by (1 - alpha).
-  const StateMat P_new = (1.0 - 0.5 * alpha) * P_t + (0.5 * alpha) * P_swapped;
+  // Convex combination toward the persymmetric average scales the mean<->difference coupling by
+  // (1 - alpha); the diagonal top-up keeps every variance at or above its original value, so the
+  // smaller axle variance inflates toward the larger one and no axis tightens. PSD-preserving.
+  StateMat P_new = (1.0 - 0.5 * alpha) * P_t + (0.5 * alpha) * P_swapped;
+  P_new.diagonal() += (0.5 * alpha) * (P_swapped.diagonal() - P_t.diagonal()).cwiseAbs();
 
   ekf_.init(X_t, P_new);  // covariance-only update
 

--- a/perception/autoware_multi_object_tracker/test/test_vehicle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/test/test_vehicle_tracker.cpp
@@ -201,16 +201,16 @@ TEST(BlendAxleCovariance, NoOpAtZero)
   EXPECT_DOUBLE_EQ(exportedYawVariance(model), yaw_var_before);
 }
 
-// The persymmetric average preserves Cov(difference), so the exported yaw variance is unchanged
-// even at full blend — the blend removes coupling, it does not loosen (or tighten) heading.
-TEST(BlendAxleCovariance, PreservesYawVariance)
+// The blend only inflates variances: the exported yaw variance never tightens, and with the
+// asymmetric front/rear covariance of an evolved vehicle it strictly grows at full blend.
+TEST(BlendAxleCovariance, NeverTightensYawVariance)
 {
   BicycleMotionModel model = makeEvolvedVehicle();
   const double yaw_var_before = exportedYawVariance(model);
 
   EXPECT_TRUE(model.blendAxleCovariance(1.0));
 
-  EXPECT_NEAR(exportedYawVariance(model), yaw_var_before, 1e-9);
+  EXPECT_GT(exportedYawVariance(model), yaw_var_before);
 }
 
 // The core behavior: a common lateral bias rotates the box when the front/rear covariance is


### PR DESCRIPTION
## Description

Follow-up to #12982. `BicycleMotionModel::blendAxleCovariance` symmetrizes the front/rear axle position covariance so a common-mode lateral bias translates the box instead of rotating it. The previous implementation used the pure persymmetric average

```
P' = (1 − α/2)·P + (α/2)·S·P·Sᵀ
```

which averages the two axle position variances. **Averaging shrinks the larger axle variance with no measurement having arrived** — the filter fabricates confidence about exactly the point (the front axle) where the model says uncertainty accrues fastest. The subsequent front-edge / yaw-informative update is then underweighted by the overconfident prior, slowing yaw correction.

### Physical interpretation

In center/half-difference coordinates `m = (p1+p2)/2`, `δ = (p2−p1)/2` (yaw and wheelbase live in `δ`), the axle variances decompose as

```
Var(p2) = V_m + V_δ + 2C ,  Var(p1) = V_m + V_δ − 2C ,  C = Cov(m, δ)
```

so the front/rear asymmetry **is** the center↔heading correlation: `Var(p2) − Var(p1) = 4C`. That correlation is genuine information (front-only differential process noise, heading swing pivoting about the rear axle), but it is also the lever arm through which a time-correlated common-mode localization bias — which the white-noise measurement model cannot represent — gets converted into yaw. The blend deliberately discards it for robustness.

- **Before:** `C → (1−α)·C` with `V_m`, `V_δ` unchanged. In axle coordinates `Var(p2)` drops by `2α|C|` for free — deleting a correlation while pocketing the difference as confidence is not conservative.
- **After:** same decorrelation, plus a diagonal top-up of `0.5·α·|Var(p2) − Var(p1)|` on each axle position variance. The larger axle variance stays exactly where it was; the smaller one inflates toward it by the blend ratio (both reach the pair's max at `α = 1`).

In the `(m, δ)` block this is `V_m += α|C|`, `V_δ += α|C|`, `C → (1−α)C`; the change matrix `α·[[|C|, −C], [−C, |C|]]` is PSD with zero determinant, i.e. the top-up is the **minimal** symmetric diagonal inflation that makes the decorrelation conservative — discarded information is paid for in variance, never claimed as confidence (covariance-union philosophy). PSD is preserved (nonnegative diagonal added to a convex combination of PSD matrices), and at full blend the result is still swap-symmetric, so the no-spurious-rotation property of #12982 is intact.

### Behavioral consequence

The exported yaw variance is no longer exactly preserved by the blend: since variances only grow while the front/rear cross covariance is unchanged, `Var(p2 − p1)` — and hence yaw variance — grows by up to `α|C|` per coasting period. Heading becomes somewhat easier for measurements to move after open-loop prediction, which is the safe direction to err.

## Related links

**Parent Issue:**

- Follow-up to #12982

## How was this PR tested?

- `colcon build` of `autoware_multi_object_tracker` (clean).
- Full `test_multi_object_tracker` suite — **30/30 tests pass**:
  - `BlendAxleCovariance.NoOpAtZero` — unchanged, still passes.
  - `BlendAxleCovariance.CommonLateralBiasDoesNotRotate` — unchanged, still passes: at full blend the covariance is swap-symmetric, so a common lateral bias still translates without rotating.
  - `BlendAxleCovariance.PreservesYawVariance` → renamed `NeverTightensYawVariance`: with the asymmetric front/rear covariance of an evolved vehicle, the exported yaw variance strictly grows at full blend (it can never shrink).

before



https://github.com/user-attachments/assets/535fbfe5-0be7-425f-80ec-52e2bcbd1821


after


https://github.com/user-attachments/assets/aba5a27f-b932-4d10-b7bc-33a053b4f09b




## Notes for reviewers

The velocity↔geometry cross terms are also scaled by `(1 − α)` without a corresponding top-up, so strict global Loewner dominance is not guaranteed — only the position blocks are. Those couplings are small in practice; the exact construction (minimal swap-symmetric dominating matrix) would extend the same inflation to the velocity rows if ever needed.

## Interface changes

None.

## Effects on system behavior

Vehicle trackers coasting without measurement updates keep their front-axle position uncertainty; yaw uncertainty inflates slightly in proportion to the accrued front/rear asymmetry, making the first heading correction after coasting weight the measurement more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
