### PR TITLE
docs(yabloc_pose_initializer): fix output topic name in README.md

### DIFF
--- a/localization/yabloc/yabloc_pose_initializer/README.md
+++ b/localization/yabloc/yabloc_pose_initializer/README.md
@@ -53,9 +53,9 @@ Converted model URL
 
 #### Output
 
-| Name                     | Type                                   | Description             |
-| ------------------------ | -------------------------------------- | ----------------------- |
-| `debug/init_candidates`  | `visualization_msgs::msg::MarkerArray` | initial pose candidates |
+| Name                    | Type                                   | Description             |
+| ----------------------- | -------------------------------------- | ----------------------- |
+| `debug/init_candidates` | `visualization_msgs::msg::MarkerArray` | initial pose candidates |
 
 ### Parameters
 

--- a/localization/yabloc/yabloc_pose_initializer/README.md
+++ b/localization/yabloc/yabloc_pose_initializer/README.md
@@ -53,9 +53,9 @@ Converted model URL
 
 #### Output
 
-| Name                | Type                                   | Description             |
-| ------------------- | -------------------------------------- | ----------------------- |
-| `output/candidates` | `visualization_msgs::msg::MarkerArray` | initial pose candidates |
+| Name                     | Type                                   | Description             |
+| ------------------------ | -------------------------------------- | ----------------------- |
+| `debug/init_candidates`  | `visualization_msgs::msg::MarkerArray` | initial pose candidates |
 
 ### Parameters
 


### PR DESCRIPTION
## Description

Fixed the output topic name in README.md. 

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware_universe/issues/13025

## How was this PR tested?

Test is not necessary. This PR only changed the README.md

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
