### PR TITLE
refactor(autoware_traffic_light_classifier): move debug-image publishing to the node

### DIFF
--- a/perception/autoware_traffic_light_classifier/src/classifier/classifier_interface.hpp
+++ b/perception/autoware_traffic_light_classifier/src/classifier/classifier_interface.hpp
@@ -29,8 +29,12 @@ class ClassifierInterface
 public:
   virtual ~ClassifierInterface() = default;
   virtual bool getTrafficSignals(
-    const std::vector<cv::Mat> & input_image,
+    const std::vector<cv::Mat> & images,
     tier4_perception_msgs::msg::TrafficLightArray & traffic_signals) = 0;
+
+  // One composite RGB debug view for the batch, rendered from the most recent getTrafficSignals
+  // call. Returns an empty Mat when there is nothing to show.
+  virtual cv::Mat make_debug_image(const std::vector<cv::Mat> & images) const = 0;
 };
 }  // namespace autoware::traffic_light
 

--- a/perception/autoware_traffic_light_classifier/src/classifier/cnn_classifier.cpp
+++ b/perception/autoware_traffic_light_classifier/src/classifier/cnn_classifier.cpp
@@ -151,13 +151,11 @@ cv::Mat CNNClassifierCore::make_debug_image(
 }
 
 // ============================== CNNClassifier ==============================
-// ROS adapter: publishes debug images, logs, and delegates classification to the Node-free core.
+// ROS adapter: logs and delegates classification and debug-image rendering to the Node-free core.
 
 CNNClassifier::CNNClassifier(rclcpp::Node * node_ptr, const CNNConfig & config)
 : node_ptr_(node_ptr), core_(config)
 {
-  image_pub_ = image_transport::create_publisher(
-    node_ptr_, "~/output/debug/image", rclcpp::QoS{1}.get_rmw_qos_profile());
 }
 
 bool CNNClassifier::getTrafficSignals(
@@ -175,18 +173,6 @@ bool CNNClassifier::getTrafficSignals(
     return false;
   }
 
-  // Publish one debug image per ROI only when a debug consumer is attached.
-  if (0 < image_pub_.getNumSubscribers()) {
-    for (size_t i = 0; i < images.size(); i++) {
-      const auto debug_image_msg =
-        cv_bridge::CvImage(
-          std_msgs::msg::Header(), "rgb8",
-          CNNClassifierCore::make_debug_image(images[i], result.signals.signals[i]))
-          .toImageMsg();
-      image_pub_.publish(debug_image_msg);
-    }
-  }
-
   // Attach the core's per-image elements to the caller's pre-populated signals,
   // preserving the traffic_light_id / traffic_light_type set upstream.
   for (size_t i = 0; i < traffic_signals.signals.size(); i++) {
@@ -195,7 +181,27 @@ bool CNNClassifier::getTrafficSignals(
     elements.insert(elements.end(), classified.begin(), classified.end());
   }
 
+  // Keep the per-image classification so make_debug_image can render it afterwards; the node
+  // owns the debug publisher and requests the image only when a consumer is attached.
+  last_signals_ = result.signals;
+
   return true;
+}
+
+cv::Mat CNNClassifier::make_debug_image(const std::vector<cv::Mat> & images) const
+{
+  // Stack each ROI's debug view (fixed 200 px wide) into one vertical strip.
+  cv::Mat debug_image;
+  const size_t count = std::min(images.size(), last_signals_.signals.size());
+  for (size_t i = 0; i < count; i++) {
+    cv::Mat strip = CNNClassifierCore::make_debug_image(images[i], last_signals_.signals[i]);
+    if (debug_image.empty()) {
+      debug_image = strip;
+    } else {
+      cv::vconcat(debug_image, strip, debug_image);
+    }
+  }
+  return debug_image;
 }
 
 }  // namespace autoware::traffic_light

--- a/perception/autoware_traffic_light_classifier/src/classifier/cnn_classifier.hpp
+++ b/perception/autoware_traffic_light_classifier/src/classifier/cnn_classifier.hpp
@@ -18,19 +18,12 @@
 #include "classifier_interface.hpp"
 
 #include <autoware/tensorrt_classifier/tensorrt_classifier.hpp>
