### PR TITLE
fix(autoware_traffic_light_compliance_checker): avoid reading uninitialized Parameters

### DIFF
--- a/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/structs.hpp
+++ b/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/structs.hpp
@@ -87,31 +87,31 @@ struct ComplianceResult
 /// @brief parameters for traffic light signal status tracking
 struct StatusTrackerParameters
 {
-  double stable_duration_threshold_red;
-  double stable_duration_threshold_amber;
-  double stable_duration_threshold_unknown;
+  double stable_duration_threshold_red{0.0};
+  double stable_duration_threshold_amber{0.0};
+  double stable_duration_threshold_unknown{0.0};
 };
 
 /// @brief parameters for traffic light compliance check
 struct Parameters
 {
-  double deceleration_limit;
-  double jerk_limit;
-  double delay_response_time;
-  double crossing_time_limit;
-  bool treat_amber_light_as_red_light;
-  bool treat_unknown_light_as_red_light;
-  double stop_overshoot_margin;
-  double allow_if_cannot_stop_distance;
-  double stable_duration_threshold_red;
-  double stable_duration_threshold_amber;
-  double stable_duration_threshold_unknown;
-  double amber_rejection_hysteresis_duration;
-  double ego_stopped_velocity_threshold;
+  double deceleration_limit{2.8};
+  double jerk_limit{5.0};
+  double delay_response_time{0.5};
+  double crossing_time_limit{2.75};
+  bool treat_amber_light_as_red_light{false};
+  bool treat_unknown_light_as_red_light{false};
+  double stop_overshoot_margin{0.5};
+  double allow_if_cannot_stop_distance{0.0};
+  double stable_duration_threshold_red{0.0};
+  double stable_duration_threshold_amber{0.0};
+  double stable_duration_threshold_unknown{0.0};
+  double amber_rejection_hysteresis_duration{0.0};
+  double ego_stopped_velocity_threshold{0.01};
   struct CheckedTrajectoryLength
   {
-    double deceleration_limit;
-    double jerk_limit;
+    double deceleration_limit{2.0};
+    double jerk_limit{2.0};
   } checked_trajectory_length;
 };
 

--- a/planning/autoware_trajectory_processor/config/trajectory_modifier.param.yaml
+++ b/planning/autoware_trajectory_processor/config/trajectory_modifier.param.yaml
@@ -138,5 +138,8 @@
       allow_if_cannot_stop_distance: 0.0 # [m]
       th_stable_duration_red: 0.2 # [s]
       th_stable_duration_amber: 0.2 # [s]
+      th_stable_duration_unknown: 0.0 # [s]
       th_amber_rejection_hysteresis: 0.5 # [s]
       crossing_time_limit: 2.75 # [s]
+      delay_response_time: 0.5 # [s]
+      ego_stopped_vel_th: 0.01 # [m/s]

