### PR TITLE
fix(autoware_image_projection_based_fusion): fix bug for contention which was introduced when `callback_group` was splitted

### DIFF
--- a/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/fusion_node.hpp
+++ b/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/fusion_node.hpp
@@ -121,7 +121,7 @@ private:
     concatenated_info_map_;
 
   diagnostic_updater::Updater diagnostic_updater_{this};
-  mutable std::recursive_mutex diagnostic_mutex_;
+  mutable std::mutex diagnostic_mutex_;
   std::shared_ptr<FusionCollectorInfoBase> diagnostic_collector_info_;
   std::unordered_map<std::size_t, double> diagnostic_id_to_stamp_map_;
 

--- a/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/fusion_node.hpp
+++ b/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/fusion_node.hpp
@@ -46,6 +46,7 @@
 #include <cstddef>
 #include <list>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -120,6 +121,7 @@ private:
     concatenated_info_map_;
 
   diagnostic_updater::Updater diagnostic_updater_{this};
+  mutable std::recursive_mutex diagnostic_mutex_;
   std::shared_ptr<FusionCollectorInfoBase> diagnostic_collector_info_;
   std::unordered_map<std::size_t, double> diagnostic_id_to_stamp_map_;
 

--- a/perception/autoware_image_projection_based_fusion/src/fusion_node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/fusion_node.cpp
@@ -304,7 +304,7 @@ void FusionNode<Msg3D, Msg2D, ExportObj>::export_process(
   std::unordered_map<std::size_t, double> id_to_stamp_map,
   std::shared_ptr<FusionCollectorInfoBase> collector_info)
 {
-  std::lock_guard<std::recursive_mutex> diagnostic_lock(diagnostic_mutex_);
+  std::unique_lock<std::mutex> diagnostic_lock(diagnostic_mutex_);
 
   ExportObj output_msg;
   postprocess(*(output_det3d_msg), output_msg);
@@ -331,7 +331,6 @@ void FusionNode<Msg3D, Msg2D, ExportObj>::export_process(
   // Move collected diagnostics info
   diagnostic_collector_info_ = std::move(collector_info);
   diagnostic_id_to_stamp_map_ = std::move(id_to_stamp_map);
-  diagnostic_updater_.force_update();
 
   // Add processing time for debugging
   if (debug_publisher_) {
@@ -362,6 +361,9 @@ void FusionNode<Msg3D, Msg2D, ExportObj>::export_process(
         timestamp_interval_ms - id_to_offset_map_[rois_id] * 1000);
     }
   }
+
+  diagnostic_lock.unlock();
+  diagnostic_updater_.force_update();
 }
 
 template <class Msg3D, class Msg2D, class ExportObj>
@@ -650,11 +652,13 @@ void FusionNode<Msg3D, Msg2D, ExportObj>::show_diagnostic_message(
   std::unordered_map<std::size_t, double> id_to_stamp_map,
   std::shared_ptr<FusionCollectorInfoBase> collector_info)
 {
-  std::lock_guard<std::recursive_mutex> diagnostic_lock(diagnostic_mutex_);
+  std::unique_lock<std::mutex> diagnostic_lock(diagnostic_mutex_);
 
   msg3d_fused_ = false;
   diagnostic_collector_info_ = std::move(collector_info);
   diagnostic_id_to_stamp_map_ = std::move(id_to_stamp_map);
+
+  diagnostic_lock.unlock();
   diagnostic_updater_.force_update();
 }
 