-#include <image_transport/image_transport.hpp>
 #include <opencv2/core/core.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <tier4_perception_msgs/msg/traffic_light.hpp>
 #include <tier4_perception_msgs/msg/traffic_light_array.hpp>
 #include <tier4_perception_msgs/msg/traffic_light_element.hpp>
-
-#if __has_include(<cv_bridge/cv_bridge.hpp>)
-#include <cv_bridge/cv_bridge.hpp>
-#else
-#include <cv_bridge/cv_bridge.h>
-#endif
 
 #include <memory>
 #include <string>
@@ -90,9 +83,8 @@ private:
   int batch_size_ = 0;
 };
 
-// Thin ROS adapter around CNNClassifierCore. Owns the node-facing concerns (parameter
-// declaration, label-file reading, debug-image publishing, logging) and delegates
-// classification to the core. Public API is unchanged.
+// Thin ROS adapter around CNNClassifierCore. Logs, and delegates classification and debug-image
+// rendering to the core.
 class CNNClassifier : public ClassifierInterface
 {
 public:
@@ -103,10 +95,14 @@ public:
     const std::vector<cv::Mat> & images,
     tier4_perception_msgs::msg::TrafficLightArray & traffic_signals) override;
 
+  cv::Mat make_debug_image(const std::vector<cv::Mat> & images) const override;
+
 private:
   rclcpp::Node * node_ptr_;
-  image_transport::Publisher image_pub_;
   CNNClassifierCore core_;
+  // Per-image classification output kept from the most recent getTrafficSignals so
+  // make_debug_image can render the batch afterwards.
+  tier4_perception_msgs::msg::TrafficLightArray last_signals_;
 };
 
 }  // namespace autoware::traffic_light

--- a/perception/autoware_traffic_light_classifier/src/classifier/cnn_lamp_recognizer.cpp
+++ b/perception/autoware_traffic_light_classifier/src/classifier/cnn_lamp_recognizer.cpp
@@ -19,8 +19,6 @@
 
 #include <autoware/cuda_utils/cuda_check_error.hpp>
 
-#include <std_msgs/msg/header.hpp>
-
 #include <algorithm>
 #include <cmath>
 #include <functional>
@@ -543,14 +541,12 @@ cv::Mat CnnLampRecognizerCore::make_debug_image(
 }
 
 // ============================== CnnLampRecognizer ==============================
-// ROS adapter: publishes debug images, logs, and delegates recognition to the Node-free core.
+// ROS adapter: logs and delegates recognition and debug-image rendering to the Node-free core.
 
 CnnLampRecognizer::CnnLampRecognizer(
   rclcpp::Node * node_ptr, const CnnLampRecognizerConfig & config)
 : node_ptr_(node_ptr), core_(config)
 {
-  image_pub_ = image_transport::create_publisher(
-    node_ptr_, "~/output/debug/image", rclcpp::QoS{1}.get_rmw_qos_profile());
 }
 
 bool CnnLampRecognizer::getTrafficSignals(
@@ -575,26 +571,33 @@ bool CnnLampRecognizer::getTrafficSignals(
       result.lamps_per_image[i], traffic_signals.signals[i]);
   }
 
-  if (image_pub_.getNumSubscribers() > 0 && !images.empty()) {
-    // build debug image by vertically concatenating each image's debug view
-    const int strip_width = 200;
-    const int strip_height = 130;
-    cv::Mat debug_img;
-    for (size_t i = 0; i < images.size(); i++) {
-      cv::Mat debug_img_i = CnnLampRecognizerCore::make_debug_image(
-        images[i], traffic_signals.signals[i], &result.lamps_per_image[i]);
-      cv::resize(debug_img_i, debug_img_i, cv::Size(strip_width, strip_height));
-      if (i == 0) {
-        debug_img = debug_img_i;
-      } else {
-        cv::vconcat(debug_img, debug_img_i, debug_img);
-      }
-    }
-    const auto debug_image_msg =
-      cv_bridge::CvImage(std_msgs::msg::Header(), "rgb8", debug_img).toImageMsg();
-    image_pub_.publish(debug_image_msg);
-  }
+  // Keep the per-image output signals and raw detections so make_debug_image can render the batch
+  // afterwards; the node owns the debug publisher and asks only when a consumer is attached.
+  last_signals_ = traffic_signals;
+  last_lamps_ = result.lamps_per_image;
+
   return true;
