### PR TITLE
refactor(autoware_traffic_light_classifier): remove dead code and clean up naming in CnnLampRecognizer

### DIFF
--- a/perception/autoware_traffic_light_classifier/src/classifier/cnn_lamp_recognizer.cpp
+++ b/perception/autoware_traffic_light_classifier/src/classifier/cnn_lamp_recognizer.cpp
@@ -33,38 +33,38 @@
 namespace autoware::traffic_light
 {
 
-using MsgTE = tier4_perception_msgs::msg::TrafficLightElement;
+using tier4_perception_msgs::msg::TrafficLightElement;
 namespace
 {
-constexpr int kDebugImageWidth = 200;
-constexpr int kDebugTextHeight = 50;
-constexpr float PI = static_cast<float>(autoware_utils::pi);
-ArrowDirection angleToArrowDirection(float angle_rad)
+constexpr int debug_image_width = 200;
+constexpr int debug_text_height = 50;
+ArrowDirection angle_to_arrow_direction(float angle_rad)
 {
-  if (angle_rad >= -PI / 8.0f && angle_rad < PI / 8.0f) return ArrowDirection::UP_ARROW;
-  if (angle_rad >= PI / 8.0f && angle_rad < 3.0f * PI / 8.0f) return ArrowDirection::UP_RIGHT_ARROW;
-  if (angle_rad >= 3.0f * PI / 8.0f && angle_rad < 5.0f * PI / 8.0f)
+  constexpr float pi = static_cast<float>(autoware_utils::pi);
+  if (angle_rad >= -pi / 8.0f && angle_rad < pi / 8.0f) return ArrowDirection::UP_ARROW;
+  if (angle_rad >= pi / 8.0f && angle_rad < 3.0f * pi / 8.0f) return ArrowDirection::UP_RIGHT_ARROW;
+  if (angle_rad >= 3.0f * pi / 8.0f && angle_rad < 5.0f * pi / 8.0f)
     return ArrowDirection::RIGHT_ARROW;
-  if (angle_rad >= 5.0f * PI / 8.0f && angle_rad < 7.0f * PI / 8.0f)
+  if (angle_rad >= 5.0f * pi / 8.0f && angle_rad < 7.0f * pi / 8.0f)
     return ArrowDirection::DOWN_RIGHT_ARROW;
-  if (angle_rad >= 7.0f * PI / 8.0f || angle_rad < -7.0f * PI / 8.0f)
+  if (angle_rad >= 7.0f * pi / 8.0f || angle_rad < -7.0f * pi / 8.0f)
     return ArrowDirection::DOWN_ARROW;
-  if (angle_rad < -5.0f * PI / 8.0f) return ArrowDirection::DOWN_LEFT_ARROW;
-  if (angle_rad < -3.0f * PI / 8.0f) return ArrowDirection::LEFT_ARROW;
+  if (angle_rad < -5.0f * pi / 8.0f) return ArrowDirection::DOWN_LEFT_ARROW;
+  if (angle_rad < -3.0f * pi / 8.0f) return ArrowDirection::LEFT_ARROW;
   return ArrowDirection::UP_LEFT_ARROW;
 }
 
-static float get2DIoU(const BBox & bbox1, const BBox & bbox2)
+static float get_2d_iou(const BBox & bbox1, const BBox & bbox2)
 {
-  auto overlap1D = [](float x1min, float x1max, float x2min, float x2max) -> float {
+  auto overlap_1d = [](float x1min, float x1max, float x2min, float x2max) -> float {
     if (x1min > x2min) {
       std::swap(x1min, x2min);
       std::swap(x1max, x2max);
     }
     return x1max < x2min ? 0.0f : std::min(x1max, x2max) - x2min;
   };
-  const float overlap_x = overlap1D(bbox1.x1, bbox1.x2, bbox2.x1, bbox2.x2);
-  const float overlap_y = overlap1D(bbox1.y1, bbox1.y2, bbox2.y1, bbox2.y2);
+  const float overlap_x = overlap_1d(bbox1.x1, bbox1.x2, bbox2.x1, bbox2.x2);
+  const float overlap_y = overlap_1d(bbox1.y1, bbox1.y2, bbox2.y1, bbox2.y2);
   const float area1 = (bbox1.x2 - bbox1.x1) * (bbox1.y2 - bbox1.y1);
   const float area2 = (bbox2.x2 - bbox2.x1) * (bbox2.y2 - bbox2.y1);
   const float overlap_2d = overlap_x * overlap_y;
@@ -72,7 +72,7 @@ static float get2DIoU(const BBox & bbox1, const BBox & bbox2)
   return (u == 0.0f) ? 0.0f : overlap_2d / u;
 }
 
-static void runNms(
+static void run_nms(
   std::vector<BBoxInfo> & detections, float iou_threshold, std::vector<BBoxInfo> & out)
 {
   out.clear();
@@ -84,7 +84,7 @@ static void runNms(
     bool keep = true;
     for (const auto & j : out) {
       if (keep) {
-        const float overlap = get2DIoU(i.box, j.box);
+        const float overlap = get_2d_iou(i.box, j.box);
         keep = (overlap <= iou_threshold);
       } else {
         break;
@@ -94,21 +94,21 @@ static void runNms(
   }
 }
 
-static void convertBBoxInfoToLampElement(const BBoxInfo & box_info, LampElement & element)
+static void convert_bbox_info_to_lamp_element(const BBoxInfo & box_info, LampElement & element)
 {
-  element.color = static_cast<Color>(std::min(2, std::max(0, box_info.subClassId)));
+  element.color = static_cast<Color>(std::min(2, std::max(0, box_info.sub_class_id)));
   element.confidence = box_info.prob;
   element.box = box_info.box;
-  element.shape = static_cast<Shape>(box_info.classId);
+  element.shape = static_cast<Shape>(box_info.class_id);
   if (element.shape == Shape::ARROW) {
     // If the network outputs a near-zero direction vector (sin, cos) ~= (0, 0), the direction is
     // considered uncertain. Prefer UNKNOWN rather than biasing inputs to atan2().
-    constexpr float kDirectionVecNormSqThreshold = 1.0e-12f;  // (1e-6)^2
+    constexpr float direction_vec_norm_sq_threshold = 1.0e-12f;  // (1e-6)^2
     const float norm_sq = box_info.sin * box_info.sin + box_info.cos * box_info.cos;
-    if (norm_sq < kDirectionVecNormSqThreshold) {
+    if (norm_sq < direction_vec_norm_sq_threshold) {
       element.arrow_direction = ArrowDirection::UNKNOWN;
     } else {
-      element.arrow_direction = angleToArrowDirection(std::atan2(box_info.sin, box_info.cos));
+      element.arrow_direction = angle_to_arrow_direction(std::atan2(box_info.sin, box_info.cos));
     }
   }
 }
@@ -224,7 +224,7 @@ void CnnLampRecognizerCore::preprocess(const std::vector<cv::Mat> & images)
     input_d_.get(), blob.ptr<float>(), copy_size, cudaMemcpyHostToDevice, *stream_));
 }
 
-bool CnnLampRecognizerCore::doInference(size_t batch_size)
+bool CnnLampRecognizerCore::do_inference(size_t batch_size)
 {
   nvinfer1::Dims input_dims = trt_common_->getInputDims(0);
   input_dims.d[0] = static_cast<int32_t>(batch_size);
@@ -259,7 +259,7 @@ bool CnnLampRecognizerCore::doInference(size_t batch_size)
   return true;
 }
 
-void CnnLampRecognizerCore::decodeTlrOutput(
+void CnnLampRecognizerCore::decode_tlr_output(
   size_t batch_size, std::vector<std::vector<BBoxInfo>> & detections_per_roi)
 {
   const auto & ml_params = model_params_;
@@ -342,9 +342,9 @@ void CnnLampRecognizerCore::decodeTlrOutput(
           info.box.y1 = y1;
           info.box.x2 = x2;
           info.box.y2 = y2;
-          info.classId = type_idx;
+          info.class_id = type_idx;
           info.prob = score;
-          info.subClassId = color_idx;
+          info.sub_class_id = color_idx;
           info.sin = sin_val;
           info.cos = cos_val;
           raw.push_back(info);
@@ -352,7 +352,7 @@ void CnnLampRecognizerCore::decodeTlrOutput(
       }
     }
 
-    runNms(raw, nms_threshold_, detections_per_roi[b]);
+    run_nms(raw, nms_threshold_, detections_per_roi[b]);
   }
 }
 
@@ -372,18 +372,18 @@ CnnLampRecognizerCore::DetectionResult CnnLampRecognizerCore::classify(
     if (!flush) continue;
 
     preprocess(batch);
-    if (!doInference(current_batch_size)) {
+    if (!do_inference(current_batch_size)) {
       result.success = false;
       return result;
     }
 
     std::vector<std::vector<BBoxInfo>> detections_per_roi;
-    decodeTlrOutput(current_batch_size, detections_per_roi);
+    decode_tlr_output(current_batch_size, detections_per_roi);
     for (size_t i = 0; i < current_batch_size; ++i) {
       std::vector<LampElement> traffic_lamps;
       for (const auto & d : detections_per_roi[i]) {
         LampElement element;
-        convertBBoxInfoToLampElement(d, element);
+        convert_bbox_info_to_lamp_element(d, element);
         traffic_lamps.push_back(element);
       }
       // if multiple detections have the same shape and arrow direction
@@ -409,87 +409,84 @@ CnnLampRecognizerCore::DetectionResult CnnLampRecognizerCore::classify(
   return result;
 }
 
-void CnnLampRecognizerCore::updateTrafficSignals(
+void CnnLampRecognizerCore::update_traffic_signals(
   const std::vector<LampElement> & unique_elements,
   tier4_perception_msgs::msg::TrafficLight & traffic_signal)
 {
   traffic_signal.elements.clear();
   bool is_pedestrian = traffic_signal.traffic_light_type == 1;
   if (unique_elements.empty()) {
-    MsgTE unknown_elem;
-    unknown_elem.color = MsgTE::UNKNOWN;
-    unknown_elem.shape = MsgTE::UNKNOWN;
+    TrafficLightElement unknown_elem;
+    unknown_elem.color = TrafficLightElement::UNKNOWN;
+    unknown_elem.shape = TrafficLightElement::UNKNOWN;
     unknown_elem.confidence = 0.0;
     traffic_signal.elements.push_back(unknown_elem);
     return;
   }
   for (const auto & e : unique_elements) {
-    MsgTE element;
+    TrafficLightElement element;
     element.confidence = e.confidence;
     switch (e.color) {
       case Color::GREEN:
-        element.color = MsgTE::GREEN;
+        element.color = TrafficLightElement::GREEN;
         break;
       case Color::AMBER:
-        element.color = MsgTE::AMBER;
+        element.color = TrafficLightElement::AMBER;
         break;
       case Color::RED:
-        element.color = MsgTE::RED;
+        element.color = TrafficLightElement::RED;
         break;
       default:
-        element.color = MsgTE::UNKNOWN;
+        element.color = TrafficLightElement::UNKNOWN;
         break;
     }
     if (is_pedestrian || e.shape == Shape::PED) {
-      element.shape = MsgTE::CIRCLE;
+      element.shape = TrafficLightElement::CIRCLE;
       traffic_signal.elements.push_back(element);
       continue;
     }
     switch (e.shape) {
       case Shape::CIRCLE:
-        element.shape = MsgTE::CIRCLE;
+        element.shape = TrafficLightElement::CIRCLE;
         break;
       case Shape::ARROW:
         switch (e.arrow_direction) {
           case ArrowDirection::UP_ARROW:
-            element.shape = MsgTE::UP_ARROW;
+            element.shape = TrafficLightElement::UP_ARROW;
             break;
           case ArrowDirection::DOWN_ARROW:
-            element.shape = MsgTE::DOWN_ARROW;
+            element.shape = TrafficLightElement::DOWN_ARROW;
             break;
           case ArrowDirection::LEFT_ARROW:
-            element.shape = MsgTE::LEFT_ARROW;
+            element.shape = TrafficLightElement::LEFT_ARROW;
             break;
           case ArrowDirection::RIGHT_ARROW:
-            element.shape = MsgTE::RIGHT_ARROW;
+            element.shape = TrafficLightElement::RIGHT_ARROW;
             break;
           case ArrowDirection::UP_LEFT_ARROW:
-            element.shape = MsgTE::UP_LEFT_ARROW;
+            element.shape = TrafficLightElement::UP_LEFT_ARROW;
             break;
           case ArrowDirection::UP_RIGHT_ARROW:
-            element.shape = MsgTE::UP_RIGHT_ARROW;
+            element.shape = TrafficLightElement::UP_RIGHT_ARROW;
             break;
           case ArrowDirection::DOWN_LEFT_ARROW:
-            element.shape = MsgTE::DOWN_LEFT_ARROW;
+            element.shape = TrafficLightElement::DOWN_LEFT_ARROW;
             break;
           case ArrowDirection::DOWN_RIGHT_ARROW:
-            element.shape = MsgTE::DOWN_RIGHT_ARROW;
+            element.shape = TrafficLightElement::DOWN_RIGHT_ARROW;
             break;
           default:
-            element.shape = MsgTE::UNKNOWN;
+            element.shape = TrafficLightElement::UNKNOWN;
             element.confidence = 0.0;
             break;
         }
         break;
-      case Shape::PED:
-        element.shape = MsgTE::CIRCLE;
-        break;
       case Shape::CROSS:
-        element.shape = MsgTE::CROSS;
+        element.shape = TrafficLightElement::CROSS;
         break;
       // TODO(badai-nguyen): update u-turn, number when msgs are updated
       default:
-        element.shape = MsgTE::UNKNOWN;
+        element.shape = TrafficLightElement::UNKNOWN;
         element.confidence = 0.0;
         break;
     }
@@ -497,10 +494,11 @@ void CnnLampRecognizerCore::updateTrafficSignals(
   }
 }
 
-void CnnLampRecognizerCore::outputDebugImage(
-  cv::Mat & debug_image, const tier4_perception_msgs::msg::TrafficLight & traffic_signal,
+cv::Mat CnnLampRecognizerCore::make_debug_image(
+  const cv::Mat & roi_image, const tier4_perception_msgs::msg::TrafficLight & traffic_signal,
   const std::vector<LampElement> * elements)
 {
+  cv::Mat debug_image = roi_image.clone();
   const int img_w = debug_image.cols;
   const int img_h = debug_image.rows;
 
@@ -535,12 +533,13 @@ void CnnLampRecognizerCore::outputDebugImage(
   }
   const std::string text = label + " " + std::to_string(probability);
   const int expand_h =
-    std::max(static_cast<int>((kDebugImageWidth * debug_image.rows) / debug_image.cols), 1);
-  cv::resize(debug_image, debug_image, cv::Size(kDebugImageWidth, expand_h));
-  cv::Mat text_img(cv::Size(kDebugImageWidth, kDebugTextHeight), CV_8UC3, cv::Scalar(0, 0, 0));
+    std::max(static_cast<int>((debug_image_width * debug_image.rows) / debug_image.cols), 1);
+  cv::resize(debug_image, debug_image, cv::Size(debug_image_width, expand_h));
+  cv::Mat text_img(cv::Size(debug_image_width, debug_text_height), CV_8UC3, cv::Scalar(0, 0, 0));
   cv::putText(
     text_img, text, cv::Point(5, 25), cv::FONT_HERSHEY_COMPLEX, 0.5, cv::Scalar(0, 255, 0), 1);
   cv::vconcat(debug_image, text_img, debug_image);
+  return debug_image;
 }
 
 // ============================== CnnLampRecognizer ==============================
@@ -613,7 +612,7 @@ bool CnnLampRecognizer::getTrafficSignals(
   }
 
   for (size_t i = 0; i < traffic_signals.signals.size(); ++i) {
-    CnnLampRecognizerCore::updateTrafficSignals(
+    CnnLampRecognizerCore::update_traffic_signals(
       result.lamps_per_image[i], traffic_signals.signals[i]);
   }
 
@@ -623,9 +622,8 @@ bool CnnLampRecognizer::getTrafficSignals(
     const int strip_height = 130;
     cv::Mat debug_img;
     for (size_t i = 0; i < images.size(); i++) {
-      cv::Mat debug_img_i = images[i].clone();
-      CnnLampRecognizerCore::outputDebugImage(
-        debug_img_i, traffic_signals.signals[i], &result.lamps_per_image[i]);
+      cv::Mat debug_img_i = CnnLampRecognizerCore::make_debug_image(
+        images[i], traffic_signals.signals[i], &result.lamps_per_image[i]);
       cv::resize(debug_img_i, debug_img_i, cv::Size(strip_width, strip_height));
       if (i == 0) {
         debug_img = debug_img_i;

--- a/perception/autoware_traffic_light_classifier/src/classifier/cnn_lamp_recognizer.hpp
+++ b/perception/autoware_traffic_light_classifier/src/classifier/cnn_lamp_recognizer.hpp
@@ -52,9 +52,9 @@ struct BBox
 struct BBoxInfo
 {
   BBox box;
-  int classId{0};  // type: circle=0, arrow=1, u-turn=2, ped=3, number=4, cross=5
+  int class_id{0};  // type: circle=0, arrow=1, u-turn=2, ped=3, number=4, cross=5
   float prob{0.f};
-  int subClassId{0};  // color: green=0, amber=1, red=2
+  int sub_class_id{0};  // color: green=0, amber=1, red=2
   float sin{0.f};
   float cos{1.f};
 };
@@ -158,20 +158,21 @@ public:
   // Map the deduplicated lamp detections into a TrafficLight's elements, honoring its
   // traffic_light_type (pedestrian forces CIRCLE). Emits a single UNKNOWN placeholder element
   // with zero confidence when unique_elements is empty.
-  static void updateTrafficSignals(
+  static void update_traffic_signals(
     const std::vector<LampElement> & unique_elements,
     tier4_perception_msgs::msg::TrafficLight & traffic_signal);
 
-  // Render one debug view onto debug_image: bounding boxes for each lamp plus a label /
-  // confidence text strip below. Mutates debug_image in place.
-  static void outputDebugImage(
-    cv::Mat & debug_image, const tier4_perception_msgs::msg::TrafficLight & traffic_signal,
+  // Build one debug view from roi_image: bounding boxes for each lamp plus a label /
+  // confidence text strip below. Returns a new image; roi_image is not modified.
+  static cv::Mat make_debug_image(
+    const cv::Mat & roi_image, const tier4_perception_msgs::msg::TrafficLight & traffic_signal,
     const std::vector<LampElement> * elements);
 
 private:
   void preprocess(const std::vector<cv::Mat> & images);
-  bool doInference(size_t batch_size);
-  void decodeTlrOutput(size_t batch_size, std::vector<std::vector<BBoxInfo>> & detections_per_roi);
+  bool do_inference(size_t batch_size);
+  void decode_tlr_output(
+    size_t batch_size, std::vector<std::vector<BBoxInfo>> & detections_per_roi);
 
   std::unique_ptr<autoware::tensorrt_common::TrtCommon> trt_common_;
   StreamUniquePtr stream_{makeCudaStream()};

--- a/perception/autoware_traffic_light_classifier/test/test_cnn_lamp_recognizer.cpp
+++ b/perception/autoware_traffic_light_classifier/test/test_cnn_lamp_recognizer.cpp
@@ -18,7 +18,7 @@
 // Tests for CnnLampRecognizerCore, the Node-free lamp recognition core. Two groups, both
 // ROS-free; all Arrange-Act-Assert.
 //
-//  - Static helpers updateTrafficSignals()/outputDebugImage() need only the message types +
+//  - Static helpers update_traffic_signals()/make_debug_image() need only the message types +
 //    OpenCV, so they run (no GPU/model). They pin the non-obvious mapping behavior
 //    (empty->placeholder, pedestrian->CIRCLE, confidence zeroing vs keeping, per-lamp order,
 //    clear-before-map) and the debug geometry. Plain enum->enum maps (color/arrow/cross) are
@@ -62,7 +62,7 @@ using tier4_perception_msgs::msg::TrafficLightElement;
 // that exercise the confidence path pass an explicit value instead.
 constexpr float default_confidence = 1.0f;
 
-// Build one lamp detection. Group A hand-constructs these; updateTrafficSignals maps them
+// Build one lamp detection. Group A hand-constructs these; update_traffic_signals maps them
 // independently of the model (box stays zero-default, which the mapping ignores).
 tl::LampElement make_lamp(
   tl::Color color, tl::Shape shape, tl::ArrowDirection arrow_direction,
@@ -89,7 +89,7 @@ TEST(CnnLampRecognizerCoreUpdateSignalsTest, EmptyInputYieldsSingleUnknownPlaceh
   const std::vector<tl::LampElement> no_lamps;
 
   // Act
-  tl::CnnLampRecognizerCore::updateTrafficSignals(no_lamps, signal);
+  tl::CnnLampRecognizerCore::update_traffic_signals(no_lamps, signal);
 
   // Assert
   ASSERT_EQ(signal.elements.size(), 1u);
@@ -98,7 +98,7 @@ TEST(CnnLampRecognizerCoreUpdateSignalsTest, EmptyInputYieldsSingleUnknownPlaceh
   EXPECT_FLOAT_EQ(signal.elements[0].confidence, 0.0f);
 }
 
-// updateTrafficSignals emits one output element per input lamp, in input order (it does not
+// update_traffic_signals emits one output element per input lamp, in input order (it does not
 // merge duplicates -- that is classify()'s job). Two distinct lamps must both survive and keep
 // their order, so a caller can trust element[i] came from lamp[i].
 TEST(CnnLampRecognizerCoreUpdateSignalsTest, MultipleLampsYieldElementPerLampInOrder)
@@ -111,7 +111,7 @@ TEST(CnnLampRecognizerCoreUpdateSignalsTest, MultipleLampsYieldElementPerLampInO
     make_lamp(tl::Color::RED, tl::Shape::CROSS, tl::ArrowDirection::UNKNOWN)};
 
   // Act
-  tl::CnnLampRecognizerCore::updateTrafficSignals(lamps, signal);
+  tl::CnnLampRecognizerCore::update_traffic_signals(lamps, signal);
 
   // Assert
   ASSERT_EQ(signal.elements.size(), 2u);
@@ -121,7 +121,7 @@ TEST(CnnLampRecognizerCoreUpdateSignalsTest, MultipleLampsYieldElementPerLampInO
   EXPECT_EQ(signal.elements[1].shape, TrafficLightElement::CROSS);
 }
 
-// updateTrafficSignals clears the signal's existing elements before mapping, so repeated calls
+// update_traffic_signals clears the signal's existing elements before mapping, so repeated calls
 // replace rather than accumulate. A stale element left in place would be a downstream bug.
 TEST(CnnLampRecognizerCoreUpdateSignalsTest, ClearsPreexistingElements)
 {
@@ -135,7 +135,7 @@ TEST(CnnLampRecognizerCoreUpdateSignalsTest, ClearsPreexistingElements)
     make_lamp(tl::Color::GREEN, tl::Shape::CIRCLE, tl::ArrowDirection::UNKNOWN)};
 
   // Act
-  tl::CnnLampRecognizerCore::updateTrafficSignals(lamps, signal);
+  tl::CnnLampRecognizerCore::update_traffic_signals(lamps, signal);
 
   // Assert -- only the freshly mapped element remains; the stale AMBER one is gone.
   ASSERT_EQ(signal.elements.size(), 1u);
@@ -155,7 +155,7 @@ TEST(CnnLampRecognizerCoreUpdateSignalsTest, PedestrianTypeForcesCircle)
     make_lamp(tl::Color::GREEN, tl::Shape::ARROW, tl::ArrowDirection::UP_ARROW, 0.8f)};
 
   // Act
-  tl::CnnLampRecognizerCore::updateTrafficSignals(lamps, signal);
+  tl::CnnLampRecognizerCore::update_traffic_signals(lamps, signal);
 
   // Assert
   ASSERT_EQ(signal.elements.size(), 1u);
@@ -174,7 +174,7 @@ TEST(CnnLampRecognizerCoreUpdateSignalsTest, PedShapeForcesCircle)
     make_lamp(tl::Color::RED, tl::Shape::PED, tl::ArrowDirection::UNKNOWN)};
 
   // Act
-  tl::CnnLampRecognizerCore::updateTrafficSignals(lamps, signal);
+  tl::CnnLampRecognizerCore::update_traffic_signals(lamps, signal);
 
   // Assert
   ASSERT_EQ(signal.elements.size(), 1u);
@@ -193,7 +193,7 @@ TEST(CnnLampRecognizerCoreUpdateSignalsTest, UnknownColorPreservesConfidence)
     make_lamp(tl::Color::UNKNOWN, tl::Shape::CIRCLE, tl::ArrowDirection::UNKNOWN, 0.7f)};
 
   // Act
-  tl::CnnLampRecognizerCore::updateTrafficSignals(lamps, signal);
+  tl::CnnLampRecognizerCore::update_traffic_signals(lamps, signal);
 
   // Assert
   ASSERT_EQ(signal.elements.size(), 1u);
@@ -212,7 +212,7 @@ TEST(CnnLampRecognizerCoreUpdateSignalsTest, UnknownArrowDirectionZeroesConfiden
     make_lamp(tl::Color::GREEN, tl::Shape::ARROW, tl::ArrowDirection::UNKNOWN, 0.9f)};
 
   // Act
-  tl::CnnLampRecognizerCore::updateTrafficSignals(lamps, signal);
+  tl::CnnLampRecognizerCore::update_traffic_signals(lamps, signal);
 
   // Assert
   ASSERT_EQ(signal.elements.size(), 1u);
@@ -220,7 +220,7 @@ TEST(CnnLampRecognizerCoreUpdateSignalsTest, UnknownArrowDirectionZeroesConfiden
   EXPECT_FLOAT_EQ(signal.elements[0].confidence, 0.0f);
 }
 
-// A shape with no message mapping yet (e.g. U_TURN, see the TODO in updateTrafficSignals) hits
+// A shape with no message mapping yet (e.g. U_TURN, see the TODO in update_traffic_signals) hits
 // the outer default: UNKNOWN with the confidence zeroed, even though the detection carried a
 // positive one.
 TEST(CnnLampRecognizerCoreUpdateSignalsTest, UnsupportedShapeZeroesConfidence)
@@ -231,7 +231,7 @@ TEST(CnnLampRecognizerCoreUpdateSignalsTest, UnsupportedShapeZeroesConfidence)
     make_lamp(tl::Color::GREEN, tl::Shape::U_TURN, tl::ArrowDirection::UNKNOWN, 0.9f)};
 
   // Act
-  tl::CnnLampRecognizerCore::updateTrafficSignals(lamps, signal);
+  tl::CnnLampRecognizerCore::update_traffic_signals(lamps, signal);
 
   // Assert
   ASSERT_EQ(signal.elements.size(), 1u);
@@ -242,8 +242,8 @@ TEST(CnnLampRecognizerCoreUpdateSignalsTest, UnsupportedShapeZeroesConfidence)
 // Fill color is immaterial -- the debug tests assert geometry only.
 const cv::Scalar roi_fill_color{0, 255, 0};
 
-// outputDebugImage rescales the ROI to a fixed width and stacks a fixed-height label strip below
-// it (kDebugImageWidth / kDebugTextHeight in the production code).
+// make_debug_image rescales the ROI to a fixed width and stacks a fixed-height label strip below
+// it (debug_image_width / debug_text_height in the production code).
 constexpr int debug_image_width = 200;
 constexpr int debug_text_height = 50;
 
@@ -254,7 +254,7 @@ TEST(CnnLampRecognizerCoreDebugImageTest, MosaicGeometry)
   // drive the label strip.
   const int roi_width = 100;
   const int roi_height = 50;
-  cv::Mat debug_image(roi_height, roi_width, CV_8UC3, roi_fill_color);
+  const cv::Mat roi_image(roi_height, roi_width, CV_8UC3, roi_fill_color);
 
   tl::LampElement lamp =
     make_lamp(tl::Color::GREEN, tl::Shape::CIRCLE, tl::ArrowDirection::UNKNOWN);
@@ -269,7 +269,8 @@ TEST(CnnLampRecognizerCoreDebugImageTest, MosaicGeometry)
   signal.elements.push_back(element);
 
   // Act
-  tl::CnnLampRecognizerCore::outputDebugImage(debug_image, signal, &lamps);
+  const cv::Mat debug_image =
+    tl::CnnLampRecognizerCore::make_debug_image(roi_image, signal, &lamps);
 
   // Assert -- fixed width; height = aspect-preserving scaled ROI + the label strip.
   const int scaled_roi_height = debug_image_width * roi_height / roi_width;  // 200*50/100 = 100
@@ -278,18 +279,19 @@ TEST(CnnLampRecognizerCoreDebugImageTest, MosaicGeometry)
   EXPECT_EQ(debug_image.type(), CV_8UC3);
 }
 
-// outputDebugImage still produces the mosaic when no per-lamp detections are supplied
+// make_debug_image still produces the mosaic when no per-lamp detections are supplied
 // (elements == nullptr) -- the box-drawing branch is guarded and must not dereference it.
 TEST(CnnLampRecognizerCoreDebugImageTest, HandlesNullElements)
 {
   // Arrange
   const int roi_width = 100;
   const int roi_height = 50;
-  cv::Mat debug_image(roi_height, roi_width, CV_8UC3, roi_fill_color);
+  const cv::Mat roi_image(roi_height, roi_width, CV_8UC3, roi_fill_color);
   TrafficLight signal;  // no elements -> empty label
 
   // Act
-  tl::CnnLampRecognizerCore::outputDebugImage(debug_image, signal, nullptr);
+  const cv::Mat debug_image =
+    tl::CnnLampRecognizerCore::make_debug_image(roi_image, signal, nullptr);
 
   // Assert
   const int scaled_roi_height = debug_image_width * roi_height / roi_width;
@@ -403,7 +405,7 @@ protected:
 };
 
 // Count/color/shape are NOT pinned (brittle across model updates; the mapping is covered
-// model-free by the updateTrafficSignals tests). Require >=1 detection so the per-lamp checks
+// model-free by the update_traffic_signals tests). Require >=1 detection so the per-lamp checks
 // can't vacuously pass on an empty result.
 TEST_F(CnnLampRecognizerCoreClassifyTest, RealCropYieldsWellFormedDetections)
 {
@@ -434,7 +436,7 @@ TEST_F(CnnLampRecognizerCoreClassifyTest, RealCropYieldsWellFormedDetections)
 // classify() returns one result vector per input image. A detected crop and a black image
 // (which yields nothing) make the slots asymmetric, so a scatter swap would empty slot 0 and
 // fill slot 1 -- identical crops could not catch that. Black keeps the empty slot model-stable:
-// no model detects a lamp in pure black. Contents are left to the updateTrafficSignals tests.
+// no model detects a lamp in pure black. Contents are left to the update_traffic_signals tests.
 TEST_F(CnnLampRecognizerCoreClassifyTest, BatchClassificationScattersPerImageResults)
 {
   if (!core_) {


### PR DESCRIPTION
## Description

Cleanup of `cnn_lamp_recognizer.{hpp,cpp}` (the `CnnLampRecognizer` ROS adapter and the Node-free `CnnLampRecognizerCore`). **No behavior change** — dead-code removal, ROS 2 snake_case naming, and two small non-behavioral refactors (a non-destructive debug-image API and dropping the `MsgTE` alias).

- **Dead code removal:** drop the unreachable `case Shape::PED` in `update_traffic_signals`. The pedestrian guard just above the `switch` always `continue`s for `Shape::PED`, so the switch never sees that value; PED still maps to `CIRCLE` via the guard.
- **ROS 2 snake_case naming:**
  - File-local constants and anonymous-namespace helpers: 
    - `kDebugImageWidth` → `debug_image_width`
    - `kDebugTextHeight` → `debug_text_height`
    - `kDirectionVecNormSqThreshold` → `direction_vec_norm_sq_threshold`
    - `angleToArrowDirection` → `angle_to_arrow_direction`
    - `get2DIoU` → `get_2d_iou`
    - `runNms` → `run_nms`
    - `convertBBoxInfoToLampElement` → `convert_bbox_info_to_lamp_element`
    -  `overlap1D` → `overlap_1d`
  - `CnnLampRecognizerCore` methods (the core is interface-free, so it owns its naming): 
    - `updateTrafficSignals` → `update_traffic_signals`
    - `doInference` → `do_inference`
    - `decodeTlrOutput` → `decode_tlr_output`
  - The other minors: 
    - `BBoxInfo` fields: `classId` → `class_id`
    - `subClassId` → `sub_class_id`
- **Non-destructive debug-image API:** `outputDebugImage(cv::Mat & debug_image, …)`, which mutated its argument in place, becomes `make_debug_image(const cv::Mat & roi_image, …) -> cv::Mat`, which clones internally and returns the new image. The `clone()` moves inside the function, so the now-redundant `images[i].clone()` at the call site is removed. The resulting debug image is identical; only the ownership/signature changes. (This is not a rename — the previous body listed it under naming by mistake.)
- **Drop the `MsgTE` alias:** replace the file-local `using MsgTE = tier4_perception_msgs::msg::TrafficLightElement;` with `using tier4_perception_msgs::msg::TrafficLightElement;`, so the type is referred to by its own name (`TrafficLightElement::…`) rather than the ad-hoc abbreviation.
- **Scope the pi constant:** the file-level `PI` was used only inside `angle_to_arrow_direction`; move it there as a local `constexpr float pi`.

The adapter's `getTrafficSignals` override is intentionally kept in camelCase because it implements `ClassifierInterface`; only the interface-free core adopts snake_case.

## Related links

None.

## How was this PR tested?

`colcon build` + `colcon test --packages-select autoware_traffic_light_classifier` on an RTX 5080 with the real TensorRT engine (`traffic_light_lamp_recognizer_comlops.onnx`): **77 tests, 0 errors, 0 failures, 0 skipped**. Both the GPU decode path and the GPU-free core unit tests run.

## Notes for reviewers

No logic changes; the debug output is unchanged. The diff is dominated by identifier renames, plus the two structural tweaks noted above (the non-destructive `make_debug_image` and the `MsgTE` alias removal). `clang-format` wrapped the `decode_tlr_output` declaration because the longer name pushed it past 100 columns.

## Interface changes

None at the package boundary. `CnnLampRecognizerCore` is an internal class under `src/` (not an installed public header), so its method-name and signature changes are package-internal. The ROS-facing `ClassifierInterface::getTrafficSignals` is unchanged.

## Effects on system behavior

None.
