### PR TITLE
refactor(autoware_traffic_light_classifier): declare classifier params in the node

### DIFF
--- a/perception/autoware_traffic_light_classifier/CMakeLists.txt
+++ b/perception/autoware_traffic_light_classifier/CMakeLists.txt
@@ -57,6 +57,7 @@ if(TRT_AVAIL AND CUDA_AVAIL)
   )
 
   ament_auto_add_library(${PROJECT_NAME} SHARED
+    src/classifier_params.cpp
     src/classifier/color_classifier.cpp
     src/classifier/cnn_classifier.cpp
     src/classifier/cnn_lamp_recognizer.cpp
@@ -79,6 +80,7 @@ if(TRT_AVAIL AND CUDA_AVAIL)
   )
 
   ament_auto_add_library(single_image_debug_inference_node SHARED
+    src/classifier_params.cpp
     src/classifier/cnn_classifier.cpp
     src/classifier/color_classifier.cpp
     src/classifier/cnn_lamp_recognizer.cpp
@@ -111,6 +113,7 @@ else()
   )
 
   ament_auto_add_library(${PROJECT_NAME} SHARED
+    src/classifier_params.cpp
     src/classifier/color_classifier.cpp
     src/traffic_light_classifier.cpp
     src/traffic_light_classifier_node.cpp

--- a/perception/autoware_traffic_light_classifier/src/classifier/cnn_classifier.cpp
+++ b/perception/autoware_traffic_light_classifier/src/classifier/cnn_classifier.cpp
@@ -22,7 +22,6 @@
 #include <boost/algorithm/string/split.hpp>
 
 #include <algorithm>
-#include <fstream>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -152,54 +151,10 @@ cv::Mat CNNClassifierCore::make_debug_image(
 }
 
 // ============================== CNNClassifier ==============================
-// ROS adapter: declares parameters, reads the label file, publishes debug images, and
-// delegates classification to the Node-free core.
+// ROS adapter: publishes debug images, logs, and delegates classification to the Node-free core.
 