+}
+
+cv::Mat CnnLampRecognizer::make_debug_image(const std::vector<cv::Mat> & images) const
+{
+  // Vertically concatenate each image's debug view: boxes from the raw detections and a
+  // label / confidence strip from the output signal, each resized to a fixed strip size.
+  const int strip_width = 200;
+  const int strip_height = 130;
+  cv::Mat debug_image;
+  const size_t count = std::min({images.size(), last_signals_.signals.size(), last_lamps_.size()});
+  for (size_t i = 0; i < count; i++) {
+    cv::Mat strip =
+      CnnLampRecognizerCore::make_debug_image(images[i], last_signals_.signals[i], &last_lamps_[i]);
+    cv::resize(strip, strip, cv::Size(strip_width, strip_height));
+    if (debug_image.empty()) {
+      debug_image = strip;
+    } else {
+      cv::vconcat(debug_image, strip, debug_image);
+    }
+  }
+  return debug_image;
 }
 
 }  // namespace autoware::traffic_light

--- a/perception/autoware_traffic_light_classifier/src/classifier/cnn_lamp_recognizer.hpp
+++ b/perception/autoware_traffic_light_classifier/src/classifier/cnn_lamp_recognizer.hpp
@@ -20,20 +20,12 @@
 #include <autoware/cuda_utils/cuda_unique_ptr.hpp>
 #include <autoware/cuda_utils/stream_unique_ptr.hpp>
 #include <autoware/tensorrt_common/tensorrt_common.hpp>
-#include <image_transport/image_transport.hpp>
 #include <opencv2/core/core.hpp>
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/opencv.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <tier4_perception_msgs/msg/traffic_light_element.hpp>
-
-// cppcheck-suppress preprocessorErrorDirective
-#if __has_include(<cv_bridge/cv_bridge.hpp>)
-#include <cv_bridge/cv_bridge.hpp>
-#else
-#include <cv_bridge/cv_bridge.h>
-#endif
 
 #include <memory>
 #include <string>
@@ -194,9 +186,8 @@ private:
   LampRegressionArchitecture model_params_;
 };
 
-// Thin ROS adapter around CnnLampRecognizerCore. Owns the node-facing concerns (parameter
-// declaration, debug-image publishing, logging) and delegates recognition to the core. Public
-// API is unchanged.
+// Thin ROS adapter around CnnLampRecognizerCore. Logs, and delegates recognition and
+// debug-image rendering to the core.
 class CnnLampRecognizer : public ClassifierInterface
 {
 public:
@@ -207,10 +198,16 @@ public:
     const std::vector<cv::Mat> & images,
     tier4_perception_msgs::msg::TrafficLightArray & traffic_signals) override;
 
+  cv::Mat make_debug_image(const std::vector<cv::Mat> & images) const override;
+
 private:
   rclcpp::Node * node_ptr_;
-  image_transport::Publisher image_pub_;
   CnnLampRecognizerCore core_;
+  // Kept from the most recent getTrafficSignals so make_debug_image can render the batch: the
+  // per-image output signals (for the text labels) and the per-image raw detections (for the
+  // bounding boxes).
+  tier4_perception_msgs::msg::TrafficLightArray last_signals_;
+  std::vector<std::vector<LampElement>> last_lamps_;
 };
 
 }  // namespace autoware::traffic_light

--- a/perception/autoware_traffic_light_classifier/src/classifier/color_classifier.cpp
+++ b/perception/autoware_traffic_light_classifier/src/classifier/color_classifier.cpp
@@ -13,6 +13,8 @@
 // limitations under the License.
 #include "color_classifier.hpp"
 
+#include <opencv2/imgproc.hpp>
+
 #include <opencv2/imgproc/imgproc_c.h>
 
 #include <algorithm>
@@ -221,8 +223,8 @@ cv::Mat ColorClassifierCore::make_debug_image(const cv::Mat & roi_image) const
 }
 
 // ============================== ColorClassifier ==============================
