### PR TITLE
ci(codecov): upload differential coverage flagless to preserve carryforward

### DIFF
--- a/.github/workflows/build-and-test-differential.yaml
+++ b/.github/workflows/build-and-test-differential.yaml
@@ -24,6 +24,10 @@ on:
         required: false
         default: ""
         type: string
+      upload-coverage:
+        default: false
+        required: false
+        type: boolean
     secrets:
       codecov-token:
         required: true
@@ -131,13 +135,13 @@ jobs:
           underlay-workspace: /opt/autoware
 
       - name: Upload coverage to CodeCov
-        if: ${{ steps.test.outputs.coverage-report-files != '' && contains(inputs.container, '-cuda') && inputs.rosdistro == 'jazzy' }}
+        if: ${{ steps.test.outputs.coverage-report-files != '' && inputs.upload-coverage }}
+        # Intentionally flagless: flagging this partial upload would suppress the full-suite carryforward.
         uses: codecov/codecov-action@v6
         with:
           files: ${{ steps.test.outputs.coverage-report-files }}
           fail_ci_if_error: false
           verbose: true
-          flags: full-suite
           token: ${{ secrets.codecov-token }}
           disable_search: true
           # Disable gcov and xcode plugins, keeping only pycoverage.

--- a/.github/workflows/build-test-tidy-pr.yaml
+++ b/.github/workflows/build-test-tidy-pr.yaml
@@ -44,6 +44,7 @@ jobs:
     if: ${{ always() }}
     needs:
       - require-label
+      - check-if-cuda-job-is-needed
     strategy:
       fail-fast: false
       matrix:
@@ -59,6 +60,8 @@ jobs:
       rosdistro: ${{ matrix.rosdistro }}
       container: ${{ matrix.container }}
       run-condition: ${{ needs.require-label.outputs.result == 'true' }}
+      # The cuda job covers coverage upload when it runs; upload here otherwise.
+      upload-coverage: ${{ matrix.rosdistro == 'jazzy' && needs.check-if-cuda-job-is-needed.outputs.cuda_job_is_needed != 'true' }}
     secrets:
       codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -102,6 +105,7 @@ jobs:
       container: ${{ matrix.container }}
       run-condition: ${{ needs.check-if-cuda-job-is-needed.outputs.cuda_job_is_needed == 'true' }}
       runner: "['self-hosted', 'Linux', 'X64']"
+      upload-coverage: ${{ matrix.rosdistro == 'jazzy' }}
     secrets:
       codecov-token: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
## Description

- Follow-up to #12430.

Codecov carryforward is all-or-nothing per flag per commit: if a flag has any upload on a commit, carryforward is skipped for that flag ([carryforward docs](https://docs.codecov.com/docs/carryforward-flags)). Since the PR differential jobs uploaded their partial reports under the `full-suite` flag, the main-branch baseline was never carried forward onto PR commits, and PR reports contained only the modified packages. Example: the [codecov comment on #12990](https://github.com/autowarefoundation/autoware_universe/pull/12990#issuecomment-4966125086) compares 76 files on the PR head against 1945 files on main.

## Changes

- Upload PR differential coverage without a flag. A flagless partial upload leaves the `full-suite` flag without uploads on PR commits, so the complete main-branch baseline carries forward and the fresh partial session merges on top. Home Assistant uses the same pattern: [flagless partial uploads in ci.yaml](https://github.com/home-assistant/core/blob/dev/.github/workflows/ci.yaml) with [carryforward enabled only on full-suite in codecov.yml](https://github.com/home-assistant/core/blob/dev/codecov.yml).
- Replace the hardcoded jazzy-cuda upload condition with an `upload-coverage` input set by the caller, so every labeled PR uploads exactly once: the cuda jazzy job when it runs, the non-cuda jazzy job otherwise. Previously only PRs touching perception/sensing/diffusion_planner paths received any coverage report.

## Verification after merge

- The codecov comment on the next labeled PR should show ~1945 files with the `full-suite` flag marked as carried forward, instead of only the modified packages.
- `head_totals` from the [codecov pulls API](https://api.codecov.io/api/v2/github/autowarefoundation/repos/autoware_universe/pulls/) should show the full file count and 2+ sessions.