@@ -662,7 +666,7 @@ template <class Msg3D, class Msg2D, class ExportObj>
 void FusionNode<Msg3D, Msg2D, ExportObj>::check_fusion_status(
   diagnostic_updater::DiagnosticStatusWrapper & stat)
 {
-  std::lock_guard<std::recursive_mutex> diagnostic_lock(diagnostic_mutex_);
+  std::lock_guard<std::mutex> diagnostic_lock(diagnostic_mutex_);
 
   if (publish_output_msg_ || drop_previous_but_late_output_msg_ || !msg3d_fused_) {
     stat.add("msg3d/is_fused", msg3d_fused_);

--- a/perception/autoware_image_projection_based_fusion/src/fusion_node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/fusion_node.cpp
@@ -304,6 +304,8 @@ void FusionNode<Msg3D, Msg2D, ExportObj>::export_process(
   std::unordered_map<std::size_t, double> id_to_stamp_map,
   std::shared_ptr<FusionCollectorInfoBase> collector_info)
 {
+  std::lock_guard<std::recursive_mutex> diagnostic_lock(diagnostic_mutex_);
+
   ExportObj output_msg;
   postprocess(*(output_det3d_msg), output_msg);
 
@@ -648,6 +650,8 @@ void FusionNode<Msg3D, Msg2D, ExportObj>::show_diagnostic_message(
   std::unordered_map<std::size_t, double> id_to_stamp_map,
   std::shared_ptr<FusionCollectorInfoBase> collector_info)
 {
+  std::lock_guard<std::recursive_mutex> diagnostic_lock(diagnostic_mutex_);
+
   msg3d_fused_ = false;
   diagnostic_collector_info_ = std::move(collector_info);
   diagnostic_id_to_stamp_map_ = std::move(id_to_stamp_map);
@@ -658,6 +662,8 @@ template <class Msg3D, class Msg2D, class ExportObj>
 void FusionNode<Msg3D, Msg2D, ExportObj>::check_fusion_status(
   diagnostic_updater::DiagnosticStatusWrapper & stat)
 {
+  std::lock_guard<std::recursive_mutex> diagnostic_lock(diagnostic_mutex_);
+
   if (publish_output_msg_ || drop_previous_but_late_output_msg_ || !msg3d_fused_) {
     stat.add("msg3d/is_fused", msg3d_fused_);
 


### PR DESCRIPTION
## Description

`roi_cluster_fusion` (and the other `FusionNode`-based nodes) can crash with a SIGSEGV inside `FusionNode::check_fusion_stax``tus()`, caused by a data race on the diagnostic members shared between the fusion callback path and the diagnostic updater's periodic timer.

### Root cause

#12439 moved the agnocast `msg3d` subscription into a dedicated callback group, so under `CallbackIsolatedAgnocastExecutor` it runs on a different thread from the diagnostic updater's periodic timer. `export_process` / `show_diagnostic_message` write the diagnostic members while `check_fusion_status` reads them, with no synchronization; concurrent access to `diagnostic_collector_info_` (a `shared_ptr`) and `diagnostic_id_to_stamp_map_` (a map) is undefined behavior and leads to the SIGSEGV. #12439 added locking for the collector info but not for these node-level diagnostic members.

### Fix

Guard the diagnostic members with a dedicated `std::mutex` (`diagnostic_mutex_`), taken in `export_process`, `show_diagnostic_message`, and `check_fusion_status`. In the two writer paths the lock is released before calling `diagnostic_updater_.force_update()`, because `force_update()` synchronously re-enters `check_fusion_status()` on the same thread and re-locks the same mutex; releasing first avoids a self-deadlock and lets a plain (non-recursive) `std::mutex` be used. Lock ordering is `fusion_mutex_` (outer) → `diagnostic_mutex_` (inner), and the timer path takes only `diagnostic_mutex_`, so there is no lock-order inversion.

This mutex is a temporary measure. Once these nodes are migrated to `agnocast_wrapper::Node` in #12688, the callback groups are reunified and the callbacks are serialized again, so this mutex (and the dedicated callback group from #12439) is planned to be removed.

## Related links

**Parent Issue:**

- Bug introduced in #12439
- Follow-up removal after #12688
- [TIER IV Internal Slack](https://star4.slack.com/archives/CRUE57C30/p1784163758920769)
## How was this PR tested?

Verified on an Autoware-based product with the camera-lidar fusion detection pipeline (`roi_cluster_fusion`) and Agnocast enabled (`CallbackIsolatedAgnocastExecutor`). Before this change the node reproducibly crashed with a SIGSEGV in `check_fusion_status()`; after this change the node runs without crashing and the fusion output and `_status` diagnostics are published normally.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