-// ROS adapter: wires dynamic reconfigure and debug-image publishing, and delegates
-// classification to the Node-free core.
+// ROS adapter: wires dynamic reconfigure and logging, and delegates classification and
+// debug-image rendering to the Node-free core.
 
 namespace
 {
@@ -244,9 +246,6 @@ ColorClassifier::ColorClassifier(rclcpp::Node * node_ptr, const HSVConfig & conf
 : node_ptr_(node_ptr), core_(config)
 {
   using std::placeholders::_1;
-  image_pub_ = image_transport::create_publisher(
-    node_ptr_, "~/debug/image", rclcpp::QoS{1}.get_rmw_qos_profile());
-
   // set parameter callback
   set_param_res_ = node_ptr_->add_on_set_parameters_callback(
     std::bind(&ColorClassifier::parametersCallback, this, _1));
@@ -263,17 +262,6 @@ bool ColorClassifier::getTrafficSignals(
 
   const ColorClassifierCore::ClassifierResult result = core_.classify(images);
 
-  // Publish one debug mosaic per ROI image only when a debug consumer is attached;
-  // make_debug_image re-runs the HSV pipeline, so it stays off the hot path.
-  if (0 < image_pub_.getNumSubscribers()) {
-    for (const auto & image : images) {
-      const auto debug_image_msg =
-        cv_bridge::CvImage(std_msgs::msg::Header(), "bgr8", core_.make_debug_image(image))
-          .toImageMsg();
-      image_pub_.publish(debug_image_msg);
-    }
-  }
-
   // Attach the core's per-image color elements to the caller's pre-populated
   // signals, preserving the traffic_light_id / traffic_light_type set upstream.
   for (size_t i = 0; i < traffic_signals.signals.size(); i++) {
@@ -286,6 +274,27 @@ bool ColorClassifier::getTrafficSignals(
     RCLCPP_ERROR(node_ptr_->get_logger(), "failed to filter image by hsv value");
   }
   return result.success;
+}
+
+cv::Mat ColorClassifier::make_debug_image(const std::vector<cv::Mat> & images) const
+{
+  // Stack each ROI's mosaic vertically. The core renders RGB-ordered pixels (raw ROI + masks) and
+  // re-runs the HSV pipeline, so this stays off the hot path. Per-ROI mosaics differ in width, so
+  // later ones are scaled to the first's width before stacking.
+  cv::Mat debug_image;
+  for (const auto & image : images) {
+    cv::Mat mosaic = core_.make_debug_image(image);
+    if (!debug_image.empty() && mosaic.cols != debug_image.cols) {
+      cv::resize(
+        mosaic, mosaic, cv::Size(debug_image.cols, mosaic.rows * debug_image.cols / mosaic.cols));
+    }
+    if (debug_image.empty()) {
+      debug_image = mosaic;
+    } else {
+      cv::vconcat(debug_image, mosaic, debug_image);
+    }
+  }
+  return debug_image;
 }
 
 rcl_interfaces::msg::SetParametersResult ColorClassifier::parametersCallback(

--- a/perception/autoware_traffic_light_classifier/src/classifier/color_classifier.hpp
+++ b/perception/autoware_traffic_light_classifier/src/classifier/color_classifier.hpp
@@ -17,18 +17,11 @@
 
 #include "classifier_interface.hpp"
 
-#include <image_transport/image_transport.hpp>
 #include <opencv2/core/core.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <tier4_perception_msgs/msg/traffic_light_array.hpp>
 #include <tier4_perception_msgs/msg/traffic_light_element.hpp>
-
-#if __has_include(<cv_bridge/cv_bridge.hpp>)
-#include <cv_bridge/cv_bridge.hpp>
-#else
-#include <cv_bridge/cv_bridge.h>
-#endif
 
 #include <vector>
 
@@ -140,9 +133,8 @@ private:
   cv::Scalar max_hsv_red_;
 };
 
-// Thin ROS adapter around ColorClassifierCore. Owns the node-facing concerns
-// (parameter declaration, dynamic reconfigure, debug-image publishing, logging)
-// and delegates classification to the core. Public API is unchanged.
+// Thin ROS adapter around ColorClassifierCore. Wires dynamic reconfigure and logging, and
+// delegates classification and debug-image rendering to the core.
 class ColorClassifier : public ClassifierInterface
 {
 public:
@@ -153,11 +145,11 @@ public:
     const std::vector<cv::Mat> & images,
     tier4_perception_msgs::msg::TrafficLightArray & traffic_signals) override;
 
+  cv::Mat make_debug_image(const std::vector<cv::Mat> & images) const override;
+
 private:
   rcl_interfaces::msg::SetParametersResult parametersCallback(
     const std::vector<rclcpp::Parameter> & parameters);
-
-  image_transport::Publisher image_pub_;
 
   rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr set_param_res_;
   rclcpp::Node * node_ptr_;

--- a/perception/autoware_traffic_light_classifier/src/traffic_light_classifier.cpp
+++ b/perception/autoware_traffic_light_classifier/src/traffic_light_classifier.cpp
@@ -83,6 +83,10 @@ std::optional<TrafficLightClassifier::Result> TrafficLightClassifier::classify(
     }
   }
 
+  // Hand the classified crops back to the caller so it can request a debug view later; the debug
+  // image reflects the classifier's view, before the UNKNOWN / exposure post-processing below.
+  result.roi_images = images;
+
   // append the undetected rois as unknown
   for (const auto & input_roi : rois.rois) {
     // if the type is the target type but the roi size is zero, the roi is undetected
@@ -104,6 +108,11 @@ std::optional<TrafficLightClassifier::Result> TrafficLightClassifier::classify(
   }
 
   return result;
+}
+
+cv::Mat TrafficLightClassifier::make_debug_image(const std::vector<cv::Mat> & roi_images) const
+{
+  return classifier_->make_debug_image(roi_images);
 }
 
 }  // namespace autoware::traffic_light

--- a/perception/autoware_traffic_light_classifier/src/traffic_light_classifier.hpp
+++ b/perception/autoware_traffic_light_classifier/src/traffic_light_classifier.hpp
@@ -25,6 +25,7 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <vector>
 
 namespace autoware::traffic_light
 {
@@ -41,6 +42,9 @@ public:
     tier4_perception_msgs::msg::TrafficLightArray signals;
     bool detected_over_exposure = false;
     bool detected_under_exposure = false;
+    // The cropped ROI images fed to the classifier, in classification order (cheap cv::Mat
+    // views). The node passes them back to make_debug_image to render a debug view.
+    std::vector<cv::Mat> roi_images;
   };
 
   TrafficLightClassifier(
@@ -53,6 +57,11 @@ public:
   // backend fails, so the caller can skip publishing.
   std::optional<Result> classify(
     const cv::Mat & image, const tier4_perception_msgs::msg::TrafficLightRoiArray & rois) const;
+
+  // Composite debug view for the most recent classify() call, built from its returned
+  // roi_images. Empty when there is nothing to render. Off the hot path: the node calls this
+  // only when a debug consumer is attached.
+  cv::Mat make_debug_image(const std::vector<cv::Mat> & roi_images) const;
 
 private:
   std::shared_ptr<ClassifierInterface> classifier_;

--- a/perception/autoware_traffic_light_classifier/src/traffic_light_classifier_node.cpp
+++ b/perception/autoware_traffic_light_classifier/src/traffic_light_classifier_node.cpp
@@ -75,6 +75,8 @@ TrafficLightClassifierNodelet::TrafficLightClassifierNodelet(const rclcpp::NodeO
     classifier_ = std::make_unique<TrafficLightClassifier>(
       classifier_ptr, classify_traffic_light_type, over_exposure_threshold,
       under_exposure_threshold);
+    debug_image_pub_ = image_transport::create_publisher(
+      this, "~/output/debug/image", rclcpp::QoS{1}.get_rmw_qos_profile());
   }
 
   diagnostics_interface_ptr_ =
@@ -146,6 +148,17 @@ void TrafficLightClassifierNodelet::imageRoiCallback(
       "Detected out-of-range exposure in ROI. Corresponding ROI was overwritten with UNKNOWN.");
   }
   diagnostics_interface_ptr_->publish(output_msg.header.stamp);
+
+  // Publish the debug view last, and only when a consumer is attached (building it is a cold path),
+  // so a debug-rendering failure cannot skip the primary signal output or diagnostics above.
+  if (debug_image_pub_.getNumSubscribers() > 0) {
+    const cv::Mat debug_image = classifier_->make_debug_image(result->roi_images);
+    if (!debug_image.empty()) {
+      const auto debug_image_msg =
+        cv_bridge::CvImage(std_msgs::msg::Header(), "rgb8", debug_image).toImageMsg();
+      debug_image_pub_.publish(debug_image_msg);
+    }
+  }
 }
 
 }  // namespace autoware::traffic_light