--- a/planning/autoware_trajectory_processor/docs/TrafficLightStop.md
+++ b/planning/autoware_trajectory_processor/docs/TrafficLightStop.md
@@ -82,5 +82,8 @@ The module parameters are grouped under `traffic_light_stop` section of `traject
 | `allow_if_cannot_stop_distance` | double | 0.0     | [m] Allow crossing when the ego front is within this distance and ego cannot stop before the stop line.           |
 | `th_stable_duration_red`        | double | 0.2     | [s] Minimum duration a RED light must be seen before it is considered active (only when ego is moving).           |
 | `th_stable_duration_amber`      | double | 0.2     | [s] Minimum duration an AMBER light must be seen before it is considered active (only when ego is moving).        |
+| `th_stable_duration_unknown`    | double | 0.0     | [s] Minimum duration an UNKNOWN light must be seen before it is considered active (only when ego is moving).      |
 | `th_amber_rejection_hysteresis` | double | 0.5     | [s] Duration to persist an amber rejection state to prevent "flipping" due to minor velocity/distance changes.    |
 | `crossing_time_limit`           | double | 2.75    | [s] Maximum time allowed for the ego vehicle to cross the stop line after an amber light appears.                 |
+| `delay_response_time`           | double | 0.5     | [s] Delay response time used to estimate the minimum ego stopping distance.                                       |
+| `ego_stopped_vel_th`            | double | 0.01    | [m/s] Velocity below which ego is considered stopped when checking traffic lights.                                |

--- a/planning/autoware_trajectory_processor/param/trajectory_modifier_parameter_struct.yaml
+++ b/planning/autoware_trajectory_processor/param/trajectory_modifier_parameter_struct.yaml
@@ -500,6 +500,13 @@ trajectory_modifier_params:
       validation:
         bounds<>: [0.0, 10.0]
       read_only: false
+    th_stable_duration_unknown:
+      type: double
+      default_value: 0.0
+      description: Threshold for stable duration of unknown light [s]
+      validation:
+        bounds<>: [0.0, 10.0]
+      read_only: false
     th_amber_rejection_hysteresis:
       type: double
       default_value: 0.5
@@ -511,6 +518,20 @@ trajectory_modifier_params:
       type: double
       default_value: 2.75
       description: Crossing time limit [s]
+      validation:
+        bounds<>: [0.0, 10.0]
+      read_only: false
+    delay_response_time:
+      type: double
+      default_value: 0.5
+      description: Delay response time used to estimate the minimum ego stopping distance [s]
+      validation:
+        bounds<>: [0.0, 10.0]
+      read_only: false
+    ego_stopped_vel_th:
+      type: double
+      default_value: 0.01
+      description: Velocity below which ego is considered stopped when checking traffic lights [m/s]
       validation:
         bounds<>: [0.0, 10.0]
       read_only: false

--- a/planning/autoware_trajectory_processor/schema/trajectory_modifier.schema.json
+++ b/planning/autoware_trajectory_processor/schema/trajectory_modifier.schema.json
@@ -574,6 +574,12 @@
               "default": 0.2,
               "minimum": 0.0
             },
+            "th_stable_duration_unknown": {
+              "type": "number",
+              "description": "Threshold for stable duration of unknown light [s]",
+              "default": 0.0,
+              "minimum": 0.0
+            },
             "th_amber_rejection_hysteresis": {
               "type": "number",
               "description": "Threshold for amber rejection hysteresis [s]",
@@ -584,6 +590,18 @@
               "type": "number",
               "description": "Crossing time limit [s]",
               "default": 2.75,
+              "minimum": 0.0
+            },
+            "delay_response_time": {
+              "type": "number",
+              "description": "Delay response time used to estimate the minimum ego stopping distance [s]",
+              "default": 0.5,
+              "minimum": 0.0
+            },
+            "ego_stopped_vel_th": {
+              "type": "number",
+              "description": "Velocity below which ego is considered stopped when checking traffic lights [m/s]",
+              "default": 0.01,
               "minimum": 0.0
             }
           },

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/traffic_light_stop.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/traffic_light_stop.cpp
@@ -38,7 +38,10 @@ autoware::traffic_light_compliance_checker::Parameters to_checker_params(
   p.allow_if_cannot_stop_distance = tl_stop_p.allow_if_cannot_stop_distance;
   p.stable_duration_threshold_red = tl_stop_p.th_stable_duration_red;
   p.stable_duration_threshold_amber = tl_stop_p.th_stable_duration_amber;
+  p.stable_duration_threshold_unknown = tl_stop_p.th_stable_duration_unknown;
   p.amber_rejection_hysteresis_duration = tl_stop_p.th_amber_rejection_hysteresis;
+  p.delay_response_time = tl_stop_p.delay_response_time;
+  p.ego_stopped_velocity_threshold = tl_stop_p.ego_stopped_vel_th;
   p.checked_trajectory_length.deceleration_limit = stopping_params.nominal_deceleration;
   p.checked_trajectory_length.jerk_limit = stopping_params.jerk_limit;
   return p;


### PR DESCRIPTION
## Description

`traffic_light_compliance_checker::Parameters` has plain `double`/`bool` members with no default initializers. `autoware_trajectory_processor`'s `to_checker_params()` builds this struct with `Parameters p;` (no value-initialization) and never sets three members: `delay_response_time`, `ego_stopped_velocity_threshold`, and `stable_duration_threshold_unknown`. They are therefore read while holding indeterminate values (undefined behavior).

This surfaced as nondeterministic (flaky) failures of `autoware_trajectory_processor`'s `TrafficLightStopIntegrationTest.TrajectoryModifiedWithAmberLightAsRedLight` / `...WithUnknownLightAsRedLight` in the `build-and-test-*-above` jobs: when the garbage `ego_stopped_velocity_threshold` happens to exceed the ego speed, the trajectory scan (`traffic_light_compliance_checker.cpp`) breaks at the first point and never reaches the stop line, so no violation is produced and `modify_trajectory()` returns `false`.

This PR fixes it in two ways:
- **Root cause:** give every `traffic_light_compliance_checker::Parameters` / `StatusTrackerParameters` member a default initializer, so no consumer can read uninitialized values.
- **Plumbing:** map the three missing parameters in `to_checker_params()` and expose them as `autoware_trajectory_processor` parameters (`delay_response_time`, `ego_stopped_vel_th`, `th_stable_duration_unknown`) with defaults matching `autoware_trajectory_validator`.

## Related links

Examples of the resulting flaky CI failures in `autoware_core`'s `build-and-test-diff-*-above` jobs (different subsets fail depending on toolchain/run, which is consistent with the undefined behavior):

- https://github.com/autowarefoundation/autoware_core/actions/runs/29887949508/job/88827938915 (humble-above: both `...AmberLightAsRedLight` and `...UnknownLightAsRedLight` fail)
- https://github.com/autowarefoundation/autoware_core/actions/runs/29541390401/job/87780070955 (jazzy-above: `...UnknownLightAsRedLight` fails)

## How was this PR tested?

Built `autoware_traffic_light_compliance_checker` and `autoware_trajectory_processor` and ran the package tests. All 201 tests pass, including the previously-flaky `TrafficLightStopIntegrationTest.TrajectoryModifiedWithAmberLightAsRedLight` and `...WithUnknownLightAsRedLight`.

## Notes for reviewers

Default values were chosen to match the equivalent parameters already used by `autoware_trajectory_validator` (`delay_response_time: 0.5`, `ego_stopped_velocity_threshold: 0.01`, `stable_duration_threshold_unknown: 0.0`).

## Interface changes

Adds three parameters under `traffic_light_stop` in `autoware_trajectory_processor` (`th_stable_duration_unknown`, `delay_response_time`, `ego_stopped_vel_th`), all with backward-compatible defaults.

## Effects on system behavior

The three checker parameters are now deterministic instead of reading indeterminate memory; behavior is well-defined and matches the intended defaults.