### PR TITLE
fix(control_validator): modernize parameter handling and support dynamic reconfigure

### DIFF
--- a/control/autoware_control_validator/CMakeLists.txt
+++ b/control/autoware_control_validator/CMakeLists.txt
@@ -4,6 +4,10 @@ project(autoware_control_validator)
 find_package(autoware_cmake REQUIRED)
 autoware_package()
 
+generate_parameter_library(control_validator_parameters
+  param/control_validator_parameters.yaml
+)
+
 ament_auto_add_library(autoware_control_validator_helpers SHARED
   src/utils.cpp
   src/debug_marker.cpp
@@ -14,7 +18,14 @@ ament_auto_add_library(autoware_control_validator_component SHARED
   include/autoware/control_validator/control_validator.hpp
   src/control_validator.cpp
 )
-target_link_libraries(autoware_control_validator_component autoware_control_validator_helpers)
+target_link_libraries(autoware_control_validator_component
+  autoware_control_validator_helpers
+  control_validator_parameters
+)
+# generate_parameter_library pulls in parameter_traits, which uses deprecated symbols.
+target_compile_options(autoware_control_validator_component PUBLIC
+  -Wno-error=deprecated-declarations
+)
 rclcpp_components_register_node(autoware_control_validator_component
   PLUGIN "autoware::control_validator::ControlValidator"
   EXECUTABLE autoware_control_validator_node
@@ -44,7 +55,10 @@ if(BUILD_TESTING)
   ament_target_dependencies(test_autoware_control_validator
     ament_index_cpp
   )
-  target_link_libraries(test_autoware_control_validator autoware_control_validator_component)
+  target_link_libraries(test_autoware_control_validator
+    autoware_control_validator_component
+    control_validator_parameters
+  )
 endif()
 
 ament_auto_package(

--- a/control/autoware_control_validator/config/control_validator.param.yaml
+++ b/control/autoware_control_validator/config/control_validator.param.yaml
@@ -7,26 +7,43 @@
 
     display_on_terminal: false # show error msg on terminal
 
-    thresholds:
-      max_distance_deviation: 1.0
-      lateral_jerk: 10.0
-      acc_error_offset: 0.8
-      acc_error_scale: 0.2
-      rolling_back_velocity: 0.5
-      over_velocity_offset: 2.0
-      over_velocity_ratio: 0.2
-      overrun_stop_point_dist: 0.8
-      will_overrun_stop_point_dist: 1.0
-      assumed_limit_acc: 5.0
-      assumed_delay_time: 0.2
-      nominal_latency: 0.01
-      yaw_deviation_error: 1.0
-      yaw_deviation_warn: 0.5
-
-    acc_lpf_gain: 0.97 # Time constant 1.11s
     vel_lpf_gain: 0.9 # Time constant 0.33
-    hold_velocity_error_until_stop: true
 
-    over_velocity:
+    acceleration_validator:
+      acc_lpf_gain: 0.97 # Time constant 1.11s
+      thresholds:
+        acc_error_offset: 0.8
+        acc_error_scale: 0.2
+
+    latency_validator:
+      thresholds:
+        nominal_latency: 0.01
+
+    lateral_jerk_validator:
+      thresholds:
+        lateral_jerk: 10.0
+
+    overrun_validator:
+      thresholds:
+        assumed_delay_time: 0.2
+        assumed_limit_acc: 5.0
+        overrun_stop_point_dist: 0.8
+        will_overrun_stop_point_dist: 1.0
+
+    trajectory_validator:
+      thresholds:
+        max_distance_deviation: 1.0
+
+    velocity_validator: # previously over_velocity
+      hold_velocity_error_until_stop: true
+      thresholds:
+        rolling_back_velocity: 0.5
+        over_velocity_offset: 2.0
+        over_velocity_ratio: 0.2
       # Longer time constant to avoid reacting to instantaneous velocity changes
       vel_lpf_gain: 0.985 # Time constant 2.0s at 30msec sampling period
+
+    trajectory_validator:
+      thresholds:
+        yaw_deviation_error: 1.0
+        yaw_deviation_warn: 0.5

--- a/control/autoware_control_validator/config/control_validator.param.yaml
+++ b/control/autoware_control_validator/config/control_validator.param.yaml
@@ -10,40 +10,33 @@
     vel_lpf_gain: 0.9 # Time constant 0.33
 
     acceleration_validator:
+      acc_error_offset: 0.8
+      acc_error_scale: 0.2
       acc_lpf_gain: 0.97 # Time constant 1.11s
-      thresholds:
-        acc_error_offset: 0.8
-        acc_error_scale: 0.2
 
     latency_validator:
-      thresholds:
-        nominal_latency: 0.01
+      nominal_latency: 0.01
 
     lateral_jerk_validator:
-      thresholds:
-        lateral_jerk: 10.0
+      lateral_jerk: 10.0
 
     overrun_validator:
-      thresholds:
-        assumed_delay_time: 0.2
-        assumed_limit_acc: 5.0
-        overrun_stop_point_dist: 0.8
-        will_overrun_stop_point_dist: 1.0
+      assumed_delay_time: 0.2
+      assumed_limit_acc: 5.0
+      overrun_stop_point_dist: 0.8
+      will_overrun_stop_point_dist: 1.0
 
     trajectory_validator:
-      thresholds:
-        max_distance_deviation: 1.0
+      max_distance_deviation: 1.0
 
     velocity_validator: # previously over_velocity
       hold_velocity_error_until_stop: true
-      thresholds:
-        rolling_back_velocity: 0.5
-        over_velocity_offset: 2.0
-        over_velocity_ratio: 0.2
+      rolling_back_velocity: 0.5
+      over_velocity_offset: 2.0
+      over_velocity_ratio: 0.2
       # Longer time constant to avoid reacting to instantaneous velocity changes
       vel_lpf_gain: 0.985 # Time constant 2.0s at 30msec sampling period
 
     yaw_validator:
-      thresholds:
-        yaw_deviation_error: 1.0
-        yaw_deviation_warn: 0.5
+      yaw_deviation_error: 1.0
+      yaw_deviation_warn: 0.5

--- a/control/autoware_control_validator/config/control_validator.param.yaml
+++ b/control/autoware_control_validator/config/control_validator.param.yaml
@@ -43,7 +43,7 @@
       # Longer time constant to avoid reacting to instantaneous velocity changes
       vel_lpf_gain: 0.985 # Time constant 2.0s at 30msec sampling period
 
-    trajectory_validator:
+    yaw_validator:
       thresholds:
         yaw_deviation_error: 1.0
         yaw_deviation_warn: 0.5

--- a/control/autoware_control_validator/include/autoware/control_validator/control_validator.hpp
+++ b/control/autoware_control_validator/include/autoware/control_validator/control_validator.hpp
@@ -21,8 +21,8 @@
 #include "diagnostic_updater/diagnostic_updater.hpp"
 
 #include <autoware/signal_processing/lowpass_filter_1d.hpp>
+#include <autoware_control_validator/control_validator_parameters.hpp>
 #include <autoware_control_validator/msg/control_validator_status.hpp>
-#include <autoware_utils/ros/parameter.hpp>
 #include <autoware_utils/system/stop_watch.hpp>
 #include <rclcpp/rclcpp.hpp>
 
@@ -48,7 +48,6 @@ using autoware_control_msgs::msg::Control;
 using autoware_control_validator::msg::ControlValidatorStatus;
 using autoware_planning_msgs::msg::Trajectory;
 using autoware_planning_msgs::msg::TrajectoryPoint;
-using autoware_utils::get_or_declare_parameter;
 using diagnostic_updater::DiagnosticStatusWrapper;
 using diagnostic_updater::Updater;
 using geometry_msgs::msg::AccelWithCovarianceStamped;
@@ -61,9 +60,8 @@ using nav_msgs::msg::Odometry;
 class LatencyValidator
 {
 public:
-  explicit LatencyValidator(rclcpp::Node & node)
-  : nominal_latency_threshold{
-      get_or_declare_parameter<double>(node, "thresholds.nominal_latency")} {};
+  explicit LatencyValidator(const ::control_validator::Params & params)
+  : nominal_latency_threshold{params.thresholds.nominal_latency} {};
 
   void validate(
     ControlValidatorStatus & res, const Control & control_cmd, rclcpp::Node & node) const;
@@ -80,9 +78,8 @@ private:
 class TrajectoryValidator
 {
 public:
-  explicit TrajectoryValidator(rclcpp::Node & node)
-  : max_distance_deviation_threshold{
-      get_or_declare_parameter<double>(node, "thresholds.max_distance_deviation")} {};
+  explicit TrajectoryValidator(const ::control_validator::Params & params)
+  : max_distance_deviation_threshold{params.thresholds.max_distance_deviation} {};
 
   void validate(
     ControlValidatorStatus & res, const Trajectory & predicted_trajectory,
@@ -100,10 +97,10 @@ private:
 class LateralJerkValidator
 {
 public:
-  explicit LateralJerkValidator(rclcpp::Node & node)
-  : lateral_jerk_threshold_{get_or_declare_parameter<double>(node, "thresholds.lateral_jerk")},
-    logger_{node.get_logger()},
-    measured_vel_lpf{get_or_declare_parameter<double>(node, "vel_lpf_gain")} {};
+  LateralJerkValidator(const rclcpp::Logger & logger, const ::control_validator::Params & params)
+  : lateral_jerk_threshold_{params.thresholds.lateral_jerk},
+    logger_{logger},
+    measured_vel_lpf{params.vel_lpf_gain} {};
 
   void validate(
     ControlValidatorStatus & res, const Odometry & kinematic_state, const Control & control_cmd,
@@ -124,11 +121,11 @@ class AccelerationValidator
 {
 public:
   friend class AccelerationValidatorTest;
-  explicit AccelerationValidator(rclcpp::Node & node)
-  : e_offset{get_or_declare_parameter<double>(node, "thresholds.acc_error_offset")},
-    e_scale{get_or_declare_parameter<double>(node, "thresholds.acc_error_scale")},
-    desired_acc_lpf{get_or_declare_parameter<double>(node, "acc_lpf_gain")},
-    measured_acc_lpf{get_or_declare_parameter<double>(node, "acc_lpf_gain")} {};
+  explicit AccelerationValidator(const ::control_validator::Params & params)
+  : e_offset{params.thresholds.acc_error_offset},
+    e_scale{params.thresholds.acc_error_scale},
+    desired_acc_lpf{params.acc_lpf_gain},
+    measured_acc_lpf{params.acc_lpf_gain} {};
 
   void validate(
     ControlValidatorStatus & res, const Odometry & kinematic_state, const Control & control_cmd,
@@ -149,21 +146,15 @@ private:
 class VelocityValidator
 {
 public:
-  explicit VelocityValidator(rclcpp::Node & node)
-  : rolling_back_velocity_th{get_or_declare_parameter<double>(
-      node, "thresholds.rolling_back_velocity")},
-    over_velocity_ratio_th{
-      get_or_declare_parameter<double>(node, "thresholds.over_velocity_ratio")},
-    over_velocity_offset_th{
-      get_or_declare_parameter<double>(node, "thresholds.over_velocity_offset")},
-    hold_velocity_error_until_stop{
-      get_or_declare_parameter<bool>(node, "hold_velocity_error_until_stop")},
-    vehicle_vel_lpf{get_or_declare_parameter<double>(node, "vel_lpf_gain")},
-    target_vel_lpf{get_or_declare_parameter<double>(node, "vel_lpf_gain")},
-    over_velocity_vehicle_vel_lpf{
-      get_or_declare_parameter<double>(node, "over_velocity.vel_lpf_gain")},
-    over_velocity_target_vel_lpf{
-      get_or_declare_parameter<double>(node, "over_velocity.vel_lpf_gain")} {};
+  explicit VelocityValidator(const ::control_validator::Params & params)
+  : rolling_back_velocity_th{params.thresholds.rolling_back_velocity},
+    over_velocity_ratio_th{params.thresholds.over_velocity_ratio},
+    over_velocity_offset_th{params.thresholds.over_velocity_offset},
+    hold_velocity_error_until_stop{params.hold_velocity_error_until_stop},
+    vehicle_vel_lpf{params.vel_lpf_gain},
+    target_vel_lpf{params.vel_lpf_gain},
+    over_velocity_vehicle_vel_lpf{params.over_velocity.vel_lpf_gain},
+    over_velocity_target_vel_lpf{params.over_velocity.vel_lpf_gain} {};
 
   void validate(
     ControlValidatorStatus & res, const Trajectory & reference_trajectory,
@@ -187,14 +178,12 @@ private:
 class OverrunValidator
 {
 public:
-  explicit OverrunValidator(rclcpp::Node & node)
-  : overrun_stop_point_dist_th{get_or_declare_parameter<double>(
-      node, "thresholds.overrun_stop_point_dist")},
-    will_overrun_stop_point_dist_th{
-      get_or_declare_parameter<double>(node, "thresholds.will_overrun_stop_point_dist")},
-    assumed_limit_acc{get_or_declare_parameter<double>(node, "thresholds.assumed_limit_acc")},
-    assumed_delay_time{get_or_declare_parameter<double>(node, "thresholds.assumed_delay_time")},
-    vehicle_vel_lpf{get_or_declare_parameter<double>(node, "vel_lpf_gain")} {};
+  explicit OverrunValidator(const ::control_validator::Params & params)
+  : overrun_stop_point_dist_th{params.thresholds.overrun_stop_point_dist},
+    will_overrun_stop_point_dist_th{params.thresholds.will_overrun_stop_point_dist},
+    assumed_limit_acc{params.thresholds.assumed_limit_acc},
+    assumed_delay_time{params.thresholds.assumed_delay_time},
+    vehicle_vel_lpf{params.vel_lpf_gain} {};
 
   void validate(
     ControlValidatorStatus & res, const Trajectory & reference_trajectory,
@@ -215,11 +204,9 @@ private:
 class YawValidator
 {
 public:
-  explicit YawValidator(rclcpp::Node & node)
-  : yaw_deviation_error_th_{get_or_declare_parameter<double>(
-      node, "thresholds.yaw_deviation_error")},
-    yaw_deviation_warn_th_{
-      get_or_declare_parameter<double>(node, "thresholds.yaw_deviation_warn")} {};
+  explicit YawValidator(const ::control_validator::Params & params)
+  : yaw_deviation_error_th_{params.thresholds.yaw_deviation_error},
+    yaw_deviation_warn_th_{params.thresholds.yaw_deviation_warn} {};
 
   void validate(
     ControlValidatorStatus & res, const Trajectory & reference_trajectory,
@@ -309,6 +296,10 @@ private:
   rclcpp::Publisher<autoware_internal_debug_msgs::msg::Float64Stamped>::SharedPtr
     pub_processing_time_;
 
+  // parameters (generated by generate_parameter_library)
+  ::control_validator::ParamListener param_listener_;
+  ::control_validator::Params params_;
+
   // system parameters
   int64_t diag_error_count_threshold_ = 0;
   bool display_on_terminal_ = true;
@@ -328,13 +319,13 @@ private:
   autoware_utils::StopWatch<std::chrono::milliseconds> stop_watch;
 
   // individual validators
-  LatencyValidator latency_validator{*this};
-  LateralJerkValidator lateral_jerk_validator{*this};
-  TrajectoryValidator trajectory_validator{*this};
-  AccelerationValidator acceleration_validator{*this};
-  VelocityValidator velocity_validator{*this};
-  OverrunValidator overrun_validator{*this};
-  YawValidator yaw_validator{*this};
+  LatencyValidator latency_validator;
+  LateralJerkValidator lateral_jerk_validator;
+  TrajectoryValidator trajectory_validator;
+  AccelerationValidator acceleration_validator;
+  VelocityValidator velocity_validator;
+  OverrunValidator overrun_validator;
+  YawValidator yaw_validator;
 };
 }  // namespace autoware::control_validator
 

--- a/control/autoware_control_validator/include/autoware/control_validator/control_validator.hpp
+++ b/control/autoware_control_validator/include/autoware/control_validator/control_validator.hpp
@@ -61,13 +61,20 @@ class LatencyValidator
 {
 public:
   explicit LatencyValidator(const ::control_validator::Params & params)
-  : nominal_latency_threshold{params.thresholds.nominal_latency} {};
+  {
+    update_parameters(params);
+  }
+
+  void update_parameters(const ::control_validator::Params & params)
+  {
+    nominal_latency_threshold = params.thresholds.nominal_latency;
+  }
 
   void validate(
     ControlValidatorStatus & res, const Control & control_cmd, rclcpp::Node & node) const;
 
 private:
-  const double nominal_latency_threshold;
+  double nominal_latency_threshold{};
 };
 
 /**
@@ -79,14 +86,21 @@ class TrajectoryValidator
 {
 public:
   explicit TrajectoryValidator(const ::control_validator::Params & params)
-  : max_distance_deviation_threshold{params.thresholds.max_distance_deviation} {};
+  {
+    update_parameters(params);
+  }
+
+  void update_parameters(const ::control_validator::Params & params)
+  {
+    max_distance_deviation_threshold = params.thresholds.max_distance_deviation;
+  }
 
   void validate(
     ControlValidatorStatus & res, const Trajectory & predicted_trajectory,
     const Trajectory & reference_trajectory);
 
 private:
-  const double max_distance_deviation_threshold;
+  double max_distance_deviation_threshold{};
   std::optional<Trajectory> prev_reference_trajectory_;
 };
 
@@ -98,9 +112,16 @@ class LateralJerkValidator
 {
 public:
   LateralJerkValidator(const rclcpp::Logger & logger, const ::control_validator::Params & params)
-  : lateral_jerk_threshold_{params.thresholds.lateral_jerk},
-    logger_{logger},
-    measured_vel_lpf{params.vel_lpf_gain} {};
+  : logger_{logger}, measured_vel_lpf{params.vel_lpf_gain}
+  {
+    update_parameters(params);
+  }
+
+  void update_parameters(const ::control_validator::Params & params)
+  {
+    lateral_jerk_threshold_ = params.thresholds.lateral_jerk;
+    measured_vel_lpf.setGain(params.vel_lpf_gain);
+  }
 
   void validate(
     ControlValidatorStatus & res, const Odometry & kinematic_state, const Control & control_cmd,
@@ -122,10 +143,18 @@ class AccelerationValidator
 public:
   friend class AccelerationValidatorTest;
   explicit AccelerationValidator(const ::control_validator::Params & params)
-  : e_offset{params.thresholds.acc_error_offset},
-    e_scale{params.thresholds.acc_error_scale},
-    desired_acc_lpf{params.acc_lpf_gain},
-    measured_acc_lpf{params.acc_lpf_gain} {};
+  : desired_acc_lpf{params.acc_lpf_gain}, measured_acc_lpf{params.acc_lpf_gain}
+  {
+    update_parameters(params);
+  }
+
+  void update_parameters(const ::control_validator::Params & params)
+  {
+    e_offset = params.thresholds.acc_error_offset;
+    e_scale = params.thresholds.acc_error_scale;
+    desired_acc_lpf.setGain(params.acc_lpf_gain);
+    measured_acc_lpf.setGain(params.acc_lpf_gain);
+  }
 
   void validate(
     ControlValidatorStatus & res, const Odometry & kinematic_state, const Control & control_cmd,
@@ -133,8 +162,8 @@ public:
 
 private:
   bool is_in_error_range() const;
-  const double e_offset;
-  const double e_scale;
+  double e_offset{};
+  double e_scale{};
   autoware::signal_processing::LowpassFilter1d desired_acc_lpf;
   autoware::signal_processing::LowpassFilter1d measured_acc_lpf;
 };
@@ -147,24 +176,35 @@ class VelocityValidator
 {
 public:
   explicit VelocityValidator(const ::control_validator::Params & params)
-  : rolling_back_velocity_th{params.thresholds.rolling_back_velocity},
-    over_velocity_ratio_th{params.thresholds.over_velocity_ratio},
-    over_velocity_offset_th{params.thresholds.over_velocity_offset},
-    hold_velocity_error_until_stop{params.hold_velocity_error_until_stop},
-    vehicle_vel_lpf{params.vel_lpf_gain},
+  : vehicle_vel_lpf{params.vel_lpf_gain},
     target_vel_lpf{params.vel_lpf_gain},
     over_velocity_vehicle_vel_lpf{params.over_velocity.vel_lpf_gain},
-    over_velocity_target_vel_lpf{params.over_velocity.vel_lpf_gain} {};
+    over_velocity_target_vel_lpf{params.over_velocity.vel_lpf_gain}
+  {
+    update_parameters(params);
+  }
+
+  void update_parameters(const ::control_validator::Params & params)
+  {
+    rolling_back_velocity_th = params.thresholds.rolling_back_velocity;
+    over_velocity_ratio_th = params.thresholds.over_velocity_ratio;
+    over_velocity_offset_th = params.thresholds.over_velocity_offset;
+    hold_velocity_error_until_stop = params.hold_velocity_error_until_stop;
+    vehicle_vel_lpf.setGain(params.vel_lpf_gain);
+    target_vel_lpf.setGain(params.vel_lpf_gain);
+    over_velocity_vehicle_vel_lpf.setGain(params.over_velocity.vel_lpf_gain);
+    over_velocity_target_vel_lpf.setGain(params.over_velocity.vel_lpf_gain);
+  }
 
   void validate(
     ControlValidatorStatus & res, const Trajectory & reference_trajectory,
     const Odometry & kinematics);
 
 private:
-  const double rolling_back_velocity_th;
-  const double over_velocity_ratio_th;
-  const double over_velocity_offset_th;
-  const bool hold_velocity_error_until_stop;
+  double rolling_back_velocity_th{};
+  double over_velocity_ratio_th{};
+  double over_velocity_offset_th{};
+  bool hold_velocity_error_until_stop{};
   autoware::signal_processing::LowpassFilter1d vehicle_vel_lpf;
   autoware::signal_processing::LowpassFilter1d target_vel_lpf;
   autoware::signal_processing::LowpassFilter1d over_velocity_vehicle_vel_lpf;
@@ -179,21 +219,29 @@ class OverrunValidator
 {
 public:
   explicit OverrunValidator(const ::control_validator::Params & params)
-  : overrun_stop_point_dist_th{params.thresholds.overrun_stop_point_dist},
-    will_overrun_stop_point_dist_th{params.thresholds.will_overrun_stop_point_dist},
-    assumed_limit_acc{params.thresholds.assumed_limit_acc},
-    assumed_delay_time{params.thresholds.assumed_delay_time},
-    vehicle_vel_lpf{params.vel_lpf_gain} {};
+  : vehicle_vel_lpf{params.vel_lpf_gain}
+  {
+    update_parameters(params);
+  }
+
+  void update_parameters(const ::control_validator::Params & params)
+  {
+    overrun_stop_point_dist_th = params.thresholds.overrun_stop_point_dist;
+    will_overrun_stop_point_dist_th = params.thresholds.will_overrun_stop_point_dist;
+    assumed_limit_acc = params.thresholds.assumed_limit_acc;
+    assumed_delay_time = params.thresholds.assumed_delay_time;
+    vehicle_vel_lpf.setGain(params.vel_lpf_gain);
+  }
 
   void validate(
     ControlValidatorStatus & res, const Trajectory & reference_trajectory,
     const Odometry & kinematics);
 
 private:
-  const double overrun_stop_point_dist_th;
-  const double will_overrun_stop_point_dist_th;
-  const double assumed_limit_acc;
-  const double assumed_delay_time;
+  double overrun_stop_point_dist_th{};
+  double will_overrun_stop_point_dist_th{};
+  double assumed_limit_acc{};
+  double assumed_delay_time{};
   autoware::signal_processing::LowpassFilter1d vehicle_vel_lpf;
 };
 
@@ -204,17 +252,21 @@ private:
 class YawValidator
 {
 public:
-  explicit YawValidator(const ::control_validator::Params & params)
-  : yaw_deviation_error_th_{params.thresholds.yaw_deviation_error},
-    yaw_deviation_warn_th_{params.thresholds.yaw_deviation_warn} {};
+  explicit YawValidator(const ::control_validator::Params & params) { update_parameters(params); }
+
+  void update_parameters(const ::control_validator::Params & params)
+  {
+    yaw_deviation_error_th_ = params.thresholds.yaw_deviation_error;
+    yaw_deviation_warn_th_ = params.thresholds.yaw_deviation_warn;
+  }
 
   void validate(
     ControlValidatorStatus & res, const Trajectory & reference_trajectory,
     const Odometry & kinematics) const;
 
 private:
-  const double yaw_deviation_error_th_;
-  const double yaw_deviation_warn_th_;
+  double yaw_deviation_error_th_{};
+  double yaw_deviation_warn_th_{};
 };
 
 /**

--- a/control/autoware_control_validator/include/autoware/control_validator/control_validator.hpp
+++ b/control/autoware_control_validator/include/autoware/control_validator/control_validator.hpp
@@ -52,6 +52,7 @@ using diagnostic_updater::DiagnosticStatusWrapper;
 using diagnostic_updater::Updater;
 using geometry_msgs::msg::AccelWithCovarianceStamped;
 using nav_msgs::msg::Odometry;
+using Params = ::control_validator::Params;
 
 /**
  * @class LatencyValidator
@@ -60,21 +61,21 @@ using nav_msgs::msg::Odometry;
 class LatencyValidator
 {
 public:
-  explicit LatencyValidator(const ::control_validator::Params & params)
+  explicit LatencyValidator(const Params & params)
+  : latency_validator_params_(params.latency_validator)
   {
-    update_parameters(params);
   }
 
-  void update_parameters(const ::control_validator::Params & params)
+  void update_parameters(const Params & params)
   {
-    nominal_latency_threshold = params.thresholds.nominal_latency;
+    latency_validator_params_ = params.latency_validator;
   }
 
   void validate(
     ControlValidatorStatus & res, const Control & control_cmd, rclcpp::Node & node) const;
 
 private:
-  double nominal_latency_threshold{};
+  Params::LatencyValidator latency_validator_params_;
 };
 
 /**
@@ -85,14 +86,14 @@ private:
 class TrajectoryValidator
 {
 public:
-  explicit TrajectoryValidator(const ::control_validator::Params & params)
+  explicit TrajectoryValidator(const Params & params)
+  : trajectory_validator_params_(params.trajectory_validator)
   {
-    update_parameters(params);
   }
 
-  void update_parameters(const ::control_validator::Params & params)
+  void update_parameters(const Params & params)
   {
-    max_distance_deviation_threshold = params.thresholds.max_distance_deviation;
+    trajectory_validator_params_ = params.trajectory_validator;
   }
 
   void validate(
@@ -100,7 +101,7 @@ public:
     const Trajectory & reference_trajectory);
 
 private:
-  double max_distance_deviation_threshold{};
+  Params::TrajectoryValidator trajectory_validator_params_;
   std::optional<Trajectory> prev_reference_trajectory_;
 };
 
@@ -111,15 +112,16 @@ private:
 class LateralJerkValidator
 {
 public:
-  LateralJerkValidator(const rclcpp::Logger & logger, const ::control_validator::Params & params)
-  : logger_{logger}, measured_vel_lpf{params.vel_lpf_gain}
+  LateralJerkValidator(const rclcpp::Logger & logger, const Params & params)
+  : logger_{logger},
+    lateral_jerk_validator_params_{params.lateral_jerk_validator},
+    measured_vel_lpf{params.vel_lpf_gain}
   {
-    update_parameters(params);
   }
 
-  void update_parameters(const ::control_validator::Params & params)
+  void update_parameters(const Params & params)
   {
-    lateral_jerk_threshold_ = params.thresholds.lateral_jerk;
+    lateral_jerk_validator_params_ = params.lateral_jerk_validator;
     measured_vel_lpf.setGain(params.vel_lpf_gain);
   }
 
@@ -128,8 +130,8 @@ public:
     const double wheel_base);
 
 private:
-  double lateral_jerk_threshold_{};  // m/s^3
   rclcpp::Logger logger_;
+  Params::LateralJerkValidator lateral_jerk_validator_params_;
   std::unique_ptr<Control> prev_control_cmd_{};
   autoware::signal_processing::LowpassFilter1d measured_vel_lpf;
 };
@@ -142,18 +144,18 @@ class AccelerationValidator
 {
 public:
   friend class AccelerationValidatorTest;
-  explicit AccelerationValidator(const ::control_validator::Params & params)
-  : desired_acc_lpf{params.acc_lpf_gain}, measured_acc_lpf{params.acc_lpf_gain}
+  explicit AccelerationValidator(const Params & params)
+  : acceleration_validator_params_{params.acceleration_validator},
+    desired_acc_lpf{params.acceleration_validator.acc_lpf_gain},
+    measured_acc_lpf{params.acceleration_validator.acc_lpf_gain}
   {
-    update_parameters(params);
   }
 
-  void update_parameters(const ::control_validator::Params & params)
+  void update_parameters(const Params & params)
   {
-    e_offset = params.thresholds.acc_error_offset;
-    e_scale = params.thresholds.acc_error_scale;
-    desired_acc_lpf.setGain(params.acc_lpf_gain);
-    measured_acc_lpf.setGain(params.acc_lpf_gain);
+    acceleration_validator_params_ = params.acceleration_validator;
+    desired_acc_lpf.setGain(acceleration_validator_params_.acc_lpf_gain);
+    measured_acc_lpf.setGain(acceleration_validator_params_.acc_lpf_gain);
   }
 
   void validate(
@@ -162,8 +164,8 @@ public:
 
 private:
   bool is_in_error_range() const;
-  double e_offset{};
-  double e_scale{};
+
+  Params::AccelerationValidator acceleration_validator_params_;
   autoware::signal_processing::LowpassFilter1d desired_acc_lpf;
   autoware::signal_processing::LowpassFilter1d measured_acc_lpf;
 };
@@ -175,25 +177,22 @@ private:
 class VelocityValidator
 {
 public:
-  explicit VelocityValidator(const ::control_validator::Params & params)
-  : vehicle_vel_lpf{params.vel_lpf_gain},
+  explicit VelocityValidator(const Params & params)
+  : velocity_validator_params_{params.velocity_validator},
+    vehicle_vel_lpf{params.vel_lpf_gain},
     target_vel_lpf{params.vel_lpf_gain},
-    over_velocity_vehicle_vel_lpf{params.over_velocity.vel_lpf_gain},
-    over_velocity_target_vel_lpf{params.over_velocity.vel_lpf_gain}
+    over_velocity_vehicle_vel_lpf{params.velocity_validator.vel_lpf_gain},
+    over_velocity_target_vel_lpf{params.velocity_validator.vel_lpf_gain}
   {
-    update_parameters(params);
   }
 
-  void update_parameters(const ::control_validator::Params & params)
+  void update_parameters(const Params & params)
   {
-    rolling_back_velocity_th = params.thresholds.rolling_back_velocity;
-    over_velocity_ratio_th = params.thresholds.over_velocity_ratio;
-    over_velocity_offset_th = params.thresholds.over_velocity_offset;
-    hold_velocity_error_until_stop = params.hold_velocity_error_until_stop;
+    velocity_validator_params_ = params.velocity_validator;
     vehicle_vel_lpf.setGain(params.vel_lpf_gain);
     target_vel_lpf.setGain(params.vel_lpf_gain);
-    over_velocity_vehicle_vel_lpf.setGain(params.over_velocity.vel_lpf_gain);
-    over_velocity_target_vel_lpf.setGain(params.over_velocity.vel_lpf_gain);
+    over_velocity_vehicle_vel_lpf.setGain(velocity_validator_params_.vel_lpf_gain);
+    over_velocity_target_vel_lpf.setGain(velocity_validator_params_.vel_lpf_gain);
   }
 
   void validate(
@@ -201,10 +200,7 @@ public:
     const Odometry & kinematics);
 
 private:
-  double rolling_back_velocity_th{};
-  double over_velocity_ratio_th{};
-  double over_velocity_offset_th{};
-  bool hold_velocity_error_until_stop{};
+  Params::VelocityValidator velocity_validator_params_;
   autoware::signal_processing::LowpassFilter1d vehicle_vel_lpf;
   autoware::signal_processing::LowpassFilter1d target_vel_lpf;
   autoware::signal_processing::LowpassFilter1d over_velocity_vehicle_vel_lpf;
@@ -218,18 +214,14 @@ private:
 class OverrunValidator
 {
 public:
-  explicit OverrunValidator(const ::control_validator::Params & params)
-  : vehicle_vel_lpf{params.vel_lpf_gain}
+  explicit OverrunValidator(const Params & params)
+  : overrun_validator_params_{params.overrun_validator}, vehicle_vel_lpf{params.vel_lpf_gain}
   {
-    update_parameters(params);
   }
 
-  void update_parameters(const ::control_validator::Params & params)
+  void update_parameters(const Params & params)
   {
-    overrun_stop_point_dist_th = params.thresholds.overrun_stop_point_dist;
-    will_overrun_stop_point_dist_th = params.thresholds.will_overrun_stop_point_dist;
-    assumed_limit_acc = params.thresholds.assumed_limit_acc;
-    assumed_delay_time = params.thresholds.assumed_delay_time;
+    overrun_validator_params_ = params.overrun_validator;
     vehicle_vel_lpf.setGain(params.vel_lpf_gain);
   }
 
@@ -238,10 +230,7 @@ public:
     const Odometry & kinematics);
 
 private:
-  double overrun_stop_point_dist_th{};
-  double will_overrun_stop_point_dist_th{};
-  double assumed_limit_acc{};
-  double assumed_delay_time{};
+  Params::OverrunValidator overrun_validator_params_;
   autoware::signal_processing::LowpassFilter1d vehicle_vel_lpf;
 };
 
@@ -252,21 +241,16 @@ private:
 class YawValidator
 {
 public:
-  explicit YawValidator(const ::control_validator::Params & params) { update_parameters(params); }
+  explicit YawValidator(const Params & params) : yaw_validator_params_(params.yaw_validator) {}
 
-  void update_parameters(const ::control_validator::Params & params)
-  {
-    yaw_deviation_error_th_ = params.thresholds.yaw_deviation_error;
-    yaw_deviation_warn_th_ = params.thresholds.yaw_deviation_warn;
-  }
+  void update_parameters(const Params & params) { yaw_validator_params_ = params.yaw_validator; }
 
   void validate(
     ControlValidatorStatus & res, const Trajectory & reference_trajectory,
     const Odometry & kinematics) const;
 
 private:
-  double yaw_deviation_error_th_{};
-  double yaw_deviation_warn_th_{};
+  Params::YawValidator yaw_validator_params_;
 };
 
 /**

--- a/control/autoware_control_validator/include/autoware/control_validator/control_validator.hpp
+++ b/control/autoware_control_validator/include/autoware/control_validator/control_validator.hpp
@@ -61,21 +61,15 @@ using Params = ::control_validator::Params;
 class LatencyValidator
 {
 public:
-  explicit LatencyValidator(const Params & params)
-  : latency_validator_params_(params.latency_validator)
-  {
-  }
+  explicit LatencyValidator(const Params & params) : params_(params.latency_validator) {}
 
-  void update_parameters(const Params & params)
-  {
-    latency_validator_params_ = params.latency_validator;
-  }
+  void update_parameters(const Params & params) { params_ = params.latency_validator; }
 
   void validate(
     ControlValidatorStatus & res, const Control & control_cmd, rclcpp::Node & node) const;
 
 private:
-  Params::LatencyValidator latency_validator_params_;
+  Params::LatencyValidator params_;
 };
 
 /**
@@ -86,22 +80,16 @@ private:
 class TrajectoryValidator
 {
 public:
-  explicit TrajectoryValidator(const Params & params)
-  : trajectory_validator_params_(params.trajectory_validator)
-  {
-  }
+  explicit TrajectoryValidator(const Params & params) : params_(params.trajectory_validator) {}
 
-  void update_parameters(const Params & params)
-  {
-    trajectory_validator_params_ = params.trajectory_validator;
-  }
+  void update_parameters(const Params & params) { params_ = params.trajectory_validator; }
 
   void validate(
     ControlValidatorStatus & res, const Trajectory & predicted_trajectory,
     const Trajectory & reference_trajectory);
 
 private:
-  Params::TrajectoryValidator trajectory_validator_params_;
+  Params::TrajectoryValidator params_;
   std::optional<Trajectory> prev_reference_trajectory_;
 };
 
@@ -113,15 +101,13 @@ class LateralJerkValidator
 {
 public:
   LateralJerkValidator(const rclcpp::Logger & logger, const Params & params)
-  : logger_{logger},
-    lateral_jerk_validator_params_{params.lateral_jerk_validator},
-    measured_vel_lpf{params.vel_lpf_gain}
+  : logger_{logger}, params_{params.lateral_jerk_validator}, measured_vel_lpf{params.vel_lpf_gain}
   {
   }
 
   void update_parameters(const Params & params)
   {
-    lateral_jerk_validator_params_ = params.lateral_jerk_validator;
+    params_ = params.lateral_jerk_validator;
     measured_vel_lpf.setGain(params.vel_lpf_gain);
   }
 
@@ -131,7 +117,7 @@ public:
 
 private:
   rclcpp::Logger logger_;
-  Params::LateralJerkValidator lateral_jerk_validator_params_;
+  Params::LateralJerkValidator params_;
   std::unique_ptr<Control> prev_control_cmd_{};
   autoware::signal_processing::LowpassFilter1d measured_vel_lpf;
 };
@@ -145,7 +131,7 @@ class AccelerationValidator
 public:
   friend class AccelerationValidatorTest;
   explicit AccelerationValidator(const Params & params)
-  : acceleration_validator_params_{params.acceleration_validator},
+  : params_{params.acceleration_validator},
     desired_acc_lpf{params.acceleration_validator.acc_lpf_gain},
     measured_acc_lpf{params.acceleration_validator.acc_lpf_gain}
   {
@@ -153,9 +139,9 @@ public:
 
   void update_parameters(const Params & params)
   {
-    acceleration_validator_params_ = params.acceleration_validator;
-    desired_acc_lpf.setGain(acceleration_validator_params_.acc_lpf_gain);
-    measured_acc_lpf.setGain(acceleration_validator_params_.acc_lpf_gain);
+    params_ = params.acceleration_validator;
+    desired_acc_lpf.setGain(params_.acc_lpf_gain);
+    measured_acc_lpf.setGain(params_.acc_lpf_gain);
   }
 
   void validate(
@@ -165,7 +151,7 @@ public:
 private:
   bool is_in_error_range() const;
 
-  Params::AccelerationValidator acceleration_validator_params_;
+  Params::AccelerationValidator params_;
   autoware::signal_processing::LowpassFilter1d desired_acc_lpf;
   autoware::signal_processing::LowpassFilter1d measured_acc_lpf;
 };
@@ -178,7 +164,7 @@ class VelocityValidator
 {
 public:
   explicit VelocityValidator(const Params & params)
-  : velocity_validator_params_{params.velocity_validator},
+  : params_{params.velocity_validator},
     vehicle_vel_lpf{params.vel_lpf_gain},
     target_vel_lpf{params.vel_lpf_gain},
     over_velocity_vehicle_vel_lpf{params.velocity_validator.vel_lpf_gain},
@@ -188,11 +174,11 @@ public:
 
   void update_parameters(const Params & params)
   {
-    velocity_validator_params_ = params.velocity_validator;
+    params_ = params.velocity_validator;
     vehicle_vel_lpf.setGain(params.vel_lpf_gain);
     target_vel_lpf.setGain(params.vel_lpf_gain);
-    over_velocity_vehicle_vel_lpf.setGain(velocity_validator_params_.vel_lpf_gain);
-    over_velocity_target_vel_lpf.setGain(velocity_validator_params_.vel_lpf_gain);
+    over_velocity_vehicle_vel_lpf.setGain(params_.vel_lpf_gain);
+    over_velocity_target_vel_lpf.setGain(params_.vel_lpf_gain);
   }
 
   void validate(
@@ -200,7 +186,7 @@ public:
     const Odometry & kinematics);
 
 private:
-  Params::VelocityValidator velocity_validator_params_;
+  Params::VelocityValidator params_;
   autoware::signal_processing::LowpassFilter1d vehicle_vel_lpf;
   autoware::signal_processing::LowpassFilter1d target_vel_lpf;
   autoware::signal_processing::LowpassFilter1d over_velocity_vehicle_vel_lpf;
@@ -215,13 +201,13 @@ class OverrunValidator
 {
 public:
   explicit OverrunValidator(const Params & params)
-  : overrun_validator_params_{params.overrun_validator}, vehicle_vel_lpf{params.vel_lpf_gain}
+  : params_{params.overrun_validator}, vehicle_vel_lpf{params.vel_lpf_gain}
   {
   }
 
   void update_parameters(const Params & params)
   {
-    overrun_validator_params_ = params.overrun_validator;
+    params_ = params.overrun_validator;
     vehicle_vel_lpf.setGain(params.vel_lpf_gain);
   }
 
@@ -230,7 +216,7 @@ public:
     const Odometry & kinematics);
 
 private:
-  Params::OverrunValidator overrun_validator_params_;
+  Params::OverrunValidator params_;
   autoware::signal_processing::LowpassFilter1d vehicle_vel_lpf;
 };
 
@@ -241,16 +227,16 @@ private:
 class YawValidator
 {
 public:
-  explicit YawValidator(const Params & params) : yaw_validator_params_(params.yaw_validator) {}
+  explicit YawValidator(const Params & params) : params_(params.yaw_validator) {}
 
-  void update_parameters(const Params & params) { yaw_validator_params_ = params.yaw_validator; }
+  void update_parameters(const Params & params) { params_ = params.yaw_validator; }
 
   void validate(
     ControlValidatorStatus & res, const Trajectory & reference_trajectory,
     const Odometry & kinematics) const;
 
 private:
-  Params::YawValidator yaw_validator_params_;
+  Params::YawValidator params_;
 };
 
 /**

--- a/control/autoware_control_validator/package.xml
+++ b/control/autoware_control_validator/package.xml
@@ -29,6 +29,7 @@
   <depend>autoware_utils</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>diagnostic_updater</depend>
+  <depend>generate_parameter_library</depend>
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>

--- a/control/autoware_control_validator/param/control_validator_parameters.yaml
+++ b/control/autoware_control_validator/param/control_validator_parameters.yaml
@@ -1,0 +1,89 @@
+control_validator:
+  diag_error_count_threshold:
+    type: int
+    default_value: 0
+    description: If the number of consecutive invalid predicted_path exceeds this threshold, the Diag will be set to ERROR.
+
+  display_on_terminal:
+    type: bool
+    default_value: false
+    description: Show error message on terminal.
+
+  acc_lpf_gain:
+    type: double
+    default_value: 0.97
+    description: Low-pass filter gain for the acceleration validator.
+
+  vel_lpf_gain:
+    type: double
+    default_value: 0.9
+    description: Low-pass filter gain for filtering vehicle and target velocity.
+
+  hold_velocity_error_until_stop:
+    type: bool
+    default_value: true
+    description: If true, a velocity error is held until the vehicle stops.
+
+  thresholds:
+    max_distance_deviation:
+      type: double
+      default_value: 1.0
+      description: Invalid threshold of the max distance deviation between the predicted path and the reference trajectory [m].
+    lateral_jerk:
+      type: double
+      default_value: 10.0
+      description: Invalid threshold of the lateral jerk for steering rate validation [m/s^3].
+    acc_error_offset:
+      type: double
+      default_value: 0.8
+      description: Offset threshold to validate the vehicle acceleration.
+    acc_error_scale:
+      type: double
+      default_value: 0.2
+      description: Scale threshold to validate the vehicle acceleration.
+    rolling_back_velocity:
+      type: double
+      default_value: 0.5
+      description: Threshold velocity to validate the vehicle velocity [m/s].
+    over_velocity_offset:
+      type: double
+      default_value: 2.0
+      description: Threshold velocity offset to validate the vehicle velocity [m/s].
+    over_velocity_ratio:
+      type: double
+      default_value: 0.2
+      description: Threshold ratio to validate the vehicle velocity.
+    overrun_stop_point_dist:
+      type: double
+      default_value: 0.8
+      description: Threshold distance to overrun stop point [m].
+    will_overrun_stop_point_dist:
+      type: double
+      default_value: 1.0
+      description: Threshold distance to predict overrun of the stop point [m].
+    assumed_limit_acc:
+      type: double
+      default_value: 5.0
+      description: Assumed acceleration for over run estimation [m/s^2].
+    assumed_delay_time:
+      type: double
+      default_value: 0.2
+      description: Assumed delay for over run estimation [s].
+    nominal_latency:
+      type: double
+      default_value: 0.01
+      description: Threshold of the control latency [s].
+    yaw_deviation_error:
+      type: double
+      default_value: 1.0
+      description: Threshold angle to validate the vehicle yaw relative to the nearest trajectory yaw [rad].
+    yaw_deviation_warn:
+      type: double
+      default_value: 0.5
+      description: Threshold angle to trigger a WARN diagnostic for the vehicle yaw [rad].
+
+  over_velocity:
+    vel_lpf_gain:
+      type: double
+      default_value: 0.985
+      description: Low-pass filter gain for filtering vehicle and target velocity in the over velocity check.

--- a/control/autoware_control_validator/param/control_validator_parameters.yaml
+++ b/control/autoware_control_validator/param/control_validator_parameters.yaml
@@ -3,87 +3,107 @@ control_validator:
     type: int
     default_value: 0
     description: If the number of consecutive invalid predicted_path exceeds this threshold, the Diag will be set to ERROR.
+    read_only: false
 
   display_on_terminal:
     type: bool
     default_value: false
     description: Show error message on terminal.
+    read_only: false
 
   acc_lpf_gain:
     type: double
     default_value: 0.97
     description: Low-pass filter gain for the acceleration validator.
+    read_only: false
 
   vel_lpf_gain:
     type: double
     default_value: 0.9
     description: Low-pass filter gain for filtering vehicle and target velocity.
+    read_only: false
 
   hold_velocity_error_until_stop:
     type: bool
     default_value: true
     description: If true, a velocity error is held until the vehicle stops.
+    read_only: false
 
   thresholds:
     max_distance_deviation:
       type: double
       default_value: 1.0
       description: Invalid threshold of the max distance deviation between the predicted path and the reference trajectory [m].
+      read_only: false
     lateral_jerk:
       type: double
       default_value: 10.0
       description: Invalid threshold of the lateral jerk for steering rate validation [m/s^3].
+      read_only: false
     acc_error_offset:
       type: double
       default_value: 0.8
       description: Offset threshold to validate the vehicle acceleration.
+      read_only: false
     acc_error_scale:
       type: double
       default_value: 0.2
       description: Scale threshold to validate the vehicle acceleration.
+      read_only: false
     rolling_back_velocity:
       type: double
       default_value: 0.5
       description: Threshold velocity to validate the vehicle velocity [m/s].
+      read_only: false
     over_velocity_offset:
       type: double
       default_value: 2.0
       description: Threshold velocity offset to validate the vehicle velocity [m/s].
+      read_only: false
     over_velocity_ratio:
       type: double
       default_value: 0.2
       description: Threshold ratio to validate the vehicle velocity.
+      read_only: false
     overrun_stop_point_dist:
       type: double
       default_value: 0.8
       description: Threshold distance to overrun stop point [m].
+      read_only: false
     will_overrun_stop_point_dist:
       type: double
       default_value: 1.0
       description: Threshold distance to predict overrun of the stop point [m].
+      read_only: false
     assumed_limit_acc:
       type: double
       default_value: 5.0
       description: Assumed acceleration for over run estimation [m/s^2].
+      read_only: false
     assumed_delay_time:
       type: double
       default_value: 0.2
       description: Assumed delay for over run estimation [s].
+      read_only: false
     nominal_latency:
       type: double
       default_value: 0.01
       description: Threshold of the control latency [s].
+      read_only: false
     yaw_deviation_error:
       type: double
       default_value: 1.0
       description: Threshold angle to validate the vehicle yaw relative to the nearest trajectory yaw [rad].
+      read_only: false
     yaw_deviation_warn:
       type: double
       default_value: 0.5
       description: Threshold angle to trigger a WARN diagnostic for the vehicle yaw [rad].
+      read_only: false
 
   over_velocity:
     vel_lpf_gain:
       type: double
       default_value: 0.985
       description: Low-pass filter gain for filtering vehicle and target velocity in the over velocity check.
+      read_only: false

--- a/control/autoware_control_validator/param/control_validator_parameters.yaml
+++ b/control/autoware_control_validator/param/control_validator_parameters.yaml
@@ -11,24 +11,6 @@ control_validator:
     type: double
     description: Low-pass filter gain for filtering vehicle and target velocity.
 
-  latency_validator:
-    thresholds:
-      nominal_latency:
-        type: double
-        description: Threshold of the control latency [s].
-
-  trajectory_validator:
-    thresholds:
-      max_distance_deviation:
-        type: double
-        description: Invalid threshold of the max distance deviation between the predicted path and the reference trajectory [m].
-
-  lateral_jerk_validator:
-    thresholds:
-      lateral_jerk:
-        type: double
-        description: Invalid threshold of the lateral jerk for steering rate validation [m/s^3].
-
   acceleration_validator:
     thresholds:
       acc_error_offset:
@@ -40,6 +22,39 @@ control_validator:
     acc_lpf_gain:
       type: double
       description: Low-pass filter gain for the acceleration validator.
+
+  latency_validator:
+    thresholds:
+      nominal_latency:
+        type: double
+        description: Threshold of the control latency [s].
+
+  lateral_jerk_validator:
+    thresholds:
+      lateral_jerk:
+        type: double
+        description: Invalid threshold of the lateral jerk for steering rate validation [m/s^3].
+
+  overrun_validator:
+    thresholds:
+      overrun_stop_point_dist:
+        type: double
+        description: Threshold distance to overrun stop point [m].
+      will_overrun_stop_point_dist:
+        type: double
+        description: Threshold distance to predict overrun of the stop point [m].
+      assumed_limit_acc:
+        type: double
+        description: Assumed acceleration for over run estimation [m/s^2].
+      assumed_delay_time:
+        type: double
+        description: Assumed delay for over run estimation [s].
+
+  trajectory_validator:
+    thresholds:
+      max_distance_deviation:
+        type: double
+        description: Invalid threshold of the max distance deviation between the predicted path and the reference trajectory [m].
 
   velocity_validator: # previously over_velocity
     hold_velocity_error_until_stop:
@@ -58,21 +73,6 @@ control_validator:
     vel_lpf_gain:
       type: double
       description: Low-pass filter gain for filtering vehicle and target velocity in the over velocity check.
-
-  overrun_validator:
-    thresholds:
-      overrun_stop_point_dist:
-        type: double
-        description: Threshold distance to overrun stop point [m].
-      will_overrun_stop_point_dist:
-        type: double
-        description: Threshold distance to predict overrun of the stop point [m].
-      assumed_limit_acc:
-        type: double
-        description: Assumed acceleration for over run estimation [m/s^2].
-      assumed_delay_time:
-        type: double
-        description: Assumed delay for over run estimation [s].
 
   yaw_validator:
     thresholds:

--- a/control/autoware_control_validator/param/control_validator_parameters.yaml
+++ b/control/autoware_control_validator/param/control_validator_parameters.yaml
@@ -12,73 +12,66 @@ control_validator:
     description: Low-pass filter gain for filtering vehicle and target velocity.
 
   acceleration_validator:
+    acc_error_offset:
+      type: double
+      description: Offset threshold to validate the vehicle acceleration.
+    acc_error_scale:
+      type: double
+      description: Scale threshold to validate the vehicle acceleration.
     acc_lpf_gain:
       type: double
       description: Low-pass filter gain for the acceleration validator.
-    thresholds:
-      acc_error_offset:
-        type: double
-        description: Offset threshold to validate the vehicle acceleration.
-      acc_error_scale:
-        type: double
-        description: Scale threshold to validate the vehicle acceleration.
 
   latency_validator:
-    thresholds:
-      nominal_latency:
-        type: double
-        description: Threshold of the control latency [s].
+    nominal_latency:
+      type: double
+      description: Threshold of the control latency [s].
 
   lateral_jerk_validator:
-    thresholds:
-      lateral_jerk:
-        type: double
-        description: Invalid threshold of the lateral jerk for steering rate validation [m/s^3].
+    lateral_jerk:
+      type: double
+      description: Invalid threshold of the lateral jerk for steering rate validation [m/s^3].
 
   overrun_validator:
-    thresholds:
-      assumed_delay_time:
-        type: double
-        description: Assumed delay for over run estimation [s].
-      assumed_limit_acc:
-        type: double
-        description: Assumed acceleration for over run estimation [m/s^2].
-      overrun_stop_point_dist:
-        type: double
-        description: Threshold distance to overrun stop point [m].
-      will_overrun_stop_point_dist:
-        type: double
-        description: Threshold distance to predict overrun of the stop point [m].
+    assumed_delay_time:
+      type: double
+      description: Assumed delay for over run estimation [s].
+    assumed_limit_acc:
+      type: double
+      description: Assumed acceleration for over run estimation [m/s^2].
+    overrun_stop_point_dist:
+      type: double
+      description: Threshold distance to overrun stop point [m].
+    will_overrun_stop_point_dist:
+      type: double
+      description: Threshold distance to predict overrun of the stop point [m].
 
   trajectory_validator:
-    thresholds:
-      max_distance_deviation:
-        type: double
-        description: Invalid threshold of the max distance deviation between the predicted path and the reference trajectory [m].
+    max_distance_deviation:
+      type: double
+      description: Invalid threshold of the max distance deviation between the predicted path and the reference trajectory [m].
 
   velocity_validator: # previously over_velocity
     hold_velocity_error_until_stop:
       type: bool
       description: If true, a velocity error is held until the vehicle stops.
-    thresholds:
-      over_velocity_offset:
-        type: double
-        description: Threshold velocity offset to validate the vehicle velocity [m/s].
-      over_velocity_ratio:
-        type: double
-        description: Threshold ratio to validate the vehicle velocity.
-      rolling_back_velocity:
-        type: double
-        description: Threshold velocity to validate the vehicle velocity [m/s].
+    over_velocity_offset:
+      type: double
+      description: Threshold velocity offset to validate the vehicle velocity [m/s].
+    over_velocity_ratio:
+      type: double
+      description: Threshold ratio to validate the vehicle velocity.
+    rolling_back_velocity:
+      type: double
+      description: Threshold velocity to validate the vehicle velocity [m/s].
     vel_lpf_gain:
       type: double
       description: Low-pass filter gain for filtering vehicle and target velocity in the over velocity check.
 
   yaw_validator:
-    thresholds:
-      yaw_deviation_error:
-        type: double
-        description: Threshold angle to validate the vehicle yaw relative to the nearest trajectory yaw [rad].
-      yaw_deviation_warn:
-        type: double
-        description: Threshold angle to trigger a WARN diagnostic for the vehicle yaw [rad].
+    yaw_deviation_error:
+      type: double
+      description: Threshold angle to validate the vehicle yaw relative to the nearest trajectory yaw [rad].
+    yaw_deviation_warn:
+      type: double
+      description: Threshold angle to trigger a WARN diagnostic for the vehicle yaw [rad].

--- a/control/autoware_control_validator/param/control_validator_parameters.yaml
+++ b/control/autoware_control_validator/param/control_validator_parameters.yaml
@@ -12,6 +12,9 @@ control_validator:
     description: Low-pass filter gain for filtering vehicle and target velocity.
 
   acceleration_validator:
+    acc_lpf_gain:
+      type: double
+      description: Low-pass filter gain for the acceleration validator.
     thresholds:
       acc_error_offset:
         type: double
@@ -19,9 +22,6 @@ control_validator:
       acc_error_scale:
         type: double
         description: Scale threshold to validate the vehicle acceleration.
-    acc_lpf_gain:
-      type: double
-      description: Low-pass filter gain for the acceleration validator.
 
   latency_validator:
     thresholds:
@@ -37,18 +37,18 @@ control_validator:
 
   overrun_validator:
     thresholds:
+      assumed_delay_time:
+        type: double
+        description: Assumed delay for over run estimation [s].
+      assumed_limit_acc:
+        type: double
+        description: Assumed acceleration for over run estimation [m/s^2].
       overrun_stop_point_dist:
         type: double
         description: Threshold distance to overrun stop point [m].
       will_overrun_stop_point_dist:
         type: double
         description: Threshold distance to predict overrun of the stop point [m].
-      assumed_limit_acc:
-        type: double
-        description: Assumed acceleration for over run estimation [m/s^2].
-      assumed_delay_time:
-        type: double
-        description: Assumed delay for over run estimation [s].
 
   trajectory_validator:
     thresholds:

--- a/control/autoware_control_validator/param/control_validator_parameters.yaml
+++ b/control/autoware_control_validator/param/control_validator_parameters.yaml
@@ -1,109 +1,84 @@
 control_validator:
   diag_error_count_threshold:
     type: int
-    default_value: 0
     description: If the number of consecutive invalid predicted_path exceeds this threshold, the Diag will be set to ERROR.
-    read_only: false
 
   display_on_terminal:
     type: bool
-    default_value: false
     description: Show error message on terminal.
-    read_only: false
-
-  acc_lpf_gain:
-    type: double
-    default_value: 0.97
-    description: Low-pass filter gain for the acceleration validator.
-    read_only: false
 
   vel_lpf_gain:
     type: double
-    default_value: 0.9
     description: Low-pass filter gain for filtering vehicle and target velocity.
-    read_only: false
 
-  hold_velocity_error_until_stop:
-    type: bool
-    default_value: true
-    description: If true, a velocity error is held until the vehicle stops.
-    read_only: false
+  latency_validator:
+    thresholds:
+      nominal_latency:
+        type: double
+        description: Threshold of the control latency [s].
 
-  thresholds:
-    max_distance_deviation:
-      type: double
-      default_value: 1.0
-      description: Invalid threshold of the max distance deviation between the predicted path and the reference trajectory [m].
-      read_only: false
-    lateral_jerk:
-      type: double
-      default_value: 10.0
-      description: Invalid threshold of the lateral jerk for steering rate validation [m/s^3].
-      read_only: false
-    acc_error_offset:
-      type: double
-      default_value: 0.8
-      description: Offset threshold to validate the vehicle acceleration.
-      read_only: false
-    acc_error_scale:
-      type: double
-      default_value: 0.2
-      description: Scale threshold to validate the vehicle acceleration.
-      read_only: false
-    rolling_back_velocity:
-      type: double
-      default_value: 0.5
-      description: Threshold velocity to validate the vehicle velocity [m/s].
-      read_only: false
-    over_velocity_offset:
-      type: double
-      default_value: 2.0
-      description: Threshold velocity offset to validate the vehicle velocity [m/s].
-      read_only: false
-    over_velocity_ratio:
-      type: double
-      default_value: 0.2
-      description: Threshold ratio to validate the vehicle velocity.
-      read_only: false
-    overrun_stop_point_dist:
-      type: double
-      default_value: 0.8
-      description: Threshold distance to overrun stop point [m].
-      read_only: false
-    will_overrun_stop_point_dist:
-      type: double
-      default_value: 1.0
-      description: Threshold distance to predict overrun of the stop point [m].
-      read_only: false
-    assumed_limit_acc:
-      type: double
-      default_value: 5.0
-      description: Assumed acceleration for over run estimation [m/s^2].
-      read_only: false
-    assumed_delay_time:
-      type: double
-      default_value: 0.2
-      description: Assumed delay for over run estimation [s].
-      read_only: false
-    nominal_latency:
-      type: double
-      default_value: 0.01
-      description: Threshold of the control latency [s].
-      read_only: false
-    yaw_deviation_error:
-      type: double
-      default_value: 1.0
-      description: Threshold angle to validate the vehicle yaw relative to the nearest trajectory yaw [rad].
-      read_only: false
-    yaw_deviation_warn:
-      type: double
-      default_value: 0.5
-      description: Threshold angle to trigger a WARN diagnostic for the vehicle yaw [rad].
-      read_only: false
+  trajectory_validator:
+    thresholds:
+      max_distance_deviation:
+        type: double
+        description: Invalid threshold of the max distance deviation between the predicted path and the reference trajectory [m].
 
-  over_velocity:
+  lateral_jerk_validator:
+    thresholds:
+      lateral_jerk:
+        type: double
+        description: Invalid threshold of the lateral jerk for steering rate validation [m/s^3].
+
+  acceleration_validator:
+    thresholds:
+      acc_error_offset:
+        type: double
+        description: Offset threshold to validate the vehicle acceleration.
+      acc_error_scale:
+        type: double
+        description: Scale threshold to validate the vehicle acceleration.
+    acc_lpf_gain:
+      type: double
+      description: Low-pass filter gain for the acceleration validator.
+
+  velocity_validator: # previously over_velocity
+    hold_velocity_error_until_stop:
+      type: bool
+      description: If true, a velocity error is held until the vehicle stops.
+    thresholds:
+      over_velocity_offset:
+        type: double
+        description: Threshold velocity offset to validate the vehicle velocity [m/s].
+      over_velocity_ratio:
+        type: double
+        description: Threshold ratio to validate the vehicle velocity.
+      rolling_back_velocity:
+        type: double
+        description: Threshold velocity to validate the vehicle velocity [m/s].
     vel_lpf_gain:
       type: double
-      default_value: 0.985
       description: Low-pass filter gain for filtering vehicle and target velocity in the over velocity check.
-      read_only: false
+
+  overrun_validator:
+    thresholds:
+      overrun_stop_point_dist:
+        type: double
+        description: Threshold distance to overrun stop point [m].
+      will_overrun_stop_point_dist:
+        type: double
+        description: Threshold distance to predict overrun of the stop point [m].
+      assumed_limit_acc:
+        type: double
+        description: Assumed acceleration for over run estimation [m/s^2].
+      assumed_delay_time:
+        type: double
+        description: Assumed delay for over run estimation [s].
+
+  yaw_validator:
+    thresholds:
+      yaw_deviation_error:
+        type: double
+        description: Threshold angle to validate the vehicle yaw relative to the nearest trajectory yaw [rad].
+      yaw_deviation_warn:
+        type: double
+        description: Threshold angle to trigger a WARN diagnostic for the vehicle yaw [rad].

--- a/control/autoware_control_validator/src/control_validator.cpp
+++ b/control/autoware_control_validator/src/control_validator.cpp
@@ -408,6 +408,20 @@ void ControlValidator::on_control_cmd(const Control::ConstSharedPtr msg)
 {
   stop_watch.tic();
 
+  // refresh parameters if they were updated at runtime
+  if (param_listener_.is_old(params_)) {
+    params_ = param_listener_.get_params();
+    diag_error_count_threshold_ = params_.diag_error_count_threshold;
+    display_on_terminal_ = params_.display_on_terminal;
+    latency_validator.update_parameters(params_);
+    lateral_jerk_validator.update_parameters(params_);
+    trajectory_validator.update_parameters(params_);
+    acceleration_validator.update_parameters(params_);
+    velocity_validator.update_parameters(params_);
+    overrun_validator.update_parameters(params_);
+    yaw_validator.update_parameters(params_);
+  }
+
   // prepare ros topics
   const auto waiting = [this](const auto topic_name) {
     RCLCPP_INFO_SKIPFIRST_THROTTLE(get_logger(), *get_clock(), 5000, "waiting for %s", topic_name);

--- a/control/autoware_control_validator/src/control_validator.cpp
+++ b/control/autoware_control_validator/src/control_validator.cpp
@@ -244,7 +244,17 @@ void YawValidator::validate(
 }
 
 ControlValidator::ControlValidator(const rclcpp::NodeOptions & options)
-: Node("control_validator", options), vehicle_info_()
+: Node("control_validator", options),
+  param_listener_(get_node_parameters_interface()),
+  params_(param_listener_.get_params()),
+  vehicle_info_(),
+  latency_validator(params_),
+  lateral_jerk_validator(get_logger(), params_),
+  trajectory_validator(params_),
+  acceleration_validator(params_),
+  velocity_validator(params_),
+  overrun_validator(params_),
+  yaw_validator(params_)
 {
   using std::placeholders::_1;
 
@@ -284,8 +294,8 @@ ControlValidator::ControlValidator(const rclcpp::NodeOptions & options)
 
 void ControlValidator::setup_parameters()
 {
-  diag_error_count_threshold_ = declare_parameter<int64_t>("diag_error_count_threshold");
-  display_on_terminal_ = declare_parameter<bool>("display_on_terminal");
+  diag_error_count_threshold_ = params_.diag_error_count_threshold;
+  display_on_terminal_ = params_.display_on_terminal;
 
   try {
     vehicle_info_ = autoware::vehicle_info_utils::VehicleInfoUtils(*this).getVehicleInfo();

--- a/control/autoware_control_validator/src/control_validator.cpp
+++ b/control/autoware_control_validator/src/control_validator.cpp
@@ -38,7 +38,7 @@ void LatencyValidator::validate(
   ControlValidatorStatus & res, const Control & control_cmd, rclcpp::Node & node) const
 {
   res.latency = (node.now() - control_cmd.stamp).seconds();
-  res.is_valid_latency = res.latency < latency_validator_params_.nominal_latency;
+  res.is_valid_latency = res.latency < params_.nominal_latency;
 }
 
 void TrajectoryValidator::validate(

--- a/control/autoware_control_validator/src/control_validator.cpp
+++ b/control/autoware_control_validator/src/control_validator.cpp
@@ -38,8 +38,7 @@ void LatencyValidator::validate(
   ControlValidatorStatus & res, const Control & control_cmd, rclcpp::Node & node) const
 {
   res.latency = (node.now() - control_cmd.stamp).seconds();
-  const double nominal_latency_threshold = latency_validator_params_.thresholds.nominal_latency;
-  res.is_valid_latency = res.latency < nominal_latency_threshold;
+  res.is_valid_latency = res.latency < latency_validator_params_.nominal_latency;
 }
 
 void TrajectoryValidator::validate(
@@ -48,9 +47,7 @@ void TrajectoryValidator::validate(
 {
   // First, check with the current reference_trajectory
   double max_dist_current = calc_max_lateral_distance(reference_trajectory, predicted_trajectory);
-  const double max_distance_deviation_threshold =
-    trajectory_validator_params_.thresholds.max_distance_deviation;
-  bool is_valid_current = max_dist_current <= max_distance_deviation_threshold;
+  bool is_valid_current = max_dist_current <= params_.max_distance_deviation;
 
   // Note: The reason for comparing with the previous reference_trajectory is that
   // the predicted_trajectory of the current cycle may not have been generated based on
@@ -62,7 +59,7 @@ void TrajectoryValidator::validate(
   if (!is_valid_current && prev_reference_trajectory_.has_value()) {
     max_dist_prev =
       calc_max_lateral_distance(prev_reference_trajectory_.value(), predicted_trajectory);
-    is_valid_prev = max_dist_prev <= max_distance_deviation_threshold;
+    is_valid_prev = max_dist_prev <= params_.max_distance_deviation;
   }
 
   // Only if both exceed the threshold, it is judged as abnormal
@@ -120,11 +117,10 @@ void LateralJerkValidator::validate(
   res.steering_rate = steering_rate;
   res.lateral_jerk = lateral_jerk;
   // Note: Assuming left-right symmetry, only considering the magnitude of jerk
-  const double lateral_jerk_threshold = lateral_jerk_validator_params_.thresholds.lateral_jerk;
-  res.is_valid_lateral_jerk = std::abs(lateral_jerk) < lateral_jerk_threshold;
+  res.is_valid_lateral_jerk = std::abs(lateral_jerk) < params_.lateral_jerk;
   if (!res.is_valid_lateral_jerk) {
     RCLCPP_DEBUG(
-      logger_, "Lateral jerk is too high. %f > %f", std::abs(lateral_jerk), lateral_jerk_threshold);
+      logger_, "Lateral jerk is too high. %f > %f", std::abs(lateral_jerk), params_.lateral_jerk);
     RCLCPP_DEBUG(
       logger_, "steering_cmd: %f, prev_steering_cmd: %f, dt: %f", steering_cmd,
       prev_control_cmd_->lateral.steering_tire_angle, dt);
@@ -155,11 +151,8 @@ bool AccelerationValidator::is_in_error_range() const
   const double des = desired_acc_lpf.getValue().value();
   const double mes = measured_acc_lpf.getValue().value();
 
-  const double e_scale = acceleration_validator_params_.thresholds.acc_error_scale;
-  const double e_offset = acceleration_validator_params_.thresholds.acc_error_offset;
-
-  return mes <= des + std::abs(e_scale * des) + e_offset &&
-         mes >= des - std::abs(e_scale * des) - e_offset;
+  return mes <= des + std::abs(params_.acc_error_scale * des) + params_.acc_error_offset &&
+         mes >= des - std::abs(params_.acc_error_scale * des) - params_.acc_error_offset;
 }
 
 void VelocityValidator::validate(
@@ -173,14 +166,9 @@ void VelocityValidator::validate(
 
   const bool is_stopped = std::abs(v_vel) < 0.05;
 
-  const double rolling_back_velocity_th =
-    velocity_validator_params_.thresholds.rolling_back_velocity;
-  const bool hold_velocity_error_until_stop =
-    velocity_validator_params_.hold_velocity_error_until_stop;
-
   const bool is_rolling_back =
-    std::signbit(v_vel * t_vel) && std::abs(v_vel) > rolling_back_velocity_th;
-  if (!hold_velocity_error_until_stop || !res.is_rolling_back || is_stopped) {
+    std::signbit(v_vel * t_vel) && std::abs(v_vel) > params_.rolling_back_velocity;
+  if (!params_.hold_velocity_error_until_stop || !res.is_rolling_back || is_stopped) {
     res.is_rolling_back = is_rolling_back;
   }
 
@@ -190,12 +178,11 @@ void VelocityValidator::validate(
     autoware::motion_utils::calcInterpolatedPoint(reference_trajectory, kinematics.pose.pose)
       .longitudinal_velocity_mps);
 
-  const double over_velocity_ratio_th = velocity_validator_params_.thresholds.over_velocity_ratio;
-  const double over_velocity_offset_th = velocity_validator_params_.thresholds.over_velocity_offset;
   const bool is_over_velocity =
     std::abs(over_velocity_v_vel) >
-    std::abs(over_velocity_t_vel) * (1.0 + over_velocity_ratio_th) + over_velocity_offset_th;
-  if (!hold_velocity_error_until_stop || !res.is_over_velocity || is_stopped) {
+    std::abs(over_velocity_t_vel) * (1.0 + params_.over_velocity_ratio) +
+      params_.over_velocity_offset;
+  if (!params_.hold_velocity_error_until_stop || !res.is_over_velocity || is_stopped) {
     res.is_over_velocity = is_over_velocity;
   }
 
@@ -228,10 +215,8 @@ void OverrunValidator::validate(
   contained in the trajectory.
   */
   const double v_vel = vehicle_vel_lpf.filter(kinematics.twist.twist.linear.x);
-  const double assumed_delay_time = overrun_validator_params_.thresholds.assumed_delay_time;
-  const double assumed_limit_acc = overrun_validator_params_.thresholds.assumed_limit_acc;
-  res.pred_dist_to_stop =
-    res.dist_to_stop - v_vel * assumed_delay_time - v_vel * v_vel / (2.0 * assumed_limit_acc);
+  res.pred_dist_to_stop = res.dist_to_stop - v_vel * params_.assumed_delay_time -
+                          v_vel * v_vel / (2.0 * params_.assumed_limit_acc);
 
   // NOTE: the same velocity threshold as autoware::motion_utils::searchZeroVelocity
   if (v_vel < 1e-3) {
@@ -239,13 +224,9 @@ void OverrunValidator::validate(
     res.will_overrun_stop_point = false;
     return;
   }
-  const double overrun_stop_point_dist_th =
-    overrun_validator_params_.thresholds.overrun_stop_point_dist;
-  const double will_overrun_stop_point_dist_th =
-    overrun_validator_params_.thresholds.will_overrun_stop_point_dist;
   res.has_overrun_stop_point =
-    res.dist_to_stop < -overrun_stop_point_dist_th && res.nearest_trajectory_vel < 1e-3;
-  res.will_overrun_stop_point = res.pred_dist_to_stop < -will_overrun_stop_point_dist_th;
+    res.dist_to_stop < -params_.overrun_stop_point_dist && res.nearest_trajectory_vel < 1e-3;
+  res.will_overrun_stop_point = res.pred_dist_to_stop < -params_.will_overrun_stop_point_dist;
 }
 
 void YawValidator::validate(
@@ -258,10 +239,8 @@ void YawValidator::validate(
     angles::shortest_angular_distance(
       tf2::getYaw(interpolated_trajectory_point.pose.orientation),
       tf2::getYaw(kinematics.pose.pose.orientation)));
-  const double yaw_deviation_error_th = yaw_validator_params_.thresholds.yaw_deviation_error;
-  const double yaw_deviation_warn_th = yaw_validator_params_.thresholds.yaw_deviation_warn;
-  res.is_valid_yaw = res.yaw_deviation <= yaw_deviation_error_th;
-  res.is_warn_yaw = res.yaw_deviation > yaw_deviation_warn_th;
+  res.is_valid_yaw = res.yaw_deviation <= params_.yaw_deviation_error;
+  res.is_warn_yaw = res.yaw_deviation > params_.yaw_deviation_warn;
 }
 
 ControlValidator::ControlValidator(const rclcpp::NodeOptions & options)

--- a/control/autoware_control_validator/src/control_validator.cpp
+++ b/control/autoware_control_validator/src/control_validator.cpp
@@ -38,6 +38,7 @@ void LatencyValidator::validate(
   ControlValidatorStatus & res, const Control & control_cmd, rclcpp::Node & node) const
 {
   res.latency = (node.now() - control_cmd.stamp).seconds();
+  const double nominal_latency_threshold = latency_validator_params_.thresholds.nominal_latency;
   res.is_valid_latency = res.latency < nominal_latency_threshold;
 }
 
@@ -47,6 +48,8 @@ void TrajectoryValidator::validate(
 {
   // First, check with the current reference_trajectory
   double max_dist_current = calc_max_lateral_distance(reference_trajectory, predicted_trajectory);
+  const double max_distance_deviation_threshold =
+    trajectory_validator_params_.thresholds.max_distance_deviation;
   bool is_valid_current = max_dist_current <= max_distance_deviation_threshold;
 
   // Note: The reason for comparing with the previous reference_trajectory is that
@@ -117,11 +120,11 @@ void LateralJerkValidator::validate(
   res.steering_rate = steering_rate;
   res.lateral_jerk = lateral_jerk;
   // Note: Assuming left-right symmetry, only considering the magnitude of jerk
-  res.is_valid_lateral_jerk = std::abs(lateral_jerk) < lateral_jerk_threshold_;
+  const double lateral_jerk_threshold = lateral_jerk_validator_params_.thresholds.lateral_jerk;
+  res.is_valid_lateral_jerk = std::abs(lateral_jerk) < lateral_jerk_threshold;
   if (!res.is_valid_lateral_jerk) {
     RCLCPP_DEBUG(
-      logger_, "Lateral jerk is too high. %f > %f", std::abs(lateral_jerk),
-      lateral_jerk_threshold_);
+      logger_, "Lateral jerk is too high. %f > %f", std::abs(lateral_jerk), lateral_jerk_threshold);
     RCLCPP_DEBUG(
       logger_, "steering_cmd: %f, prev_steering_cmd: %f, dt: %f", steering_cmd,
       prev_control_cmd_->lateral.steering_tire_angle, dt);
@@ -152,6 +155,9 @@ bool AccelerationValidator::is_in_error_range() const
   const double des = desired_acc_lpf.getValue().value();
   const double mes = measured_acc_lpf.getValue().value();
 
+  const double e_scale = acceleration_validator_params_.thresholds.acc_error_scale;
+  const double e_offset = acceleration_validator_params_.thresholds.acc_error_offset;
+
   return mes <= des + std::abs(e_scale * des) + e_offset &&
          mes >= des - std::abs(e_scale * des) - e_offset;
 }
@@ -167,6 +173,11 @@ void VelocityValidator::validate(
 
   const bool is_stopped = std::abs(v_vel) < 0.05;
 
+  const double rolling_back_velocity_th =
+    velocity_validator_params_.thresholds.rolling_back_velocity;
+  const bool hold_velocity_error_until_stop =
+    velocity_validator_params_.hold_velocity_error_until_stop;
+
   const bool is_rolling_back =
     std::signbit(v_vel * t_vel) && std::abs(v_vel) > rolling_back_velocity_th;
   if (!hold_velocity_error_until_stop || !res.is_rolling_back || is_stopped) {
@@ -179,6 +190,8 @@ void VelocityValidator::validate(
     autoware::motion_utils::calcInterpolatedPoint(reference_trajectory, kinematics.pose.pose)
       .longitudinal_velocity_mps);
 
+  const double over_velocity_ratio_th = velocity_validator_params_.thresholds.over_velocity_ratio;
+  const double over_velocity_offset_th = velocity_validator_params_.thresholds.over_velocity_offset;
   const bool is_over_velocity =
     std::abs(over_velocity_v_vel) >
     std::abs(over_velocity_t_vel) * (1.0 + over_velocity_ratio_th) + over_velocity_offset_th;
@@ -215,6 +228,8 @@ void OverrunValidator::validate(
   contained in the trajectory.
   */
   const double v_vel = vehicle_vel_lpf.filter(kinematics.twist.twist.linear.x);
+  const double assumed_delay_time = overrun_validator_params_.thresholds.assumed_delay_time;
+  const double assumed_limit_acc = overrun_validator_params_.thresholds.assumed_limit_acc;
   res.pred_dist_to_stop =
     res.dist_to_stop - v_vel * assumed_delay_time - v_vel * v_vel / (2.0 * assumed_limit_acc);
 
@@ -224,6 +239,10 @@ void OverrunValidator::validate(
     res.will_overrun_stop_point = false;
     return;
   }
+  const double overrun_stop_point_dist_th =
+    overrun_validator_params_.thresholds.overrun_stop_point_dist;
+  const double will_overrun_stop_point_dist_th =
+    overrun_validator_params_.thresholds.will_overrun_stop_point_dist;
   res.has_overrun_stop_point =
     res.dist_to_stop < -overrun_stop_point_dist_th && res.nearest_trajectory_vel < 1e-3;
   res.will_overrun_stop_point = res.pred_dist_to_stop < -will_overrun_stop_point_dist_th;
@@ -239,8 +258,10 @@ void YawValidator::validate(
     angles::shortest_angular_distance(
       tf2::getYaw(interpolated_trajectory_point.pose.orientation),
       tf2::getYaw(kinematics.pose.pose.orientation)));
-  res.is_valid_yaw = res.yaw_deviation <= yaw_deviation_error_th_;
-  res.is_warn_yaw = res.yaw_deviation > yaw_deviation_warn_th_;
+  const double yaw_deviation_error_th = yaw_validator_params_.thresholds.yaw_deviation_error;
+  const double yaw_deviation_warn_th = yaw_validator_params_.thresholds.yaw_deviation_warn;
+  res.is_valid_yaw = res.yaw_deviation <= yaw_deviation_error_th;
+  res.is_warn_yaw = res.yaw_deviation > yaw_deviation_warn_th;
 }
 
 ControlValidator::ControlValidator(const rclcpp::NodeOptions & options)

--- a/control/autoware_control_validator/test/test_control_validator.cpp
+++ b/control/autoware_control_validator/test/test_control_validator.cpp
@@ -100,7 +100,8 @@ protected:
          "/config/test_vehicle_info.param.yaml"});
 
     node_ = std::make_shared<ControlValidator>(options);
-    trajectory_validator_ = std::make_shared<TrajectoryValidator>(*node_);
+    ::control_validator::ParamListener param_listener(node_->get_node_parameters_interface());
+    trajectory_validator_ = std::make_shared<TrajectoryValidator>(param_listener.get_params());
   }
   void TearDown() override { rclcpp::shutdown(); }
 
@@ -203,7 +204,8 @@ protected:
          "/config/test_vehicle_info.param.yaml"});
 
     node_ = std::make_shared<ControlValidator>(options);
-    acceleration_validator_ = std::make_shared<AccelerationValidator>(*node_);
+    ::control_validator::ParamListener param_listener(node_->get_node_parameters_interface());
+    acceleration_validator_ = std::make_shared<AccelerationValidator>(param_listener.get_params());
   }
   void TearDown() override { rclcpp::shutdown(); }
 


### PR DESCRIPTION
## Description

Migrates `autoware_control_validator`'s parameter handling to `generate_parameter_library`.

- Replaced the imperative `declare_parameter` / `get_or_declare_parameter` calls with a typed `generate_parameter_library` schema (`param/control_validator_parameters.yaml`, namespace `::control_validator`), matching the in-repo pattern used by `autoware_shift_decider` and `autoware_trajectory_validator`.
- Each validator (`LatencyValidator`, `TrajectoryValidator`, `LateralJerkValidator`, `AccelerationValidator`, `VelocityValidator`, `OverrunValidator`, `YawValidator`) now takes the typed `Params` struct instead of `rclcpp::Node &`.
- Added live parameter reconfigure: every validator exposes `update_parameters(const Params &)`, and `on_control_cmd` refreshes them via `param_listener_.is_old(params_)`. Previously parameters were read once at startup and could not be changed at runtime.
- ROS parameter names and the config file layout are unchanged, so the validation logic itself is behavior-preserving.

## Related links

**Parent Issue:**

- Link

## How was this PR tested?

- `colcon` build of `autoware_control_validator` passes.
- Package unit tests pass (`100% tests passed, 0 tests failed out of 5`). The existing `TrajectoryValidator` / `AccelerationValidator` suites keep their expectations, confirming the migration is behavior-preserving.

## Notes for reviewers

- The generated parameter header is included as `<autoware_control_validator/control_validator_parameters.hpp>` and the target uses `-Wno-error=deprecated-declarations` (same as `autoware_trajectory_validator`) because `parameter_traits`, pulled in transitively by any generated header, references a deprecated symbol.
- The generated namespace is referenced with a leading `::` (`::control_validator::`) to avoid clashing with the `autoware::control_validator` package namespace.
- All parameters are declared `read_only: false` (kept mutable/live-reconfigurable).

## Interface changes

None.

## Effects on system behavior

- Parameters can now be changed at runtime (live reconfigure); previously they were fixed at node startup. Validation logic is otherwise unchanged.
