### PR TITLE
feat(carla_interface): launch shift_decider as standalone node when agnocast

### DIFF
--- a/simulator/autoware_carla_interface/launch/autoware_carla_interface.launch.xml
+++ b/simulator/autoware_carla_interface/launch/autoware_carla_interface.launch.xml
@@ -195,9 +195,7 @@
         </composable_node>
       </node_container>
 
-      <!-- shift_decider runs as autoware::agnocast_wrapper::Node, which does not support
-           component containers, so it is launched standalone instead of loaded into
-           /e2e_control_container. -->
+      <!-- shift_decider runs as standalone node -->
       <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
       <node pkg="autoware_shift_decider" exec="autoware_shift_decider" name="autoware_shift_decider" output="screen">
         <param from="$(find-pkg-share $(var launch_config_pkg))/config/control/shift_decider/shift_decider.param.yaml"/>

--- a/simulator/autoware_carla_interface/launch/autoware_carla_interface.launch.xml
+++ b/simulator/autoware_carla_interface/launch/autoware_carla_interface.launch.xml
@@ -195,16 +195,18 @@
         </composable_node>
       </node_container>
 
-      <!-- Load shift decider as composable node -->
-      <load_composable_node target="/e2e_control_container">
-        <composable_node pkg="autoware_shift_decider" plugin="autoware::shift_decider::ShiftDecider" name="autoware_shift_decider">
-          <param from="$(find-pkg-share $(var launch_config_pkg))/config/control/shift_decider/shift_decider.param.yaml"/>
-          <remap from="input/control_cmd" to="/trajectory_follower/control_cmd"/>
-          <remap from="input/state" to="/autoware/state"/>
-          <remap from="input/current_gear" to="/vehicle/status/gear_status"/>
-          <remap from="output/gear_cmd" to="/control/shift_decider/gear_cmd"/>
-        </composable_node>
-      </load_composable_node>
+      <!-- shift_decider runs as autoware::agnocast_wrapper::Node, which does not support
+           component containers, so it is launched standalone instead of loaded into
+           /e2e_control_container. -->
+      <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
+      <node pkg="autoware_shift_decider" exec="autoware_shift_decider" name="autoware_shift_decider" output="screen">
+        <param from="$(find-pkg-share $(var launch_config_pkg))/config/control/shift_decider/shift_decider.param.yaml"/>
+        <remap from="input/control_cmd" to="/trajectory_follower/control_cmd"/>
+        <remap from="input/state" to="/autoware/state"/>
+        <remap from="input/current_gear" to="/vehicle/status/gear_status"/>
+        <remap from="output/gear_cmd" to="/control/shift_decider/gear_cmd"/>
+        <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
+      </node>
 
       <node pkg="topic_tools" exec="relay" name="trajectory_follower_control_cmd_relay" output="log" args="/trajectory_follower/control_cmd /trajectory_follower_control_cmd"/>
 

--- a/simulator/autoware_carla_interface/package.xml
+++ b/simulator/autoware_carla_interface/package.xml
@@ -8,6 +8,7 @@
   <maintainer email="masaya.kataoka@tier4.jp">Masaya Kataoka</maintainer>
   <license>Apache License 2.0</license>
 
+  <exec_depend>autoware_agnocast_wrapper</exec_depend>
   <exec_depend>autoware_external_cmd_selector</exec_depend>
   <exec_depend>autoware_twist2accel</exec_depend>
   <exec_depend>autoware_vehicle_velocity_converter</exec_depend>


### PR DESCRIPTION
## Description
When `shift_decider` is built with Agnocast enabled (`ENABLE_AGNOCAST=1`), it becomes an `AgnocastOnly` node (`agnocast_wrapper::Node`, Method 2) and can no longer run as a composable node inside a component container (agnocast-aware or not): the container's `main()` never calls `agnocast::init()`, so the node fails to start.

This PR launches `shift_decider` as a standalone node in `autoware_carla_interface.launch.xml`:

- Stop loading `shift_decider` into `/e2e_control_container` via `load_composable_node`, and launch it as a standalone `<node>` (`autoware_shift_decider`) instead, so it initializes Agnocast on its own.
- Include `autoware_agnocast_wrapper`'s `agnocast_env.launch.xml` and set `LD_PRELOAD` (`$(var ld_preload_value)`) on the node for the Agnocast heaphook.
- Add `autoware_agnocast_wrapper` as an `exec_depend` in `package.xml`.

The node is always launched standalone (no `ENABLE_AGNOCAST` conditional branching). Zero-copy still works across processes via Agnocast, so co-locating it in a container is unnecessary. When `ENABLE_AGNOCAST` is not set or `0`, `ld_preload_value` resolves to the existing `LD_PRELOAD`, so the default behavior is preserved.

## Related links

- https://github.com/autowarefoundation/autoware/issues/7007
- autowarefoundation/autoware_universe#12918 (node-side `agnocast_wrapper::Node` adoption for `autoware_shift_decider`)
- autowarefoundation/autoware_launch#1921 (the other launch-side standalone change, in `tier4_control_launch`)

## How was this PR tested?
- Build: `colcon build` succeeds with both `ENABLE_AGNOCAST=1` and `ENABLE_AGNOCAST=0`.
- Standalone launch: Confirmed `shift_decider` launches as a standalone node (not loaded into `/e2e_control_container`) under both `ENABLE_AGNOCAST=0` and `ENABLE_AGNOCAST=1`, with parameters resolved correctly.

## Notes for reviewers
This is the CARLA-interface launch-side change paired with the node-side `agnocast_wrapper::Node` adoption for `autoware_shift_decider` (autowarefoundation/autoware_universe#12918). The launch-side PRs (this one and autowarefoundation/autoware_launch#1921) should be merged before the node-side PR.

## Interface changes

None.

## Effects on system behavior

None when `ENABLE_AGNOCAST` is not set or set to `0` on runtime. When `ENABLE_AGNOCAST=1`, `shift_decider` runs standalone with the Agnocast heaphook and CPU time for message serialization/deserialization is reduced.