--- a/perception/autoware_traffic_light_classifier/src/traffic_light_classifier_node.hpp
+++ b/perception/autoware_traffic_light_classifier/src/traffic_light_classifier_node.hpp
@@ -91,6 +91,7 @@ private:
   bool is_approximate_sync_;
   rclcpp::Publisher<tier4_perception_msgs::msg::TrafficLightArray>::SharedPtr
     traffic_signal_array_pub_;
+  image_transport::Publisher debug_image_pub_;
   std::unique_ptr<TrafficLightClassifier> classifier_;
 
   std::unique_ptr<autoware_utils::DiagnosticsInterface>

--- a/perception/autoware_traffic_light_classifier/test/test_traffic_light_classifier.cpp
+++ b/perception/autoware_traffic_light_classifier/test/test_traffic_light_classifier.cpp
@@ -89,6 +89,8 @@ public:
 
   int call_count = 0;
   std::vector<cv::Mat> received_images;
+  // Recorded by make_debug_image so a test can confirm the wrapper forwards roi_images here.
+  mutable std::vector<cv::Mat> debug_images_received;
 
   bool getTrafficSignals(
     const std::vector<cv::Mat> & images,
@@ -109,6 +111,13 @@ public:
       signal.elements.push_back(element);
     }
     return true;