-namespace
-{
-// Read the label file into a vector of lines. Logs and throws std::runtime_error if the
-// file cannot be opened, so a misconfigured path fails node construction fast rather than
-// leaving the classifier with an empty label table (which would be an out-of-range
-// lookup at inference time).
-std::vector<std::string> read_label_file(rclcpp::Node * node, const std::string & filepath)
-{
-  std::ifstream labels_file(filepath);
-  if (!labels_file.is_open()) {
-    RCLCPP_ERROR(node->get_logger(), "Could not open label file. [%s]", filepath.c_str());
-    throw std::runtime_error("Could not open label file: " + filepath);
-  }
-  std::vector<std::string> labels;
-  std::string label;
-  while (std::getline(labels_file, label)) {
-    labels.push_back(label);
-  }
-  return labels;
-}
-
-// Declare the CNN parameters on `node`, read the label file, and return the resulting
-// config. ROS params cannot load std::vector<float>, so mean/std are declared as
-// std::vector<double> and narrowed here -- keeping that quirk in the adapter so the core
-// sees plain std::vector<float>.
-CNNConfig declare_cnn_config(rclcpp::Node * node)
-{
-  const std::string precision = node->declare_parameter<std::string>("precision");
-  const std::string label_path = node->declare_parameter<std::string>("label_path");
-  const std::string model_path = node->declare_parameter<std::string>("model_path");
-  const auto mean_d = node->declare_parameter<std::vector<double>>("mean");
-  const auto std_d = node->declare_parameter<std::vector<double>>("std");
-
-  CNNConfig config;
-  config.model_path = model_path;
-  config.precision = precision;
-  config.labels = read_label_file(node, label_path);
-  config.mean = std::vector<float>(mean_d.begin(), mean_d.end());
-  config.std = std::vector<float>(std_d.begin(), std_d.end());
-  return config;
-}
-}  // namespace
-
-CNNClassifier::CNNClassifier(rclcpp::Node * node_ptr)
-: node_ptr_(node_ptr), core_(declare_cnn_config(node_ptr))
+CNNClassifier::CNNClassifier(rclcpp::Node * node_ptr, const CNNConfig & config)
+: node_ptr_(node_ptr), core_(config)
 {
   image_pub_ = image_transport::create_publisher(
     node_ptr_, "~/output/debug/image", rclcpp::QoS{1}.get_rmw_qos_profile());

--- a/perception/autoware_traffic_light_classifier/src/classifier/cnn_classifier.hpp
+++ b/perception/autoware_traffic_light_classifier/src/classifier/cnn_classifier.hpp
@@ -96,7 +96,7 @@ private:
 class CNNClassifier : public ClassifierInterface
 {
 public:
-  explicit CNNClassifier(rclcpp::Node * node_ptr);
+  CNNClassifier(rclcpp::Node * node_ptr, const CNNConfig & config);
   virtual ~CNNClassifier() = default;
 
   bool getTrafficSignals(

--- a/perception/autoware_traffic_light_classifier/src/classifier/cnn_lamp_recognizer.cpp
+++ b/perception/autoware_traffic_light_classifier/src/classifier/cnn_lamp_recognizer.cpp
@@ -543,52 +543,11 @@ cv::Mat CnnLampRecognizerCore::make_debug_image(
 }
 
 // ============================== CnnLampRecognizer ==============================
-// ROS adapter: declares parameters, publishes debug images, and delegates recognition to the
-// Node-free core.
+// ROS adapter: publishes debug images, logs, and delegates recognition to the Node-free core.
 
-namespace
-{
-// Declare the lamp recognizer parameters on `node` and return the config. Anchors are narrowed
-// double->float here (a ROS quirk); config-data invariants live in the core ctor, not here.
-CnnLampRecognizerConfig declare_lamp_config(rclcpp::Node * node)
-{
-  CnnLampRecognizerConfig config;
-  config.model_path = node->declare_parameter<std::string>("model_path");
-  config.precision = node->declare_parameter<std::string>("precision");
-  config.score_threshold = static_cast<float>(node->declare_parameter<double>("score_threshold"));
-  config.nms_threshold = static_cast<float>(node->declare_parameter<double>("nms_threshold"));
-  config.max_batch_size = node->declare_parameter<int>("max_batch_size");
-
-  auto & model_params = config.model_params;
-  model_params.num_anchors = node->declare_parameter<int>("model_params.num_anchors");
-  model_params.chans_per_anchor = node->declare_parameter<int>("model_params.chans_per_anchor");
-  model_params.x_index = node->declare_parameter<int>("model_params.x_index");
-  model_params.y_index = node->declare_parameter<int>("model_params.y_index");
-  model_params.w_index = node->declare_parameter<int>("model_params.w_index");
-  model_params.h_index = node->declare_parameter<int>("model_params.h_index");
-  model_params.obj_index = node->declare_parameter<int>("model_params.obj_index");
-  model_params.color_start = node->declare_parameter<int>("model_params.color_start");
-  model_params.type_start = node->declare_parameter<int>("model_params.type_start");
-  model_params.num_types = node->declare_parameter<int>("model_params.num_types");
-  model_params.num_colors = node->declare_parameter<int>("model_params.num_colors");
-  model_params.cos_index = node->declare_parameter<int>("model_params.cos_index");
-  model_params.sin_index = node->declare_parameter<int>("model_params.sin_index");
-  model_params.scale_x_y =
-    static_cast<float>(node->declare_parameter<double>("model_params.scale_x_y"));
-
-  const auto anchors_param = node->declare_parameter<std::vector<double>>("model_params.anchors");
-  model_params.anchors.clear();
-  model_params.anchors.reserve(anchors_param.size());
-  for (double v : anchors_param) {
-    model_params.anchors.push_back(static_cast<float>(v));
-  }
-
-  return config;
-}
-}  // namespace
-
-CnnLampRecognizer::CnnLampRecognizer(rclcpp::Node * node_ptr)
-: node_ptr_(node_ptr), core_(declare_lamp_config(node_ptr))
+CnnLampRecognizer::CnnLampRecognizer(
+  rclcpp::Node * node_ptr, const CnnLampRecognizerConfig & config)
+: node_ptr_(node_ptr), core_(config)
 {
   image_pub_ = image_transport::create_publisher(
     node_ptr_, "~/output/debug/image", rclcpp::QoS{1}.get_rmw_qos_profile());

--- a/perception/autoware_traffic_light_classifier/src/classifier/cnn_lamp_recognizer.hpp
+++ b/perception/autoware_traffic_light_classifier/src/classifier/cnn_lamp_recognizer.hpp
@@ -200,7 +200,7 @@ private:
 class CnnLampRecognizer : public ClassifierInterface
 {
 public:
-  explicit CnnLampRecognizer(rclcpp::Node * node_ptr);
+  CnnLampRecognizer(rclcpp::Node * node_ptr, const CnnLampRecognizerConfig & config);
   ~CnnLampRecognizer() override = default;
 
   bool getTrafficSignals(

--- a/perception/autoware_traffic_light_classifier/src/classifier/color_classifier.cpp
+++ b/perception/autoware_traffic_light_classifier/src/classifier/color_classifier.cpp
@@ -221,8 +221,8 @@ cv::Mat ColorClassifierCore::make_debug_image(const cv::Mat & roi_image) const
 }
 
 // ============================== ColorClassifier ==============================
-// ROS adapter: declares parameters, wires dynamic reconfigure and debug-image
-// publishing, and delegates classification to the Node-free core.
+// ROS adapter: wires dynamic reconfigure and debug-image publishing, and delegates
+// classification to the Node-free core.
 
 namespace
 {
@@ -238,37 +238,10 @@ bool update_param(
   }
   return false;
 }
-
-// Declare the 18 HSV threshold parameters on `node`, seeding each from the HSVConfig
-// defaults, and return the resulting config. Lets the constructor build the core's
-// thresholds in a single pass instead of default-constructing then reconfiguring.
-HSVConfig declare_hsv_config(rclcpp::Node * node)
-{
-  HSVConfig config;
-  config.green_min_h = node->declare_parameter("green_min_h", config.green_min_h);
-  config.green_min_s = node->declare_parameter("green_min_s", config.green_min_s);
-  config.green_min_v = node->declare_parameter("green_min_v", config.green_min_v);
-  config.green_max_h = node->declare_parameter("green_max_h", config.green_max_h);
-  config.green_max_s = node->declare_parameter("green_max_s", config.green_max_s);
-  config.green_max_v = node->declare_parameter("green_max_v", config.green_max_v);
-  config.yellow_min_h = node->declare_parameter("yellow_min_h", config.yellow_min_h);
-  config.yellow_min_s = node->declare_parameter("yellow_min_s", config.yellow_min_s);
-  config.yellow_min_v = node->declare_parameter("yellow_min_v", config.yellow_min_v);
-  config.yellow_max_h = node->declare_parameter("yellow_max_h", config.yellow_max_h);
-  config.yellow_max_s = node->declare_parameter("yellow_max_s", config.yellow_max_s);
-  config.yellow_max_v = node->declare_parameter("yellow_max_v", config.yellow_max_v);
-  config.red_min_h = node->declare_parameter("red_min_h", config.red_min_h);
-  config.red_min_s = node->declare_parameter("red_min_s", config.red_min_s);
-  config.red_min_v = node->declare_parameter("red_min_v", config.red_min_v);
-  config.red_max_h = node->declare_parameter("red_max_h", config.red_max_h);
-  config.red_max_s = node->declare_parameter("red_max_s", config.red_max_s);
-  config.red_max_v = node->declare_parameter("red_max_v", config.red_max_v);
-  return config;
-}
 }  // namespace
 
-ColorClassifier::ColorClassifier(rclcpp::Node * node_ptr)
-: node_ptr_(node_ptr), core_(declare_hsv_config(node_ptr))
+ColorClassifier::ColorClassifier(rclcpp::Node * node_ptr, const HSVConfig & config)
+: node_ptr_(node_ptr), core_(config)
 {
   using std::placeholders::_1;
   image_pub_ = image_transport::create_publisher(

--- a/perception/autoware_traffic_light_classifier/src/classifier/color_classifier.hpp
+++ b/perception/autoware_traffic_light_classifier/src/classifier/color_classifier.hpp
@@ -146,7 +146,7 @@ private:
 class ColorClassifier : public ClassifierInterface
 {
 public:
-  explicit ColorClassifier(rclcpp::Node * node_ptr);
+  ColorClassifier(rclcpp::Node * node_ptr, const HSVConfig & config);
   virtual ~ColorClassifier() = default;
 
   bool getTrafficSignals(

--- a/perception/autoware_traffic_light_classifier/src/classifier_params.cpp
+++ b/perception/autoware_traffic_light_classifier/src/classifier_params.cpp
@@ -1,0 +1,125 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "classifier_params.hpp"
+
+#if ENABLE_GPU
+#include <fstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+#endif
+
+namespace autoware::traffic_light
+{
+HSVConfig declare_hsv_config(rclcpp::Node * node)
+{
+  HSVConfig config;
+  config.green_min_h = node->declare_parameter("green_min_h", config.green_min_h);
+  config.green_min_s = node->declare_parameter("green_min_s", config.green_min_s);
+  config.green_min_v = node->declare_parameter("green_min_v", config.green_min_v);
+  config.green_max_h = node->declare_parameter("green_max_h", config.green_max_h);
+  config.green_max_s = node->declare_parameter("green_max_s", config.green_max_s);
+  config.green_max_v = node->declare_parameter("green_max_v", config.green_max_v);
+  config.yellow_min_h = node->declare_parameter("yellow_min_h", config.yellow_min_h);
+  config.yellow_min_s = node->declare_parameter("yellow_min_s", config.yellow_min_s);
+  config.yellow_min_v = node->declare_parameter("yellow_min_v", config.yellow_min_v);
+  config.yellow_max_h = node->declare_parameter("yellow_max_h", config.yellow_max_h);
+  config.yellow_max_s = node->declare_parameter("yellow_max_s", config.yellow_max_s);
+  config.yellow_max_v = node->declare_parameter("yellow_max_v", config.yellow_max_v);
+  config.red_min_h = node->declare_parameter("red_min_h", config.red_min_h);
+  config.red_min_s = node->declare_parameter("red_min_s", config.red_min_s);
+  config.red_min_v = node->declare_parameter("red_min_v", config.red_min_v);
+  config.red_max_h = node->declare_parameter("red_max_h", config.red_max_h);
+  config.red_max_s = node->declare_parameter("red_max_s", config.red_max_s);
+  config.red_max_v = node->declare_parameter("red_max_v", config.red_max_v);
+  return config;
+}
+
+#if ENABLE_GPU
+namespace
+{
+// Read the label file into a vector of lines. Logs and throws std::runtime_error if the file
+// cannot be opened, so a misconfigured path fails node construction fast rather than leaving the
+// classifier with an empty label table (which would be an out-of-range lookup at inference time).
+std::vector<std::string> read_label_file(rclcpp::Node * node, const std::string & filepath)
+{
+  std::ifstream labels_file(filepath);
+  if (!labels_file.is_open()) {
+    RCLCPP_ERROR(node->get_logger(), "Could not open label file. [%s]", filepath.c_str());
+    throw std::runtime_error("Could not open label file: " + filepath);
+  }
+  std::vector<std::string> labels;
+  std::string label;
+  while (std::getline(labels_file, label)) {
+    labels.push_back(label);
+  }
+  return labels;
+}
+}  // namespace
+
+CNNConfig declare_cnn_config(rclcpp::Node * node)
+{
+  const std::string precision = node->declare_parameter<std::string>("precision");
+  const std::string label_path = node->declare_parameter<std::string>("label_path");
+  const std::string model_path = node->declare_parameter<std::string>("model_path");
+  const auto mean_d = node->declare_parameter<std::vector<double>>("mean");
+  const auto std_d = node->declare_parameter<std::vector<double>>("std");
+
+  CNNConfig config;
+  config.model_path = model_path;
+  config.precision = precision;
+  config.labels = read_label_file(node, label_path);
+  config.mean = std::vector<float>(mean_d.begin(), mean_d.end());
+  config.std = std::vector<float>(std_d.begin(), std_d.end());
+  return config;
+}
+
+CnnLampRecognizerConfig declare_lamp_config(rclcpp::Node * node)
+{
+  CnnLampRecognizerConfig config;
+  config.model_path = node->declare_parameter<std::string>("model_path");
+  config.precision = node->declare_parameter<std::string>("precision");
+  config.score_threshold = static_cast<float>(node->declare_parameter<double>("score_threshold"));
+  config.nms_threshold = static_cast<float>(node->declare_parameter<double>("nms_threshold"));
+  config.max_batch_size = node->declare_parameter<int>("max_batch_size");
+
+  auto & model_params = config.model_params;
+  model_params.num_anchors = node->declare_parameter<int>("model_params.num_anchors");
+  model_params.chans_per_anchor = node->declare_parameter<int>("model_params.chans_per_anchor");
+  model_params.x_index = node->declare_parameter<int>("model_params.x_index");
+  model_params.y_index = node->declare_parameter<int>("model_params.y_index");
+  model_params.w_index = node->declare_parameter<int>("model_params.w_index");
+  model_params.h_index = node->declare_parameter<int>("model_params.h_index");
+  model_params.obj_index = node->declare_parameter<int>("model_params.obj_index");
+  model_params.color_start = node->declare_parameter<int>("model_params.color_start");
+  model_params.type_start = node->declare_parameter<int>("model_params.type_start");
+  model_params.num_types = node->declare_parameter<int>("model_params.num_types");
+  model_params.num_colors = node->declare_parameter<int>("model_params.num_colors");
+  model_params.cos_index = node->declare_parameter<int>("model_params.cos_index");
+  model_params.sin_index = node->declare_parameter<int>("model_params.sin_index");
+  model_params.scale_x_y =
+    static_cast<float>(node->declare_parameter<double>("model_params.scale_x_y"));
+
+  const auto anchors_param = node->declare_parameter<std::vector<double>>("model_params.anchors");
+  model_params.anchors.clear();
+  model_params.anchors.reserve(anchors_param.size());
+  for (double v : anchors_param) {
+    model_params.anchors.push_back(static_cast<float>(v));
+  }
+
+  return config;
+}
+#endif
+}  // namespace autoware::traffic_light

--- a/perception/autoware_traffic_light_classifier/src/classifier_params.hpp
+++ b/perception/autoware_traffic_light_classifier/src/classifier_params.hpp
@@ -1,0 +1,50 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CLASSIFIER_PARAMS_HPP_
+#define CLASSIFIER_PARAMS_HPP_
+
+// Node-side helpers that declare the classifier parameters on a node and return the plain config
+// structs the (ROS-free) classifier cores consume. Lives at the node layer, not under classifier/,
+// because declaring parameters is a Node concern; the cores themselves never touch rclcpp.
+
+#include "classifier/color_classifier.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+
+#if ENABLE_GPU
+#include "classifier/cnn_classifier.hpp"
+#include "classifier/cnn_lamp_recognizer.hpp"
+#endif
+
+namespace autoware::traffic_light
+{
+// Declare the 18 HSV threshold parameters on `node`, seeding each from the HSVConfig defaults, and
+// return the resulting config.
+HSVConfig declare_hsv_config(rclcpp::Node * node);
+
+#if ENABLE_GPU
+// Declare the CNN parameters on `node`, read the label file, and return the config. ROS params
+// cannot load std::vector<float>, so mean/std are declared as std::vector<double> and narrowed
+// here.
+CNNConfig declare_cnn_config(rclcpp::Node * node);
+
+// Declare the lamp recognizer parameters on `node` and return the config. The anchors and the
+// float scalars (score / nms thresholds, scale_x_y) are narrowed double->float here (a ROS
+// quirk); config-data invariants live in the core ctor, not here.
+CnnLampRecognizerConfig declare_lamp_config(rclcpp::Node * node);
+#endif
+}  // namespace autoware::traffic_light
+
+#endif  // CLASSIFIER_PARAMS_HPP_

--- a/perception/autoware_traffic_light_classifier/src/single_image_debug_inference_node.cpp
+++ b/perception/autoware_traffic_light_classifier/src/single_image_debug_inference_node.cpp
@@ -19,6 +19,7 @@
 #endif
 
 #include "classifier/color_classifier.hpp"
+#include "classifier_params.hpp"
 #include "traffic_light_classifier_node.hpp"
 
 #include <memory>
@@ -74,10 +75,10 @@ public:
       "classifier_type",
       static_cast<int>(TrafficLightClassifierNodelet::ClassifierType::HSVFilter));
     if (classifier_type == TrafficLightClassifierNodelet::ClassifierType::HSVFilter) {
-      classifier_ptr_ = std::make_unique<ColorClassifier>(this);
+      classifier_ptr_ = std::make_unique<ColorClassifier>(this, declare_hsv_config(this));
     } else if (classifier_type == TrafficLightClassifierNodelet::ClassifierType::CNN) {
 #if ENABLE_GPU
-      classifier_ptr_ = std::make_unique<CNNClassifier>(this);
+      classifier_ptr_ = std::make_unique<CNNClassifier>(this, declare_cnn_config(this));
 #else
       RCLCPP_ERROR(get_logger(), "please install CUDA, and TensorRT to use cnn classifier");
 #endif

--- a/perception/autoware_traffic_light_classifier/src/traffic_light_classifier_node.cpp
+++ b/perception/autoware_traffic_light_classifier/src/traffic_light_classifier_node.cpp
@@ -13,6 +13,8 @@
 // limitations under the License.
 #include "traffic_light_classifier_node.hpp"
 
+#include "classifier_params.hpp"
+
 #include <diagnostic_msgs/msg/diagnostic_status.hpp>
 #include <tier4_perception_msgs/msg/traffic_light_element.hpp>
 
@@ -53,16 +55,16 @@ TrafficLightClassifierNodelet::TrafficLightClassifierNodelet(const rclcpp::NodeO
   int classifier_type = this->declare_parameter<int>("classifier_type");
   std::shared_ptr<ClassifierInterface> classifier_ptr;
   if (classifier_type == TrafficLightClassifierNodelet::ClassifierType::HSVFilter) {
-    classifier_ptr = std::make_shared<ColorClassifier>(this);
+    classifier_ptr = std::make_shared<ColorClassifier>(this, declare_hsv_config(this));
   } else if (classifier_type == TrafficLightClassifierNodelet::ClassifierType::CNN) {
 #if ENABLE_GPU
-    classifier_ptr = std::make_shared<CNNClassifier>(this);
+    classifier_ptr = std::make_shared<CNNClassifier>(this, declare_cnn_config(this));
 #else
     RCLCPP_ERROR(this->get_logger(), "please install CUDA, and TensorRT to use cnn classifier");
 #endif
   } else if (classifier_type == TrafficLightClassifierNodelet::ClassifierType::LampRecognizer) {
 #if ENABLE_GPU
-    classifier_ptr = std::make_shared<CnnLampRecognizer>(this);
+    classifier_ptr = std::make_shared<CnnLampRecognizer>(this, declare_lamp_config(this));
 #else
     RCLCPP_ERROR(
       this->get_logger(), "please install CUDA, CUDNN and TensorRT to use LampRecognizer");

--- a/perception/autoware_traffic_light_classifier/test/test_cnn_classifier_adapter.cpp
+++ b/perception/autoware_traffic_light_classifier/test/test_cnn_classifier_adapter.cpp
@@ -30,6 +30,7 @@
 //
 
 #include "../src/classifier/cnn_classifier.hpp"
+#include "../src/classifier_params.hpp"
 
 #include <autoware/cuda_utils/cuda_gtest_utils.hpp>
 #include <opencv2/core.hpp>
@@ -116,7 +117,8 @@ protected:
     // "environment unavailable" -> skip (not fail), with a reason the test reports.
     try {
       node_ = std::make_shared<rclcpp::Node>("cnn_classifier_adapter_test", options);
-      classifier_ = std::make_shared<tl::CNNClassifier>(node_.get());
+      classifier_ =
+        std::make_shared<tl::CNNClassifier>(node_.get(), tl::declare_cnn_config(node_.get()));
     } catch (const std::exception & e) {
       skip_reason_ = std::string("CNNClassifier environment unavailable: ") + e.what();
       classifier_.reset();

--- a/perception/autoware_traffic_light_classifier/test/test_cnn_lamp_recognizer_adapter.cpp
+++ b/perception/autoware_traffic_light_classifier/test/test_cnn_lamp_recognizer_adapter.cpp
@@ -36,6 +36,7 @@
 //
 
 #include "../src/classifier/cnn_lamp_recognizer.hpp"
+#include "../src/classifier_params.hpp"
 
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <autoware/cuda_utils/cuda_gtest_utils.hpp>
@@ -166,7 +167,8 @@ protected:
     // GTEST_SKIP.
     try {
       node_ = std::make_shared<rclcpp::Node>("cnn_lamp_recognizer_adapter_test", options);
-      recognizer_ = std::make_shared<tl::CnnLampRecognizer>(node_.get());
+      recognizer_ =
+        std::make_shared<tl::CnnLampRecognizer>(node_.get(), tl::declare_lamp_config(node_.get()));
     } catch (const std::exception & e) {
       skip_reason_ = std::string("CnnLampRecognizer environment unavailable: ") + e.what();
       recognizer_.reset();

--- a/perception/autoware_traffic_light_classifier/test/test_color_classifier_adapter.cpp
+++ b/perception/autoware_traffic_light_classifier/test/test_color_classifier_adapter.cpp
@@ -24,6 +24,7 @@
 //
 
 #include "../src/classifier/color_classifier.hpp"
+#include "../src/classifier_params.hpp"
 
 #include <opencv2/core.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -46,7 +47,7 @@ TEST(ColorClassifierAdapterTest, MismatchedSizesReturnFalse)
 {
   // Arrange
   auto node = std::make_shared<rclcpp::Node>("color_classifier_adapter_test");
-  tl::ColorClassifier classifier(node.get());
+  tl::ColorClassifier classifier(node.get(), tl::declare_hsv_config(node.get()));
   const std::vector<cv::Mat> images{cv::Mat(4, 4, CV_8UC3, cv::Scalar(0, 0, 0))};
   TrafficLightArray signals;
   signals.signals.resize(2);  // two signals but one image -- the deliberate count mismatch


### PR DESCRIPTION
## Description

First step of an incremental, by-concern campaign to remove the ROS Node dependency from the three traffic-light classifier implementations (`ColorClassifier`, `CNNClassifier`, `CnnLampRecognizer`). Each classifier already has a Node-free `…Core`; the remaining ROS coupling lives in the thin adapters, which take an `rclcpp::Node *` to declare parameters, publish debug images, log, and (Color only) register dynamic reconfigure.

This PR moves **parameter declaration** out of the classifier files:

- New node-side translation unit `src/classifier_params.{hpp,cpp}` holding `declare_hsv_config`,
  `declare_cnn_config` (+ `read_label_file`), and `declare_lamp_config`, moved verbatim from the
  adapter anonymous namespaces (the CNN/lamp helpers are `#if ENABLE_GPU`-guarded so the non-GPU,
  color-only library build still compiles). It is the only classifier-side file that includes
  `rclcpp`.
- It lives at the node layer (`src/`, next to `traffic_light_classifier_node.cpp`) rather than
  under `src/classifier/`, because declaring parameters is a Node concern and both consumers
  (`traffic_light_classifier_node` and `single_image_debug_inference_node`) are Node classes.
- Each adapter constructor changes from `(rclcpp::Node *)` to `(rclcpp::Node *, const Config &)`;
  the node builds the config via `declare_*_config(this)` and passes it in. The classifier files no
  longer call `declare_parameter` or read the label file.

No behavior change: the same parameters are declared with the same names, defaults, and types.

## Related links

None.

## How was this PR tested?

`colcon build` and `colcon test` for `autoware_traffic_light_classifier` on a GPU environment: 83 tests, 0 failures, 0 skipped. The existing ROS-isolated adapter tests were updated to build the adapter via `(node, declare_*_config(node))`, so parameter declaration is still exercised end to end.

## Notes for reviewers

This is the first of a small series of by-concern PRs that progressively remove the Node dependency from the classifier layer (parameters → debug image → logging/reconfigure → adapter collapse). It is intentionally minimal: only parameter declaration moves here.

## Interface changes

None. (No ROS topics or parameters are added, removed, or renamed; only the C++ constructor signatures of the internal classifier adapters change.)

## Effects on system behavior

None.
