### PR TITLE
feat(autoware_ptv3): update filtered classes

### DIFF
--- a/perception/autoware_ptv3/config/ptv3.param.yaml
+++ b/perception/autoware_ptv3/config/ptv3.param.yaml
@@ -18,7 +18,7 @@
       source_reconstruction: "full"
       filter:
         class_probability_threshold: 0.05
-        classes: ["drivable_flat"]
+        classes: ["drivable_flat", "non_drivable_flat", "noise"]
         output_format: ""
     detection3d:
       use_head: $(var use_det3d_head)


### PR DESCRIPTION
## Description

Update filtered classes to mimic typical ground segmentation algorithm.
Current model might have wrong classification for flat surfaces (drivable and non-drivable classes) duo to obvious geometrical similarity.
It is safe to filter them out because lanelets are responsible for handling area of interests for planners.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