+  }
+
+  cv::Mat make_debug_image(const std::vector<cv::Mat> & images) const override
+  {
+    debug_images_received = images;
+    // The row count encodes the batch size so callers can verify what was forwarded.
+    return cv::Mat(static_cast<int>(images.size()), 1, CV_8UC3, cv::Scalar(0, 0, 0));
   }
 };
 
@@ -196,6 +205,41 @@ protected:
 
   std::shared_ptr<FakeClassifier> fake_classifier_;
 };
+
+// --------------------------------------------------------------------------
+// roi_images is the *classified subset* -- the valid, target-type ROIs in
+// classification order -- NOT the input ROIs and NOT the post-processed output
+// signals (which also carry appended-UNKNOWN slots). make_debug_image forwards
+// exactly that subset to the backend. This 1:1 alignment between roi_images[i]
+// and the backend's per-image view is what lets the node render debug crops
+// correctly; if roi_images were ever set to the final signals, debug labels and
+// crops would silently fall out of sync.
+// --------------------------------------------------------------------------
+TEST_F(TrafficLightClassifierTest, RoiImagesAreClassifiedSubsetForwardedToDebug)
+{
+  // Arrange: three ROIs of which only one is classified --
+  //   id=1 valid car      -> classified (the sole entry in roi_images)
+  //   id=2 zero-sized car  -> appended to signals as UNKNOWN, NOT in roi_images
+  //   id=3 pedestrian type -> dropped entirely (in neither)
+  auto classifier = make_classifier(no_over_threshold, no_under_threshold);
+  const auto image = make_solid_image(gray);
+  TrafficLightRoiArray rois;
+  rois.rois.push_back(make_valid_roi(/*id=*/1));
+  rois.rois.push_back(make_zero_sized_roi(/*id=*/2));
+  rois.rois.push_back(make_roi(/*id=*/3, pedestrian_type, 0, 0, 16, 16));
+
+  // Act
+  const auto result = classifier.classify(image, rois);
+  ASSERT_TRUE(result.has_value());
+  classifier.make_debug_image(result->roi_images);
+
+  // Assert: roi_images holds only the 1 classified ROI -- distinct from both the 3
+  // inputs and the 2 output signals (classified + appended-UNKNOWN) -- and that same
+  // subset is exactly what make_debug_image hands the backend.
+  EXPECT_EQ(result->roi_images.size(), 1u);
+  EXPECT_EQ(result->signals.signals.size(), 2u);
+  EXPECT_EQ(fake_classifier_->debug_images_received.size(), 1u);
+}
 
 // --------------------------------------------------------------------------
 // No ROIs -> empty result, no exposure flags, and the backend is never invoked


### PR DESCRIPTION
## Description

Second step of the by-concern campaign to remove the ROS Node dependency from the traffic-light
classifiers (follows #13041, which moved parameter declaration to the node).

This PR moves **debug-image publishing** out of the three classifiers and into the node:

- `ClassifierInterface` gains a value-returning `cv::Mat make_debug_image(const std::vector<cv::Mat> &)`,
  which renders one composite RGB debug frame for the batch from the most recent `getTrafficSignals`
  call. Each classifier stops owning an `image_transport::Publisher`; the publish block is removed.
- The node owns a single `image_transport::Publisher` on `~/output/debug/image` and publishes only
  when a debug consumer is attached (subscriber-gated, so the composite is built only on demand).
- `TrafficLightClassifier` exposes the cropped ROI views via `Result::roi_images` and forwards
  `make_debug_image`, so the node can request the debug view without re-implementing ROI cropping.

Each classifier keeps the per-image debug rendering it already had; only the *publishing* moves.

## Related links

- Follows #13041 (parameter declaration → node).

## How was this PR tested?

`colcon build` and `colcon test` for `autoware_traffic_light_classifier` on GPU environment: 84 tests, 0 failures, 0 skipped. A new ROS-free wrapper test
(`ExposesRoiImagesAndForwardsDebug`) pins that `classify()` exposes the cropped ROIs and that `make_debug_image` is forwarded to the backend.

## Notes for reviewers

Part of a small by-concern series (parameters → debug image → logging/reconfigure → adapter collapse) that progressively removes the Node dependency from the classifier layer.

## Interface changes

No ROS interface change in topic type or name. One debug topic is renamed for consistency (see below).

### Topic changes

#### Modifications

| Version | Topic Type | Topic Name              | Message Type        | Description                          |
|:--------|:-----------|:------------------------|:--------------------|:-------------------------------------|
| Old     | Pub        | `~/debug/image`         | `sensor_msgs/Image` | Color (HSV) classifier debug image   |
| New     | Pub        | `~/output/debug/image`  | `sensor_msgs/Image` | Color (HSV) classifier debug image   |

The CNN and lamp backends already published on `~/output/debug/image`; the color backend's
`~/debug/image` is unified onto the same topic (no launch/rviz config referenced the old name).

## Effects on system behavior

Only the debug visualization changes. The primary output `~/output/traffic_signals` is unchanged
in content, type, and timing.

For one camera frame with N target-type ROIs, the debug image on `~/output/debug/image` changes as
follows:

| Backend     | Debug topic (old → new)                  | Messages / frame (old → new) | Encoding (old → new) |
|:------------|:-----------------------------------------|:-----------------------------|:---------------------|
| Color (HSV) | `~/debug/image` → `~/output/debug/image` | N → 1 (stacked vertically)   | `bgr8` → `rgb8`      |
| CNN         | `~/output/debug/image` (unchanged)       | N → 1 (stacked vertically)   | `rgb8` (unchanged)   |
| Lamp        | `~/output/debug/image` (unchanged)       | 1 (unchanged)                | `rgb8` (unchanged)   |

- **Color debug topic is unified** onto `~/output/debug/image`; a viewer still subscribed to the old
  `~/debug/image` receives nothing until it re-subscribes. CNN and lamp topics are unchanged.
- **CNN and Color now publish one composite frame** (the per-ROI views stacked vertically) instead of
  one message per ROI. The lamp backend already composited, so it is unchanged.
- **Color debug colors now display correctly.** The mosaic's raw-ROI pixels are RGB-ordered, so the
  old `bgr8` label swapped R/B in viewers; publishing as `rgb8` corrects the label. The pixel buffer
  is unchanged — this is a label fix, not a pixel change.
- **Debug publishing stays subscriber-gated.** The composite is built and published only when
  `~/output/debug/image` has a subscriber (a cold path); with no subscriber, no work is done. Only
  the publisher owner changed (per-classifier publisher → a single node-owned publisher).
- **Debug rendering can no longer affect the primary output.** The debug build/publish now runs after
  the `~/output/traffic_signals` publish and the diagnostics publish, so a failure there (e.g. an
  OpenCV exception) cannot skip the primary signal output or diagnostics.

