### PR TITLE
feat(autoware_multi_object_tracker): orientation sign belief for heading flip decisions

### DIFF
--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/kalman_filter_template.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/kalman_filter_template.hpp
@@ -148,6 +148,17 @@ public:
   [[nodiscard]] Scalar getXelement(unsigned int i) const noexcept { return x_(i); }
 
   /**
+   * @brief get element of P
+   * @param i row index of P
+   * @param j column index of P
+   * @return value of the kalman filter covariance P[i, j]
+   */
+  [[nodiscard]] Scalar getPelement(unsigned int i, unsigned int j) const noexcept
+  {
+    return P_(i, j);
+  }
+
+  /**
    * @brief calculate kalman filter state and covariance by prediction model with A, B, Q matrix.
    * This is mainly for EKF with variable matrix.
    * @param u input for model

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/object_model/object_model.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/object_model/object_model.hpp
@@ -122,6 +122,7 @@ struct OrientationSignBelief
   double log_odds_max{0.0};       // [-] belief clamp bound
   double flip_threshold{0.0};     // [-] flip when log_odds < -flip_threshold
   double vote_vel_par{0.0};  // [m/s] speed where a velocity vote equals an AVAILABLE yaw vote
+  double vote_vel_var{0.0};  // [m^2/s^2] velocity variance where a velocity vote halves
 };
 
 class ObjectModel
@@ -193,6 +194,7 @@ public:
         orientation_sign_belief.log_odds_max = 4.0;
         orientation_sign_belief.flip_threshold = 2.0;
         orientation_sign_belief.vote_vel_par = kmph2mps(5.0);
+        orientation_sign_belief.vote_vel_var = sq(1.0);
         break;
 
       case ObjectModelType::NormalVehicle:
@@ -247,6 +249,7 @@ public:
         orientation_sign_belief.log_odds_max = 4.0;
         orientation_sign_belief.flip_threshold = 2.0;
         orientation_sign_belief.vote_vel_par = kmph2mps(5.0);
+        orientation_sign_belief.vote_vel_var = sq(1.0);
         break;
 
       case ObjectModelType::BigVehicle:
@@ -301,6 +304,7 @@ public:
         orientation_sign_belief.log_odds_max = 4.0;
         orientation_sign_belief.flip_threshold = 2.0;
         orientation_sign_belief.vote_vel_par = kmph2mps(5.0);
+        orientation_sign_belief.vote_vel_var = sq(1.0);
         break;
 
       case ObjectModelType::Bicycle:
@@ -355,6 +359,7 @@ public:
         orientation_sign_belief.log_odds_max = 4.0;
         orientation_sign_belief.flip_threshold = 2.0;
         orientation_sign_belief.vote_vel_par = kmph2mps(5.0);
+        orientation_sign_belief.vote_vel_var = sq(1.0);
         break;
 
       case ObjectModelType::Pedestrian:

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/object_model/object_model.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/object_model/object_model.hpp
@@ -116,13 +116,16 @@ struct BicycleModelState
 };
 struct OrientationSignBelief
 {
-  double vote_sign_unknown{0.0};  // [-] log-odds increment per SIGN_UNKNOWN measurement
-  double vote_available{0.0};     // [-] log-odds increment per AVAILABLE measurement
-  double dead_zone{0.0};          // [rad] no-vote band around |yaw_diff| = 90 deg
-  double log_odds_max{0.0};       // [-] belief clamp bound
-  double flip_threshold{0.0};     // [-] flip when log_odds < -flip_threshold
-  double vote_vel_par{0.0};  // [m/s] speed where a velocity vote equals an AVAILABLE yaw vote
-  double vote_vel_var{0.0};  // [m^2/s^2] velocity variance where a velocity vote halves
+  double tau{0.0};                 // [s] evidence memory time constant
+  double stationary_var{0.0};      // [-] variance of the uninformed agreement prior
+  double r_yaw_available{0.0};     // [-] yaw-vote noise variance, sign known
+  double r_yaw_sign_unknown{0.0};  // [-] yaw-vote noise variance, sign unknown
+  double dead_zone{0.0};           // [rad] no-vote band around |yaw_diff| = 90 deg
+  double r_vel{0.0};               // [-] velocity-evidence noise variance at the par speed
+  double vote_vel_par{0.0};        // [m/s] speed where the velocity evidence saturates
+  double vote_vel_var{0.0};        // [m^2/s^2] velocity variance where its certainty halves
+  double flip_z{0.0};              // [-] posterior confidence gate (z-score) for flipping
+  double flip_min_agreement{0.0};  // [-] fused-agreement magnitude floor for flipping
 };
 
 class ObjectModel
@@ -188,13 +191,16 @@ public:
         bicycle_state.length_uncertainty = 1.0;
 
         // orientation sign belief
-        orientation_sign_belief.vote_sign_unknown = 1.1;
-        orientation_sign_belief.vote_available = 2.2;
+        orientation_sign_belief.tau = 3.0;
+        orientation_sign_belief.stationary_var = sq(0.5);
+        orientation_sign_belief.r_yaw_available = 0.5;
+        orientation_sign_belief.r_yaw_sign_unknown = 2.0;
         orientation_sign_belief.dead_zone = deg2rad(30.0);
-        orientation_sign_belief.log_odds_max = 4.0;
-        orientation_sign_belief.flip_threshold = 2.0;
+        orientation_sign_belief.r_vel = 0.1;
         orientation_sign_belief.vote_vel_par = kmph2mps(5.0);
         orientation_sign_belief.vote_vel_var = sq(1.0);
+        orientation_sign_belief.flip_z = 1.3;
+        orientation_sign_belief.flip_min_agreement = 0.2;
         break;
 
       case ObjectModelType::NormalVehicle:
@@ -243,13 +249,16 @@ public:
         bicycle_state.length_uncertainty = 0.5;
 
         // orientation sign belief
-        orientation_sign_belief.vote_sign_unknown = 1.1;
-        orientation_sign_belief.vote_available = 2.2;
+        orientation_sign_belief.tau = 3.0;
+        orientation_sign_belief.stationary_var = sq(0.5);
+        orientation_sign_belief.r_yaw_available = 0.5;
+        orientation_sign_belief.r_yaw_sign_unknown = 2.0;
         orientation_sign_belief.dead_zone = deg2rad(30.0);
-        orientation_sign_belief.log_odds_max = 4.0;
-        orientation_sign_belief.flip_threshold = 2.0;
+        orientation_sign_belief.r_vel = 0.1;
         orientation_sign_belief.vote_vel_par = kmph2mps(5.0);
         orientation_sign_belief.vote_vel_var = sq(1.0);
+        orientation_sign_belief.flip_z = 1.3;
+        orientation_sign_belief.flip_min_agreement = 0.2;
         break;
 
       case ObjectModelType::BigVehicle:
@@ -298,13 +307,16 @@ public:
         bicycle_state.length_uncertainty = 0.8;
 
         // orientation sign belief
-        orientation_sign_belief.vote_sign_unknown = 1.1;
-        orientation_sign_belief.vote_available = 2.2;
+        orientation_sign_belief.tau = 3.0;
+        orientation_sign_belief.stationary_var = sq(0.5);
+        orientation_sign_belief.r_yaw_available = 0.5;
+        orientation_sign_belief.r_yaw_sign_unknown = 2.0;
         orientation_sign_belief.dead_zone = deg2rad(30.0);
-        orientation_sign_belief.log_odds_max = 4.0;
-        orientation_sign_belief.flip_threshold = 2.0;
+        orientation_sign_belief.r_vel = 0.1;
         orientation_sign_belief.vote_vel_par = kmph2mps(5.0);
         orientation_sign_belief.vote_vel_var = sq(1.0);
+        orientation_sign_belief.flip_z = 1.3;
+        orientation_sign_belief.flip_min_agreement = 0.2;
         break;
 
       case ObjectModelType::Bicycle:
@@ -353,13 +365,16 @@ public:
         bicycle_state.length_uncertainty = 0.3;
 
         // orientation sign belief
-        orientation_sign_belief.vote_sign_unknown = 1.1;
-        orientation_sign_belief.vote_available = 2.2;
+        orientation_sign_belief.tau = 3.0;
+        orientation_sign_belief.stationary_var = sq(0.5);
+        orientation_sign_belief.r_yaw_available = 0.5;
+        orientation_sign_belief.r_yaw_sign_unknown = 2.0;
         orientation_sign_belief.dead_zone = deg2rad(30.0);
-        orientation_sign_belief.log_odds_max = 4.0;
-        orientation_sign_belief.flip_threshold = 2.0;
+        orientation_sign_belief.r_vel = 0.1;
         orientation_sign_belief.vote_vel_par = kmph2mps(5.0);
         orientation_sign_belief.vote_vel_var = sq(1.0);
+        orientation_sign_belief.flip_z = 1.3;
+        orientation_sign_belief.flip_min_agreement = 0.2;
         break;
 
       case ObjectModelType::Pedestrian:

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/object_model/object_model.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/object_model/object_model.hpp
@@ -114,19 +114,6 @@ struct BicycleModelState
   double wheel_pos_rear_min{0.0};     // [m]
   double length_uncertainty{0.0};     // [m] length uncertainty
 };
-struct OrientationSignBelief
-{
-  double tau{0.0};                 // [s] evidence memory time constant
-  double stationary_var{0.0};      // [-] variance of the uninformed agreement prior
-  double r_yaw_available{0.0};     // [-] yaw-vote noise variance, sign known
-  double r_yaw_sign_unknown{0.0};  // [-] yaw-vote noise variance, sign unknown
-  double dead_zone{0.0};           // [rad] no-vote band around |yaw_diff| = 90 deg
-  double r_vel{0.0};               // [-] velocity-evidence noise variance at the par speed
-  double vote_vel_par{0.0};        // [m/s] speed where the velocity evidence saturates
-  double vote_vel_var{0.0};        // [m^2/s^2] velocity variance where its certainty halves
-  double flip_z{0.0};              // [-] posterior confidence gate (z-score) for flipping
-  double flip_min_agreement{0.0};  // [-] fused-agreement magnitude floor for flipping
-};
 
 class ObjectModel
 {
@@ -139,7 +126,6 @@ public:
   StateCovariance initial_covariance;
   StateCovariance measurement_covariance;
   BicycleModelState bicycle_state;
-  OrientationSignBelief orientation_sign_belief;
 
   explicit ObjectModel(const ObjectModelType & type_set)
   {
@@ -189,18 +175,6 @@ public:
         bicycle_state.wheel_pos_front_min = 1.0;
         bicycle_state.wheel_pos_rear_min = 1.0;
         bicycle_state.length_uncertainty = 1.0;
-
-        // orientation sign belief
-        orientation_sign_belief.tau = 3.0;
-        orientation_sign_belief.stationary_var = sq(0.5);
-        orientation_sign_belief.r_yaw_available = 0.5;
-        orientation_sign_belief.r_yaw_sign_unknown = 2.0;
-        orientation_sign_belief.dead_zone = deg2rad(30.0);
-        orientation_sign_belief.r_vel = 0.1;
-        orientation_sign_belief.vote_vel_par = kmph2mps(5.0);
-        orientation_sign_belief.vote_vel_var = sq(1.0);
-        orientation_sign_belief.flip_z = 1.3;
-        orientation_sign_belief.flip_min_agreement = 0.2;
         break;
 
       case ObjectModelType::NormalVehicle:
@@ -247,18 +221,6 @@ public:
         bicycle_state.wheel_pos_front_min = 1.0;
         bicycle_state.wheel_pos_rear_min = 1.0;
         bicycle_state.length_uncertainty = 0.5;
-
-        // orientation sign belief
-        orientation_sign_belief.tau = 3.0;
-        orientation_sign_belief.stationary_var = sq(0.5);
-        orientation_sign_belief.r_yaw_available = 0.5;
-        orientation_sign_belief.r_yaw_sign_unknown = 2.0;
-        orientation_sign_belief.dead_zone = deg2rad(30.0);
-        orientation_sign_belief.r_vel = 0.1;
-        orientation_sign_belief.vote_vel_par = kmph2mps(5.0);
-        orientation_sign_belief.vote_vel_var = sq(1.0);
-        orientation_sign_belief.flip_z = 1.3;
-        orientation_sign_belief.flip_min_agreement = 0.2;
         break;
 
       case ObjectModelType::BigVehicle:
@@ -305,18 +267,6 @@ public:
         bicycle_state.wheel_pos_front_min = 1.5;
         bicycle_state.wheel_pos_rear_min = 1.5;
         bicycle_state.length_uncertainty = 0.8;
-
-        // orientation sign belief
-        orientation_sign_belief.tau = 3.0;
-        orientation_sign_belief.stationary_var = sq(0.5);
-        orientation_sign_belief.r_yaw_available = 0.5;
-        orientation_sign_belief.r_yaw_sign_unknown = 2.0;
-        orientation_sign_belief.dead_zone = deg2rad(30.0);
-        orientation_sign_belief.r_vel = 0.1;
-        orientation_sign_belief.vote_vel_par = kmph2mps(5.0);
-        orientation_sign_belief.vote_vel_var = sq(1.0);
-        orientation_sign_belief.flip_z = 1.3;
-        orientation_sign_belief.flip_min_agreement = 0.2;
         break;
 
       case ObjectModelType::Bicycle:
@@ -363,18 +313,6 @@ public:
         bicycle_state.wheel_pos_front_min = 0.3;
         bicycle_state.wheel_pos_rear_min = 0.3;
         bicycle_state.length_uncertainty = 0.3;
-
-        // orientation sign belief
-        orientation_sign_belief.tau = 3.0;
-        orientation_sign_belief.stationary_var = sq(0.5);
-        orientation_sign_belief.r_yaw_available = 0.5;
-        orientation_sign_belief.r_yaw_sign_unknown = 2.0;
-        orientation_sign_belief.dead_zone = deg2rad(30.0);
-        orientation_sign_belief.r_vel = 0.1;
-        orientation_sign_belief.vote_vel_par = kmph2mps(5.0);
-        orientation_sign_belief.vote_vel_var = sq(1.0);
-        orientation_sign_belief.flip_z = 1.3;
-        orientation_sign_belief.flip_min_agreement = 0.2;
         break;
 
       case ObjectModelType::Pedestrian:

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/object_model/object_model.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/object_model/object_model.hpp
@@ -114,6 +114,15 @@ struct BicycleModelState
   double wheel_pos_rear_min{0.0};     // [m]
   double length_uncertainty{0.0};     // [m] length uncertainty
 };
+struct OrientationSignBelief
+{
+  double vote_sign_unknown{0.0};  // [-] log-odds increment per SIGN_UNKNOWN measurement
+  double vote_available{0.0};     // [-] log-odds increment per AVAILABLE measurement
+  double dead_zone{0.0};          // [rad] no-vote band around |yaw_diff| = 90 deg
+  double log_odds_max{0.0};       // [-] belief clamp bound
+  double flip_threshold{0.0};     // [-] flip when log_odds < -flip_threshold
+  double flip_vel_limit{0.0};     // [m/s] belief-based flip enabled below this |vel_long|
+};
 
 class ObjectModel
 {
@@ -126,6 +135,7 @@ public:
   StateCovariance initial_covariance;
   StateCovariance measurement_covariance;
   BicycleModelState bicycle_state;
+  OrientationSignBelief orientation_sign_belief;
 
   explicit ObjectModel(const ObjectModelType & type_set)
   {
@@ -175,6 +185,14 @@ public:
         bicycle_state.wheel_pos_front_min = 1.0;
         bicycle_state.wheel_pos_rear_min = 1.0;
         bicycle_state.length_uncertainty = 1.0;
+
+        // orientation sign belief
+        orientation_sign_belief.vote_sign_unknown = 1.1;
+        orientation_sign_belief.vote_available = 2.2;
+        orientation_sign_belief.dead_zone = deg2rad(30.0);
+        orientation_sign_belief.log_odds_max = 4.0;
+        orientation_sign_belief.flip_threshold = 2.0;
+        orientation_sign_belief.flip_vel_limit = kmph2mps(5.0);
         break;
 
       case ObjectModelType::NormalVehicle:
@@ -221,6 +239,14 @@ public:
         bicycle_state.wheel_pos_front_min = 1.0;
         bicycle_state.wheel_pos_rear_min = 1.0;
         bicycle_state.length_uncertainty = 0.5;
+
+        // orientation sign belief
+        orientation_sign_belief.vote_sign_unknown = 1.1;
+        orientation_sign_belief.vote_available = 2.2;
+        orientation_sign_belief.dead_zone = deg2rad(30.0);
+        orientation_sign_belief.log_odds_max = 4.0;
+        orientation_sign_belief.flip_threshold = 2.0;
+        orientation_sign_belief.flip_vel_limit = kmph2mps(5.0);
         break;
 
       case ObjectModelType::BigVehicle:
@@ -267,6 +293,14 @@ public:
         bicycle_state.wheel_pos_front_min = 1.5;
         bicycle_state.wheel_pos_rear_min = 1.5;
         bicycle_state.length_uncertainty = 0.8;
+
+        // orientation sign belief
+        orientation_sign_belief.vote_sign_unknown = 1.1;
+        orientation_sign_belief.vote_available = 2.2;
+        orientation_sign_belief.dead_zone = deg2rad(30.0);
+        orientation_sign_belief.log_odds_max = 4.0;
+        orientation_sign_belief.flip_threshold = 2.0;
+        orientation_sign_belief.flip_vel_limit = kmph2mps(5.0);
         break;
 
       case ObjectModelType::Bicycle:
@@ -313,6 +347,14 @@ public:
         bicycle_state.wheel_pos_front_min = 0.3;
         bicycle_state.wheel_pos_rear_min = 0.3;
         bicycle_state.length_uncertainty = 0.3;
+
+        // orientation sign belief
+        orientation_sign_belief.vote_sign_unknown = 1.1;
+        orientation_sign_belief.vote_available = 2.2;
+        orientation_sign_belief.dead_zone = deg2rad(30.0);
+        orientation_sign_belief.log_odds_max = 4.0;
+        orientation_sign_belief.flip_threshold = 2.0;
+        orientation_sign_belief.flip_vel_limit = kmph2mps(5.0);
         break;
 
       case ObjectModelType::Pedestrian:

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/object_model/object_model.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/object_model/object_model.hpp
@@ -121,7 +121,7 @@ struct OrientationSignBelief
   double dead_zone{0.0};          // [rad] no-vote band around |yaw_diff| = 90 deg
   double log_odds_max{0.0};       // [-] belief clamp bound
   double flip_threshold{0.0};     // [-] flip when log_odds < -flip_threshold
-  double flip_vel_limit{0.0};     // [m/s] belief-based flip enabled below this |vel_long|
+  double vote_vel_par{0.0};  // [m/s] speed where a velocity vote equals an AVAILABLE yaw vote
 };
 
 class ObjectModel
@@ -192,7 +192,7 @@ public:
         orientation_sign_belief.dead_zone = deg2rad(30.0);
         orientation_sign_belief.log_odds_max = 4.0;
         orientation_sign_belief.flip_threshold = 2.0;
-        orientation_sign_belief.flip_vel_limit = kmph2mps(5.0);
+        orientation_sign_belief.vote_vel_par = kmph2mps(5.0);
         break;
 
       case ObjectModelType::NormalVehicle:
@@ -246,7 +246,7 @@ public:
         orientation_sign_belief.dead_zone = deg2rad(30.0);
         orientation_sign_belief.log_odds_max = 4.0;
         orientation_sign_belief.flip_threshold = 2.0;
-        orientation_sign_belief.flip_vel_limit = kmph2mps(5.0);
+        orientation_sign_belief.vote_vel_par = kmph2mps(5.0);
         break;
 
       case ObjectModelType::BigVehicle:
@@ -300,7 +300,7 @@ public:
         orientation_sign_belief.dead_zone = deg2rad(30.0);
         orientation_sign_belief.log_odds_max = 4.0;
         orientation_sign_belief.flip_threshold = 2.0;
-        orientation_sign_belief.flip_vel_limit = kmph2mps(5.0);
+        orientation_sign_belief.vote_vel_par = kmph2mps(5.0);
         break;
 
       case ObjectModelType::Bicycle:
@@ -354,7 +354,7 @@ public:
         orientation_sign_belief.dead_zone = deg2rad(30.0);
         orientation_sign_belief.log_odds_max = 4.0;
         orientation_sign_belief.flip_threshold = 2.0;
-        orientation_sign_belief.flip_vel_limit = kmph2mps(5.0);
+        orientation_sign_belief.vote_vel_par = kmph2mps(5.0);
         break;
 
       case ObjectModelType::Pedestrian:

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/motion_model/bicycle_motion_model.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/motion_model/bicycle_motion_model.hpp
@@ -66,6 +66,10 @@ private:
     double q_cov_length = 0.25;                  // [m^2] covariance of the length uncertainty, 0.5m
   } motion_params_;
 
+  // 180° heading flip on a raw state/covariance pair: swap the axle points about the body
+  // center, negate the longitudinal velocity, swap the matching covariance rows/cols.
+  void flipStateOrientation(StateVec & X, StateMat & P) const;
+
 public:
   BicycleMotionModel();
 
@@ -126,6 +130,10 @@ public:
   bool blendAxleCovariance(const double blend_ratio);
 
   bool limitStates();
+
+  // Rotate the tracked heading 180°: swap the axle points about the body center and negate the
+  // longitudinal velocity.
+  bool flipOrientation();
 
   bool predictStateStep(const double dt, KalmanFilter & ekf) const override;
 

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/motion_model/bicycle_motion_model.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/motion_model/bicycle_motion_model.hpp
@@ -52,9 +52,7 @@ private:
     double lr_min = 1.0;     // [m] minimum distance from the center to the rear wheel
     double wheel_base_ratio_inv =
       1 / (lf_ratio + lr_ratio);  // [-] inverse of the sum of lf_ratio and lr_ratio
-    double max_vel = 27.8;        // [m/s] maximum velocity, 100km/h
-    double max_reverse_vel =
-      -1.389;  // [m/s] maximum reverse velocity, -5km/h. The value is expected to be negative
+    double max_vel = 27.8;  // [m/s] maximum velocity, 100km/h
     double wheel_pos_ratio =
       (lf_ratio + lr_ratio) /
       lr_ratio;  // [-] distance ratio of the wheel base over center-to-rear-wheel

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/motion_model/bicycle_motion_model.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/motion_model/bicycle_motion_model.hpp
@@ -52,7 +52,7 @@ private:
     double lr_min = 1.0;     // [m] minimum distance from the center to the rear wheel
     double wheel_base_ratio_inv =
       1 / (lf_ratio + lr_ratio);  // [-] inverse of the sum of lf_ratio and lr_ratio
-    double max_vel = 27.8;  // [m/s] maximum velocity, 100km/h
+    double max_vel = 27.8;        // [m/s] maximum velocity, 100km/h
     double wheel_pos_ratio =
       (lf_ratio + lr_ratio) /
       lr_ratio;  // [-] distance ratio of the wheel base over center-to-rear-wheel

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/motion_model/ctrv_motion_model.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/motion_model/ctrv_motion_model.hpp
@@ -74,6 +74,9 @@ public:
 
   bool adjustPosition(const double & x, const double & y);
 
+  // 180° heading flip of the raw state: rotate yaw by pi and negate the velocity.
+  bool flipOrientation();
+
   bool limitStates();
 
   double getYawState() const noexcept { return getStateElement(IDX::YAW); }

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/motion_model/motion_model_base.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/motion_model/motion_model_base.hpp
@@ -75,6 +75,10 @@ public:
   }
   void setMaxDeltaTime(const double dt_max) noexcept { dt_max_ = dt_max; }
   double getStateElement(unsigned int idx) const noexcept { return ekf_.getXelement(idx); }
+  double getCovarianceElement(unsigned int i, unsigned int j) const noexcept
+  {
+    return ekf_.getPelement(i, j);
+  }
   void getStateVector(StateVec & X) const noexcept { ekf_.getX(X); }
 
   bool initialize(const rclcpp::Time & time, const StateVec & X, const StateMat & P);

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/trackers/multiple_vehicle_tracker.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/trackers/multiple_vehicle_tracker.hpp
@@ -30,6 +30,9 @@ private:
   VehicleTracker normal_vehicle_tracker_;
   VehicleTracker big_vehicle_tracker_;
 
+  // Heading-sign consensus across the layers; the stronger sign belief is authoritative.
+  void alignOrientationSigns();
+
   // Inner tracker that backs the published object for the current highest-prob label.
   VehicleTracker & activeInner()
   {

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/trackers/pedestrian_and_bicycle_tracker.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/trackers/pedestrian_and_bicycle_tracker.hpp
@@ -29,6 +29,9 @@ private:
   PedestrianTracker pedestrian_tracker_;
   VehicleTracker bicycle_tracker_;
 
+  // Heading-sign consensus across the layers; the bicycle layer's sign belief is authoritative.
+  void alignOrientationSigns();
+
 public:
   PedestrianAndBicycleTracker(const rclcpp::Time & time, const types::DynamicObject & object);
 

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/trackers/pedestrian_tracker.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/trackers/pedestrian_tracker.hpp
@@ -55,6 +55,15 @@ public:
     geometry_msgs::msg::Twist & twist, std::array<double, 36> & twist_cov) const override;
   rclcpp::Time getStateTime() const override { return motion_model_.getLastPredictionTime(); }
 
+  // Heading state and 180° state flip; composite trackers use these for heading-sign
+  // consensus across their layers.
+  double getYawState() const { return motion_model_.getYawState(); }
+  void flipOrientationSign()
+  {
+    motion_model_.flipOrientation();
+    removeCache();
+  }
+
   ShapeModelBase & getShapeModel() override { return shape_model_; }
   const ShapeModelBase & getShapeModel() const override { return shape_model_; }
   void assembleShapeTo(types::DynamicObject & output, bool /*to_publish*/) const override

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/trackers/vehicle_tracker.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/trackers/vehicle_tracker.hpp
@@ -50,6 +50,10 @@ private:
   // Accumulated heading-sign evidence from raw detection yaws.
   OrientationSignBelief sign_belief_;
 
+  // Belief-driven 180° flip on the fused posterior: yaw votes decide the sign at low speed and
+  // the instantaneous velocity sign decides above the par speed.
+  void evaluateSignFlip(const rclcpp::Time & time);
+
   // EKF kinematic update — selects update variant based on data availability.
   bool updateKinematics(
     const types::DynamicObject & object, const types::InputChannel & channel_info);
@@ -90,10 +94,7 @@ public:
   // Heading state, sign-belief confidence, and 180° state flip; composite trackers use these
   // for heading-sign consensus across their layers.
   double getYawState() const { return motion_model_.getYawState(); }
-  double signBeliefConfidence() const
-  {
-    return std::abs(sign_belief_.agreement()) / std::sqrt(sign_belief_.variance());
-  }
+  double signBeliefConfidence() const { return sign_belief_.confidence(); }
   void flipOrientationSign();
 
   ShapeModelBase & getShapeModel() override { return shape_model_; }

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/trackers/vehicle_tracker.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/trackers/vehicle_tracker.hpp
@@ -19,6 +19,7 @@
 #include "autoware/multi_object_tracker/tracker/motion_model/bicycle_motion_model.hpp"
 #include "autoware/multi_object_tracker/tracker/shape_model/vehicle_shape_model.hpp"
 #include "autoware/multi_object_tracker/tracker/trackers/tracker_base.hpp"
+#include "autoware/multi_object_tracker/tracker/update/orientation_sign_belief.hpp"
 #include "autoware/multi_object_tracker/tracker/update/vehicle_update_strategy.hpp"
 #include "autoware/multi_object_tracker/types.hpp"
 
@@ -45,6 +46,9 @@ private:
 
   // Interval [s] since the last measurement update.
   double time_since_correction_{0.0};
+
+  // Accumulated heading-sign evidence from raw detection yaws.
+  OrientationSignBelief sign_belief_;
 
   // EKF kinematic update — selects update variant based on data availability.
   bool updateKinematics(

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/trackers/vehicle_tracker.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/trackers/vehicle_tracker.hpp
@@ -87,6 +87,12 @@ public:
     geometry_msgs::msg::Twist & twist, std::array<double, 36> & twist_cov) const override;
   rclcpp::Time getStateTime() const override { return motion_model_.getLastPredictionTime(); }
 
+  // Heading state, sign-belief confidence, and 180° state flip; composite trackers use these
+  // for heading-sign consensus across their layers.
+  double getYawState() const { return motion_model_.getYawState(); }
+  double signBeliefLogOdds() const { return sign_belief_.logOdds(); }
+  void flipOrientationSign();
+
   ShapeModelBase & getShapeModel() override { return shape_model_; }
   const ShapeModelBase & getShapeModel() const override { return shape_model_; }
   void assembleShapeTo(types::DynamicObject & output, bool to_publish) const override;

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/trackers/vehicle_tracker.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/trackers/vehicle_tracker.hpp
@@ -90,7 +90,10 @@ public:
   // Heading state, sign-belief confidence, and 180° state flip; composite trackers use these
   // for heading-sign consensus across their layers.
   double getYawState() const { return motion_model_.getYawState(); }
-  double signBeliefLogOdds() const { return sign_belief_.logOdds(); }
+  double signBeliefConfidence() const
+  {
+    return std::abs(sign_belief_.agreement()) / std::sqrt(sign_belief_.variance());
+  }
   void flipOrientationSign();
 
   ShapeModelBase & getShapeModel() override { return shape_model_; }

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/update/orientation_sign_belief.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/update/orientation_sign_belief.hpp
@@ -55,10 +55,13 @@ public:
 
   // Forward motion agrees with the heading sign, reverse motion disagrees. The vote weight grows
   // linearly with speed and matches an AVAILABLE yaw vote at vote_vel_par, so a slow reverse
-  // maneuver (e.g. parking) barely moves the belief while yaw votes dominate.
-  void voteVelocity(const double vel_long)
+  // maneuver (e.g. parking) barely moves the belief while yaw votes dominate. The vote is
+  // discounted by the velocity variance, halving at vote_vel_var; a poorly converged velocity
+  // estimate carries little weight.
+  void voteVelocity(const double vel_long, const double vel_var)
   {
-    log_odds_ += params_.vote_available * vel_long / params_.vote_vel_par;
+    const double confidence = params_.vote_vel_var / (params_.vote_vel_var + vel_var);
+    log_odds_ += params_.vote_available * confidence * vel_long / params_.vote_vel_par;
     log_odds_ = std::clamp(log_odds_, -params_.log_odds_max, params_.log_odds_max);
   }
 

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/update/orientation_sign_belief.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/update/orientation_sign_belief.hpp
@@ -18,63 +18,104 @@
 #include "autoware/multi_object_tracker/object_model/object_model.hpp"
 #include "autoware/multi_object_tracker/types.hpp"
 
+#include <rclcpp/time.hpp>
+
 #include <algorithm>
 #include <cmath>
 
 namespace autoware::multi_object_tracker
 {
 
-// Log-odds belief that the tracker's heading sign is correct. Each detection votes by its raw yaw
-// sign and the tracked longitudinal velocity votes by its sign; a strongly negative belief
-// triggers a 180° flip, and negation on flip provides hysteresis against oscillation.
+// Heading-sign belief with two separated evidence sources. Detection-yaw votes accumulate in a
+// scalar OU-Kalman agreement estimate (+1 = sign correct, -1 = wrong) that relaxes toward an
+// uninformed prior over time; the tracked longitudinal velocity contributes memorylessly at
+// decision time, weighted by speed and velocity certainty. A confidently negative fused
+// agreement triggers a 180° flip, and negation on flip provides hysteresis against oscillation.
 class OrientationSignBelief
 {
 public:
   OrientationSignBelief(
     const object_model::OrientationSignBelief & params,
-    const types::OrientationAvailability initial_availability)
-  : params_(params)
+    const types::OrientationAvailability initial_availability, const rclcpp::Time & time)
+  : params_(params), variance_(params.stationary_var), last_update_time_(time)
   {
     // The seeding detection also seeds the tracker yaw, so it counts as one agreeing vote.
     if (initial_availability == types::OrientationAvailability::AVAILABLE) {
-      log_odds_ = params_.vote_available;
+      correct(1.0, params_.r_yaw_available);
     } else if (initial_availability == types::OrientationAvailability::SIGN_UNKNOWN) {
-      log_odds_ = params_.vote_sign_unknown;
+      correct(1.0, params_.r_yaw_sign_unknown);
     }
+    fused_agreement_ = agreement_;
+    fused_variance_ = variance_;
   }
 
   // yaw_diff: normalized measurement yaw minus tracker yaw [rad]
-  void vote(const double yaw_diff, const bool is_sign_known)
+  void vote(const rclcpp::Time & time, const double yaw_diff, const bool is_sign_known)
   {
+    predictTo(time);
     // Near-perpendicular boxes carry axis ambiguity, not sign evidence.
     if (std::abs(std::abs(yaw_diff) - M_PI_2) < params_.dead_zone) return;
-    const double weight = is_sign_known ? params_.vote_available : params_.vote_sign_unknown;
-    log_odds_ += std::abs(yaw_diff) < M_PI_2 ? weight : -weight;
-    log_odds_ = std::clamp(log_odds_, -params_.log_odds_max, params_.log_odds_max);
+    const double z = std::abs(yaw_diff) < M_PI_2 ? 1.0 : -1.0;
+    correct(z, is_sign_known ? params_.r_yaw_available : params_.r_yaw_sign_unknown);
   }
 
-  // Forward motion agrees with the heading sign, reverse motion disagrees. The vote weight grows
-  // linearly with speed and matches an AVAILABLE yaw vote at vote_vel_par, so a slow reverse
-  // maneuver (e.g. parking) barely moves the belief while yaw votes dominate. The vote is
-  // discounted by the velocity variance, halving at vote_vel_var; a poorly converged velocity
-  // estimate carries little weight.
-  void voteVelocity(const double vel_long, const double vel_var)
+  // Fuses the accumulated agreement with the instantaneous velocity-sign evidence. The velocity
+  // weight vanishes at standstill, saturates at vote_vel_par, and is discounted by the velocity
+  // variance, so only sustained, well-estimated motion can override the yaw evidence. The flip
+  // fires when the fused sign is wrong with high posterior confidence.
+  bool shouldFlip(const rclcpp::Time & time, const double vel_long, const double vel_var)
   {
-    const double confidence = params_.vote_vel_var / (params_.vote_vel_var + vel_var);
-    log_odds_ += params_.vote_available * confidence * vel_long / params_.vote_vel_par;
-    log_odds_ = std::clamp(log_odds_, -params_.log_odds_max, params_.log_odds_max);
+    predictTo(time);
+    const double vel_ratio = vel_long / params_.vote_vel_par;
+    const double z_vel = std::clamp(vel_ratio, -1.0, 1.0);
+    const double info_vel = std::min(vel_ratio * vel_ratio, 1.0) / params_.r_vel *
+                            params_.vote_vel_var / (params_.vote_vel_var + vel_var);
+    fused_variance_ = 1.0 / (1.0 / variance_ + info_vel);
+    fused_agreement_ = (agreement_ / variance_ + z_vel * info_vel) * fused_variance_;
+    return fused_agreement_ + params_.flip_z * std::sqrt(fused_variance_) < 0.0 &&
+           fused_agreement_ < -params_.flip_min_agreement;
   }
-
-  bool shouldFlip() const { return log_odds_ < -params_.flip_threshold; }
 
   // A 180° state flip turns every past disagreeing vote into an agreeing one.
-  void onFlipped() { log_odds_ = -log_odds_; }
+  void onFlipped()
+  {
+    agreement_ = -agreement_;
+    fused_agreement_ = -fused_agreement_;
+  }
 
-  double logOdds() const { return log_odds_; }
+  double agreement() const { return agreement_; }
+  double variance() const { return variance_; }
+  double fusedAgreement() const { return fused_agreement_; }
+  double fusedVariance() const { return fused_variance_; }
 
 private:
+  // OU relaxation toward the (0, stationary_var) prior over the elapsed time. Zero elapsed time
+  // leaves the state untouched, so near-simultaneous votes fuse batch-equivalently and
+  // contradicting detections of one frame compensate independent of processing order.
+  void predictTo(const rclcpp::Time & time)
+  {
+    const double dt = (time - last_update_time_).seconds();
+    if (dt <= 0.0) return;
+    last_update_time_ = time;
+    const double alpha = std::exp(-dt / params_.tau);
+    agreement_ *= alpha;
+    variance_ = alpha * alpha * variance_ + (1.0 - alpha * alpha) * params_.stationary_var;
+  }
+
+  // Scalar Kalman update of the agreement estimate.
+  void correct(const double z, const double r)
+  {
+    const double gain = variance_ / (variance_ + r);
+    agreement_ += gain * (z - agreement_);
+    variance_ *= (1.0 - gain);
+  }
+
   object_model::OrientationSignBelief params_;
-  double log_odds_{0.0};
+  double agreement_{0.0};
+  double variance_{0.0};
+  rclcpp::Time last_update_time_;
+  double fused_agreement_{0.0};
+  double fused_variance_{0.0};
 };
 
 }  // namespace autoware::multi_object_tracker

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/update/orientation_sign_belief.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/update/orientation_sign_belief.hpp
@@ -1,0 +1,70 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__MULTI_OBJECT_TRACKER__TRACKER__UPDATE__ORIENTATION_SIGN_BELIEF_HPP_
+#define AUTOWARE__MULTI_OBJECT_TRACKER__TRACKER__UPDATE__ORIENTATION_SIGN_BELIEF_HPP_
+
+#include "autoware/multi_object_tracker/object_model/object_model.hpp"
+#include "autoware/multi_object_tracker/types.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+namespace autoware::multi_object_tracker
+{
+
+// Log-odds belief that the tracker's heading sign is correct. Each detection votes by its raw yaw
+// sign; a strongly negative belief triggers a 180° flip, and negation on flip provides hysteresis
+// against oscillation.
+class OrientationSignBelief
+{
+public:
+  OrientationSignBelief(
+    const object_model::OrientationSignBelief & params,
+    const types::OrientationAvailability initial_availability)
+  : params_(params)
+  {
+    // The seeding detection also seeds the tracker yaw, so it counts as one agreeing vote.
+    if (initial_availability == types::OrientationAvailability::AVAILABLE) {
+      log_odds_ = params_.vote_available;
+    } else if (initial_availability == types::OrientationAvailability::SIGN_UNKNOWN) {
+      log_odds_ = params_.vote_sign_unknown;
+    }
+  }
+
+  // yaw_diff: normalized measurement yaw minus tracker yaw [rad]
+  void vote(const double yaw_diff, const bool is_sign_known)
+  {
+    // Near-perpendicular boxes carry axis ambiguity, not sign evidence.
+    if (std::abs(std::abs(yaw_diff) - M_PI_2) < params_.dead_zone) return;
+    const double weight = is_sign_known ? params_.vote_available : params_.vote_sign_unknown;
+    log_odds_ += std::abs(yaw_diff) < M_PI_2 ? weight : -weight;
+    log_odds_ = std::clamp(log_odds_, -params_.log_odds_max, params_.log_odds_max);
+  }
+
+  bool shouldFlip() const { return log_odds_ < -params_.flip_threshold; }
+
+  // A 180° state flip turns every past disagreeing vote into an agreeing one.
+  void onFlipped() { log_odds_ = -log_odds_; }
+
+  double logOdds() const { return log_odds_; }
+
+private:
+  object_model::OrientationSignBelief params_;
+  double log_odds_{0.0};
+};
+
+}  // namespace autoware::multi_object_tracker
+
+#endif  // AUTOWARE__MULTI_OBJECT_TRACKER__TRACKER__UPDATE__ORIENTATION_SIGN_BELIEF_HPP_

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/update/orientation_sign_belief.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/update/orientation_sign_belief.hpp
@@ -101,6 +101,8 @@ public:
 
   double agreement() const { return agreement_; }
   double variance() const { return variance_; }
+  // Yaw-vote agreement magnitude as a z-score.
+  double confidence() const { return std::abs(agreement_) / std::sqrt(variance_); }
   double fusedAgreement() const { return fused_agreement_; }
   double fusedVariance() const { return fused_variance_; }
 

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/update/orientation_sign_belief.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/update/orientation_sign_belief.hpp
@@ -15,7 +15,6 @@
 #ifndef AUTOWARE__MULTI_OBJECT_TRACKER__TRACKER__UPDATE__ORIENTATION_SIGN_BELIEF_HPP_
 #define AUTOWARE__MULTI_OBJECT_TRACKER__TRACKER__UPDATE__ORIENTATION_SIGN_BELIEF_HPP_
 
-#include "autoware/multi_object_tracker/object_model/object_model.hpp"
 #include "autoware/multi_object_tracker/types.hpp"
 
 #include <rclcpp/time.hpp>
@@ -31,12 +30,29 @@ namespace autoware::multi_object_tracker
 // uninformed prior over time; the tracked longitudinal velocity contributes memorylessly at
 // decision time, weighted by speed and velocity certainty. A confidently negative fused
 // agreement triggers a 180° flip, and negation on flip provides hysteresis against oscillation.
+// Class-independent tuning constants shared by every vehicle tracker.
+struct OrientationSignBeliefParams
+{
+  double tau{3.0};                 // [s] evidence memory time constant
+  double stationary_var{0.25};     // [-] variance of the uninformed agreement prior
+  double r_yaw_available{0.5};     // [-] yaw-vote noise variance, sign known
+  double r_yaw_sign_unknown{2.0};  // [-] yaw-vote noise variance, sign unknown
+  double dead_zone{M_PI / 6.0};    // [rad] no-vote band around |yaw_diff| = 90 deg
+  double r_vel{0.1};               // [-] velocity-evidence noise variance at the par speed
+  double vote_vel_par{5.0 / 3.6};  // [m/s] speed where the velocity evidence saturates
+  double vote_vel_var{1.0};        // [m^2/s^2] velocity variance where its certainty halves
+  double flip_z{1.3};              // [-] posterior confidence gate (z-score) for flipping
+  double flip_min_agreement{0.2};  // [-] fused-agreement magnitude floor for flipping
+};
+
 class OrientationSignBelief
 {
 public:
+  using Params = OrientationSignBeliefParams;
+
   OrientationSignBelief(
-    const object_model::OrientationSignBelief & params,
-    const types::OrientationAvailability initial_availability, const rclcpp::Time & time)
+    const types::OrientationAvailability initial_availability, const rclcpp::Time & time,
+    const Params & params = Params{})
   : params_(params), variance_(params.stationary_var), last_update_time_(time)
   {
     // The seeding detection also seeds the tracker yaw, so it counts as one agreeing vote.
@@ -110,7 +126,7 @@ private:
     variance_ *= (1.0 - gain);
   }
 
-  object_model::OrientationSignBelief params_;
+  Params params_;
   double agreement_{0.0};
   double variance_{0.0};
   rclcpp::Time last_update_time_;

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/update/orientation_sign_belief.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/update/orientation_sign_belief.hpp
@@ -25,8 +25,8 @@ namespace autoware::multi_object_tracker
 {
 
 // Log-odds belief that the tracker's heading sign is correct. Each detection votes by its raw yaw
-// sign; a strongly negative belief triggers a 180° flip, and negation on flip provides hysteresis
-// against oscillation.
+// sign and the tracked longitudinal velocity votes by its sign; a strongly negative belief
+// triggers a 180° flip, and negation on flip provides hysteresis against oscillation.
 class OrientationSignBelief
 {
 public:
@@ -50,6 +50,15 @@ public:
     if (std::abs(std::abs(yaw_diff) - M_PI_2) < params_.dead_zone) return;
     const double weight = is_sign_known ? params_.vote_available : params_.vote_sign_unknown;
     log_odds_ += std::abs(yaw_diff) < M_PI_2 ? weight : -weight;
+    log_odds_ = std::clamp(log_odds_, -params_.log_odds_max, params_.log_odds_max);
+  }
+
+  // Forward motion agrees with the heading sign, reverse motion disagrees. The vote weight grows
+  // linearly with speed and matches an AVAILABLE yaw vote at vote_vel_par, so a slow reverse
+  // maneuver (e.g. parking) barely moves the belief while yaw votes dominate.
+  void voteVelocity(const double vel_long)
+  {
+    log_odds_ += params_.vote_available * vel_long / params_.vote_vel_par;
     log_odds_ = std::clamp(log_odds_, -params_.log_odds_max, params_.log_odds_max);
   }
 

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/update/orientation_sign_belief.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/update/orientation_sign_belief.hpp
@@ -42,7 +42,7 @@ struct OrientationSignBeliefParams
 
 // Heading-sign belief with two separated evidence sources. Detection-yaw votes accumulate in a
 // scalar OU-Kalman agreement estimate (+1 = sign correct, -1 = wrong) that relaxes toward an
-// uninformed prior over time; the tracked longitudinal velocity contributes memorylessly at
+// uninformed prior over time; the tracked longitudinal velocity contributes memory-less at
 // decision time, weighted by speed and velocity certainty. A confidently negative fused
 // agreement triggers a 180° flip, and negation on flip provides hysteresis against oscillation.
 class OrientationSignBelief

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/update/orientation_sign_belief.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/update/orientation_sign_belief.hpp
@@ -25,12 +25,7 @@
 namespace autoware::multi_object_tracker
 {
 
-// Heading-sign belief with two separated evidence sources. Detection-yaw votes accumulate in a
-// scalar OU-Kalman agreement estimate (+1 = sign correct, -1 = wrong) that relaxes toward an
-// uninformed prior over time; the tracked longitudinal velocity contributes memorylessly at
-// decision time, weighted by speed and velocity certainty. A confidently negative fused
-// agreement triggers a 180° flip, and negation on flip provides hysteresis against oscillation.
-// Class-independent tuning constants shared by every vehicle tracker.
+// Tuning constants for OrientationSignBelief; one set applies to all vehicle classes.
 struct OrientationSignBeliefParams
 {
   double tau{3.0};                 // [s] evidence memory time constant
@@ -45,6 +40,11 @@ struct OrientationSignBeliefParams
   double flip_min_agreement{0.2};  // [-] fused-agreement magnitude floor for flipping
 };
 
+// Heading-sign belief with two separated evidence sources. Detection-yaw votes accumulate in a
+// scalar OU-Kalman agreement estimate (+1 = sign correct, -1 = wrong) that relaxes toward an
+// uninformed prior over time; the tracked longitudinal velocity contributes memorylessly at
+// decision time, weighted by speed and velocity certainty. A confidently negative fused
+// agreement triggers a 180° flip, and negation on flip provides hysteresis against oscillation.
 class OrientationSignBelief
 {
 public:

--- a/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
@@ -367,6 +367,51 @@ bool BicycleMotionModel::updateStateLength(
   return true;
 }
 
+void BicycleMotionModel::flipStateOrientation(StateVec & X, StateMat & P) const
+{
+  // rotate the object orientation by 180 degrees
+  // replace X1 and Y1 with X2 and Y2
+  const double x_center =
+    (X(IDX::X1) * motion_params_.lf_ratio + X(IDX::X2) * motion_params_.lr_ratio) *
+    motion_params_.wheel_base_ratio_inv;
+  const double y_center =
+    (X(IDX::Y1) * motion_params_.lf_ratio + X(IDX::Y2) * motion_params_.lr_ratio) *
+    motion_params_.wheel_base_ratio_inv;
+  const double x1_rel = X(IDX::X1) - x_center;
+  const double y1_rel = X(IDX::Y1) - y_center;
+  const double x2_rel = X(IDX::X2) - x_center;
+  const double y2_rel = X(IDX::Y2) - y_center;
+
+  X(IDX::X1) = x_center + x2_rel;
+  X(IDX::Y1) = y_center + y2_rel;
+  X(IDX::X2) = x_center + x1_rel;
+  X(IDX::Y2) = y_center + y1_rel;
+
+  // reverse the velocity
+  X(IDX::U) = -X(IDX::U);
+  // rotation velocity does not change
+
+  // replace covariance
+  // Swap rows and columns
+  P.row(IDX::X1).swap(P.row(IDX::X2));
+  P.row(IDX::Y1).swap(P.row(IDX::Y2));
+  P.col(IDX::X1).swap(P.col(IDX::X2));
+  P.col(IDX::Y1).swap(P.col(IDX::Y2));
+}
+
+bool BicycleMotionModel::flipOrientation()
+{
+  if (!checkInitialized()) return false;
+
+  StateVec X_t;
+  StateMat P_t;
+  ekf_.getX(X_t);
+  ekf_.getP(P_t);
+  flipStateOrientation(X_t, P_t);
+  ekf_.init(X_t, P_t);
+  return true;
+}
+
 bool BicycleMotionModel::limitStates()
 {
   StateVec X_t;
@@ -376,34 +421,7 @@ bool BicycleMotionModel::limitStates()
 
   // maximum reverse velocity
   if (motion_params_.max_reverse_vel < 0 && X_t(IDX::U) < motion_params_.max_reverse_vel) {
-    // rotate the object orientation by 180 degrees
-    // replace X1 and Y1 with X2 and Y2
-    const double x_center =
-      (X_t(IDX::X1) * motion_params_.lf_ratio + X_t(IDX::X2) * motion_params_.lr_ratio) *
-      motion_params_.wheel_base_ratio_inv;
-    const double y_center =
-      (X_t(IDX::Y1) * motion_params_.lf_ratio + X_t(IDX::Y2) * motion_params_.lr_ratio) *
-      motion_params_.wheel_base_ratio_inv;
-    const double x1_rel = X_t(IDX::X1) - x_center;
-    const double y1_rel = X_t(IDX::Y1) - y_center;
-    const double x2_rel = X_t(IDX::X2) - x_center;
-    const double y2_rel = X_t(IDX::Y2) - y_center;
-
-    X_t(IDX::X1) = x_center + x2_rel;
-    X_t(IDX::Y1) = y_center + y2_rel;
-    X_t(IDX::X2) = x_center + x1_rel;
-    X_t(IDX::Y2) = y_center + y1_rel;
-
-    // reverse the velocity
-    X_t(IDX::U) = -X_t(IDX::U);
-    // rotation velocity does not change
-
-    // replace covariance
-    // Swap rows and columns
-    P_t.row(IDX::X1).swap(P_t.row(IDX::X2));
-    P_t.row(IDX::Y1).swap(P_t.row(IDX::Y2));
-    P_t.col(IDX::X1).swap(P_t.col(IDX::X2));
-    P_t.col(IDX::Y1).swap(P_t.col(IDX::Y2));
+    flipStateOrientation(X_t, P_t);
   }
   // maximum velocity
   if (!(-motion_params_.max_vel <= X_t(IDX::U) && X_t(IDX::U) <= motion_params_.max_vel)) {

--- a/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
@@ -419,10 +419,6 @@ bool BicycleMotionModel::limitStates()
   ekf_.getX(X_t);
   ekf_.getP(P_t);
 
-  // maximum reverse velocity
-  if (motion_params_.max_reverse_vel < 0 && X_t(IDX::U) < motion_params_.max_reverse_vel) {
-    flipStateOrientation(X_t, P_t);
-  }
   // maximum velocity
   if (!(-motion_params_.max_vel <= X_t(IDX::U) && X_t(IDX::U) <= motion_params_.max_vel)) {
     X_t(IDX::U) = X_t(IDX::U) < 0 ? -motion_params_.max_vel : motion_params_.max_vel;

--- a/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
@@ -387,16 +387,18 @@ void BicycleMotionModel::flipStateOrientation(StateVec & X, StateMat & P) const
   X(IDX::X2) = x_center + x1_rel;
   X(IDX::Y2) = y_center + y1_rel;
 
-  // reverse the velocity
+  // reverse longitudinal velocity (U) direction
   X(IDX::U) = -X(IDX::U);
-  // rotation velocity does not change
+  // horizontal velocity does not change
 
-  // replace covariance
-  // Swap rows and columns
+  // covariance transform T*P*T^T: swap the axle rows/columns and negate the U cross-covariances
+  // U self-variance remains unchanged
   P.row(IDX::X1).swap(P.row(IDX::X2));
   P.row(IDX::Y1).swap(P.row(IDX::Y2));
   P.col(IDX::X1).swap(P.col(IDX::X2));
   P.col(IDX::Y1).swap(P.col(IDX::Y2));
+  P.row(IDX::U) *= -1.0;
+  P.col(IDX::U) *= -1.0;
 }
 
 bool BicycleMotionModel::flipOrientation()

--- a/perception/autoware_multi_object_tracker/lib/tracker/motion_model/ctrv_motion_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/motion_model/ctrv_motion_model.cpp
@@ -202,6 +202,9 @@ bool CTRVMotionModel::flipOrientation()
   ekf_.getP(P_t);
   X_t(IDX::YAW) = autoware_utils_math::normalize_radian(X_t(IDX::YAW) + M_PI);
   X_t(IDX::VEL) = -X_t(IDX::VEL);
+  // covariance transform T*P*T^T: negate the VEL cross-covariances
+  P_t.row(IDX::VEL) *= -1.0;
+  P_t.col(IDX::VEL) *= -1.0;
   ekf_.init(X_t, P_t);
   return true;
 }

--- a/perception/autoware_multi_object_tracker/lib/tracker/motion_model/ctrv_motion_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/motion_model/ctrv_motion_model.cpp
@@ -192,6 +192,21 @@ bool CTRVMotionModel::updateStatePoseHeadVel(
   return ekf_.update(Y, C, R);
 }
 
+// 180° heading flip of the raw state: rotate yaw by pi and negate the velocity.
+bool CTRVMotionModel::flipOrientation()
+{
+  if (!checkInitialized()) return false;
+
+  StateVec X_t;
+  StateMat P_t;
+  ekf_.getX(X_t);
+  ekf_.getP(P_t);
+  X_t(IDX::YAW) = autoware_utils_math::normalize_radian(X_t(IDX::YAW) + M_PI);
+  X_t(IDX::VEL) = -X_t(IDX::VEL);
+  ekf_.init(X_t, P_t);
+  return true;
+}
+
 bool CTRVMotionModel::limitStates()
 {
   StateVec X_t;

--- a/perception/autoware_multi_object_tracker/lib/tracker/motion_model/ctrv_motion_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/motion_model/ctrv_motion_model.cpp
@@ -192,7 +192,6 @@ bool CTRVMotionModel::updateStatePoseHeadVel(
   return ekf_.update(Y, C, R);
 }
 
-// 180° heading flip of the raw state: rotate yaw by pi and negate the velocity.
 bool CTRVMotionModel::flipOrientation()
 {
   if (!checkInitialized()) return false;

--- a/perception/autoware_multi_object_tracker/lib/tracker/trackers/multiple_vehicle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/trackers/multiple_vehicle_tracker.cpp
@@ -55,8 +55,8 @@ bool MultipleVehicleTracker::measure(
 // is authoritative.
 void MultipleVehicleTracker::alignOrientationSigns()
 {
-  const bool big_leads = std::abs(big_vehicle_tracker_.signBeliefLogOdds()) >=
-                         std::abs(normal_vehicle_tracker_.signBeliefLogOdds());
+  const bool big_leads =
+    big_vehicle_tracker_.signBeliefConfidence() >= normal_vehicle_tracker_.signBeliefConfidence();
   VehicleTracker & leader = big_leads ? big_vehicle_tracker_ : normal_vehicle_tracker_;
   VehicleTracker & follower = big_leads ? normal_vehicle_tracker_ : big_vehicle_tracker_;
   const double yaw_diff =

--- a/perception/autoware_multi_object_tracker/lib/tracker/trackers/multiple_vehicle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/trackers/multiple_vehicle_tracker.cpp
@@ -75,6 +75,7 @@ bool MultipleVehicleTracker::conditionedUpdate(
     measurement, prediction, measurement_time, channel_info);
   big_vehicle_tracker_.setLatestMeasurementTime(measurement_time);
   normal_vehicle_tracker_.setLatestMeasurementTime(measurement_time);
+  alignOrientationSigns();
 
   return true;
 }

--- a/perception/autoware_multi_object_tracker/lib/tracker/trackers/multiple_vehicle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/trackers/multiple_vehicle_tracker.cpp
@@ -16,6 +16,10 @@
 
 #include "autoware/multi_object_tracker/object_model/object_model.hpp"
 
+#include <autoware_utils_math/normalization.hpp>
+
+#include <cmath>
+
 namespace autoware::multi_object_tracker
 {
 MultipleVehicleTracker::MultipleVehicleTracker(
@@ -42,8 +46,24 @@ bool MultipleVehicleTracker::measure(
   normal_vehicle_tracker_.measure(object, time, channel_info);
   big_vehicle_tracker_.setLatestMeasurementTime(time);
   normal_vehicle_tracker_.setLatestMeasurementTime(time);
+  alignOrientationSigns();
 
   return true;
+}
+
+// Layers publish interchangeably and must agree on the heading sign; the stronger sign belief
+// is authoritative.
+void MultipleVehicleTracker::alignOrientationSigns()
+{
+  const bool big_leads = std::abs(big_vehicle_tracker_.signBeliefLogOdds()) >=
+                         std::abs(normal_vehicle_tracker_.signBeliefLogOdds());
+  VehicleTracker & leader = big_leads ? big_vehicle_tracker_ : normal_vehicle_tracker_;
+  VehicleTracker & follower = big_leads ? normal_vehicle_tracker_ : big_vehicle_tracker_;
+  const double yaw_diff =
+    autoware_utils_math::normalize_radian(leader.getYawState() - follower.getYawState());
+  if (std::abs(yaw_diff) > M_PI_2) {
+    follower.flipOrientationSign();
+  }
 }
 
 bool MultipleVehicleTracker::conditionedUpdate(

--- a/perception/autoware_multi_object_tracker/lib/tracker/trackers/pedestrian_and_bicycle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/trackers/pedestrian_and_bicycle_tracker.cpp
@@ -14,6 +14,10 @@
 
 #include "autoware/multi_object_tracker/tracker/trackers/pedestrian_and_bicycle_tracker.hpp"
 
+#include <autoware_utils_math/normalization.hpp>
+
+#include <cmath>
+
 namespace autoware::multi_object_tracker
 {
 PedestrianAndBicycleTracker::PedestrianAndBicycleTracker(
@@ -40,8 +44,19 @@ bool PedestrianAndBicycleTracker::measure(
   bicycle_tracker_.measure(object, time, channel_info);
   pedestrian_tracker_.setLatestMeasurementTime(time);
   bicycle_tracker_.setLatestMeasurementTime(time);
+  alignOrientationSigns();
 
   return true;
+}
+
+// Only the bicycle layer accumulates heading-sign evidence; the pedestrian layer follows it.
+void PedestrianAndBicycleTracker::alignOrientationSigns()
+{
+  const double yaw_diff = autoware_utils_math::normalize_radian(
+    bicycle_tracker_.getYawState() - pedestrian_tracker_.getYawState());
+  if (std::abs(yaw_diff) > M_PI_2) {
+    pedestrian_tracker_.flipOrientationSign();
+  }
 }
 
 bool PedestrianAndBicycleTracker::getTrackedObject(

--- a/perception/autoware_multi_object_tracker/lib/tracker/trackers/vehicle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/trackers/vehicle_tracker.cpp
@@ -292,12 +292,12 @@ bool VehicleTracker::measure(
   shape_model_.updateFootprint(
     corrected, time, has_pose ? std::make_optional(tracker_pose) : std::nullopt);
 
-  // Belief-driven 180° flip, enabled only at low speed where the reverse-velocity limit cannot
-  // correct the heading sign.
-  if (
-    sign_belief_.shouldFlip() &&
-    std::abs(motion_model_.getStateElement(IDX::U)) <
-      object_model_.orientation_sign_belief.flip_vel_limit) {
+  // The tracked longitudinal velocity votes on the heading-sign belief once per measurement.
+  sign_belief_.voteVelocity(motion_model_.getStateElement(IDX::U));
+
+  // Belief-driven 180° flip. Velocity evidence is part of the belief, so yaw votes decide the
+  // sign at low speed and the velocity sign decides above the par speed.
+  if (sign_belief_.shouldFlip()) {
     motion_model_.flipOrientation();
     if (shape_model_.isFootprintValid()) {
       shape_model_.flipFootprintXY();

--- a/perception/autoware_multi_object_tracker/lib/tracker/trackers/vehicle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/trackers/vehicle_tracker.cpp
@@ -63,7 +63,8 @@ VehicleTracker::VehicleTracker(
   logger_(rclcpp::get_logger("VehicleTracker")),
   object_model_(object_model),
   shape_model_(object_model),
-  shape_update_anchor_(BicycleMotionModel::LengthUpdateAnchor::CENTER)
+  shape_update_anchor_(BicycleMotionModel::LengthUpdateAnchor::CENTER),
+  sign_belief_(object_model.orientation_sign_belief, object.kinematics.orientation_availability)
 {
   // set tracker type based on object model
   switch (object_model.type) {
@@ -202,11 +203,13 @@ bool VehicleTracker::updateKinematics(
     }
     const double pre_limit_yaw = motion_model_.getYawState();
     motion_model_.limitStates();
-    // Flip stored footprint when yaw-limit correction reverses heading by 180°
-    if (shape_model_.isFootprintValid()) {
-      const double yaw_diff =
-        autoware_utils_math::normalize_radian(motion_model_.getYawState() - pre_limit_yaw);
-      if (std::abs(yaw_diff) > M_PI_2) {
+    // A yaw-limit correction reversing the heading by 180° also negates the sign belief and
+    // flips the stored footprint.
+    const double limit_yaw_diff =
+      autoware_utils_math::normalize_radian(motion_model_.getYawState() - pre_limit_yaw);
+    if (std::abs(limit_yaw_diff) > M_PI_2) {
+      sign_belief_.onFlipped();
+      if (shape_model_.isFootprintValid()) {
         shape_model_.flipFootprintXY();
       }
     }
@@ -260,7 +263,19 @@ bool VehicleTracker::measure(
       dt);
   }
 
-  const types::DynamicObject corrected = normalizeYaw(in_object, motion_model_.getYawState());
+  // The raw yaw sign votes on the heading-sign belief before normalization discards it.
+  const double tracker_yaw = motion_model_.getYawState();
+  if (
+    in_object.kinematics.orientation_availability != types::OrientationAvailability::UNAVAILABLE &&
+    channel_info.trust_orientation) {
+    const double raw_yaw_diff = autoware_utils_math::normalize_radian(
+      tf2::getYaw(in_object.pose.orientation) - tracker_yaw);
+    sign_belief_.vote(
+      raw_yaw_diff,
+      in_object.kinematics.orientation_availability == types::OrientationAvailability::AVAILABLE);
+  }
+
+  const types::DynamicObject corrected = normalizeYaw(in_object, tracker_yaw);
 
   const bool is_bbox = (corrected.shape.type == autoware_perception_msgs::msg::Shape::BOUNDING_BOX);
   updateKinematics(corrected, channel_info);
@@ -276,6 +291,19 @@ bool VehicleTracker::measure(
     motion_model_.getPredictedState(time, tracker_pose, dummy_cov, dummy_twist, dummy_cov);
   shape_model_.updateFootprint(
     corrected, time, has_pose ? std::make_optional(tracker_pose) : std::nullopt);
+
+  // Belief-driven 180° flip, enabled only at low speed where the reverse-velocity limit cannot
+  // correct the heading sign.
+  if (
+    sign_belief_.shouldFlip() &&
+    std::abs(motion_model_.getStateElement(IDX::U)) <
+      object_model_.orientation_sign_belief.flip_vel_limit) {
+    motion_model_.flipOrientation();
+    if (shape_model_.isFootprintValid()) {
+      shape_model_.flipFootprintXY();
+    }
+    sign_belief_.onFlipped();
+  }
 
   shape_update_anchor_ = BicycleMotionModel::LengthUpdateAnchor::CENTER;
   removeCache();

--- a/perception/autoware_multi_object_tracker/lib/tracker/trackers/vehicle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/trackers/vehicle_tracker.cpp
@@ -281,17 +281,20 @@ bool VehicleTracker::measure(
   shape_model_.updateFootprint(
     corrected, time, has_pose ? std::make_optional(tracker_pose) : std::nullopt);
 
-  // Belief-driven 180° flip on the fused posterior: yaw votes decide the sign at low speed and
-  // the instantaneous velocity sign decides above the par speed.
+  evaluateSignFlip(time);
+
+  shape_update_anchor_ = BicycleMotionModel::LengthUpdateAnchor::CENTER;
+  removeCache();
+  return true;
+}
+
+void VehicleTracker::evaluateSignFlip(const rclcpp::Time & time)
+{
   const double vel_long = motion_model_.getStateElement(IDX::U);
   const double vel_var = motion_model_.getCovarianceElement(IDX::U, IDX::U);
   if (sign_belief_.shouldFlip(time, vel_long, vel_var)) {
     flipOrientationSign();
   }
-
-  shape_update_anchor_ = BicycleMotionModel::LengthUpdateAnchor::CENTER;
-  removeCache();
-  return true;
 }
 
 // 180° heading flip of the full tracker state: motion model, stored footprint, and sign belief.
@@ -372,6 +375,8 @@ bool VehicleTracker::conditionedUpdate(
     shape_model_.updateFootprint(
       measurement, measurement_time, has_pose ? std::make_optional(tracker_pose) : std::nullopt);
 
+    evaluateSignFlip(measurement_time);
+
     shape_update_anchor_ = BicycleMotionModel::LengthUpdateAnchor::CENTER;
     removeCache();
     return true;
@@ -388,6 +393,8 @@ bool VehicleTracker::conditionedUpdate(
     measurement_time, tracker_pose, dummy_cov, dummy_twist, dummy_cov);
   shape_model_.updateFootprint(
     measurement, measurement_time, has_pose ? std::make_optional(tracker_pose) : std::nullopt);
+
+  evaluateSignFlip(measurement_time);
 
   shape_update_anchor_ = BicycleMotionModel::LengthUpdateAnchor::CENTER;
   removeCache();

--- a/perception/autoware_multi_object_tracker/lib/tracker/trackers/vehicle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/trackers/vehicle_tracker.cpp
@@ -297,11 +297,7 @@ bool VehicleTracker::measure(
   // Belief-driven 180° flip. Velocity evidence is part of the belief, so yaw votes decide the
   // sign at low speed and the velocity sign decides above the par speed.
   if (sign_belief_.shouldFlip()) {
-    motion_model_.flipOrientation();
-    if (shape_model_.isFootprintValid()) {
-      shape_model_.flipFootprintXY();
-    }
-    sign_belief_.onFlipped();
+    flipOrientationSign();
     RCLCPP_INFO(
       logger_, "SignBelief[%s] belief flip: log_odds=%.3f", getUuidString().c_str(),
       sign_belief_.logOdds());
@@ -310,6 +306,17 @@ bool VehicleTracker::measure(
   shape_update_anchor_ = BicycleMotionModel::LengthUpdateAnchor::CENTER;
   removeCache();
   return true;
+}
+
+// 180° heading flip of the full tracker state: motion model, stored footprint, and sign belief.
+void VehicleTracker::flipOrientationSign()
+{
+  motion_model_.flipOrientation();
+  if (shape_model_.isFootprintValid()) {
+    shape_model_.flipFootprintXY();
+  }
+  sign_belief_.onFlipped();
+  removeCache();
 }
 
 bool VehicleTracker::getMotionState(

--- a/perception/autoware_multi_object_tracker/lib/tracker/trackers/vehicle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/trackers/vehicle_tracker.cpp
@@ -201,18 +201,7 @@ bool VehicleTracker::updateKinematics(
     } else {
       is_updated = motion_model_.updateStatePose(x, y, object.pose_covariance, length);
     }
-    const double pre_limit_yaw = motion_model_.getYawState();
     motion_model_.limitStates();
-    // A yaw-limit correction reversing the heading by 180° also negates the sign belief and
-    // flips the stored footprint.
-    const double limit_yaw_diff =
-      autoware_utils_math::normalize_radian(motion_model_.getYawState() - pre_limit_yaw);
-    if (std::abs(limit_yaw_diff) > M_PI_2) {
-      sign_belief_.onFlipped();
-      if (shape_model_.isFootprintValid()) {
-        shape_model_.flipFootprintXY();
-      }
-    }
   }
 
   // Low-pass filter on z position (2D motion model does not track z).
@@ -273,6 +262,11 @@ bool VehicleTracker::measure(
     sign_belief_.vote(
       raw_yaw_diff,
       in_object.kinematics.orientation_availability == types::OrientationAvailability::AVAILABLE);
+    RCLCPP_INFO(
+      logger_, "SignBelief[%s] yaw vote: yaw_diff=%.3f sign_known=%d log_odds=%.3f",
+      getUuidString().c_str(), raw_yaw_diff,
+      in_object.kinematics.orientation_availability == types::OrientationAvailability::AVAILABLE,
+      sign_belief_.logOdds());
   }
 
   const types::DynamicObject corrected = normalizeYaw(in_object, tracker_yaw);
@@ -293,7 +287,12 @@ bool VehicleTracker::measure(
     corrected, time, has_pose ? std::make_optional(tracker_pose) : std::nullopt);
 
   // The tracked longitudinal velocity votes on the heading-sign belief once per measurement.
-  sign_belief_.voteVelocity(motion_model_.getStateElement(IDX::U));
+  const double vel_long = motion_model_.getStateElement(IDX::U);
+  const double vel_var = motion_model_.getCovarianceElement(IDX::U, IDX::U);
+  sign_belief_.voteVelocity(vel_long, vel_var);
+  RCLCPP_INFO(
+    logger_, "SignBelief[%s] velocity vote: vel_long=%.3f vel_var=%.3f log_odds=%.3f",
+    getUuidString().c_str(), vel_long, vel_var, sign_belief_.logOdds());
 
   // Belief-driven 180° flip. Velocity evidence is part of the belief, so yaw votes decide the
   // sign at low speed and the velocity sign decides above the par speed.
@@ -303,6 +302,9 @@ bool VehicleTracker::measure(
       shape_model_.flipFootprintXY();
     }
     sign_belief_.onFlipped();
+    RCLCPP_INFO(
+      logger_, "SignBelief[%s] belief flip: log_odds=%.3f", getUuidString().c_str(),
+      sign_belief_.logOdds());
   }
 
   shape_update_anchor_ = BicycleMotionModel::LengthUpdateAnchor::CENTER;

--- a/perception/autoware_multi_object_tracker/lib/tracker/trackers/vehicle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/trackers/vehicle_tracker.cpp
@@ -64,8 +64,7 @@ VehicleTracker::VehicleTracker(
   object_model_(object_model),
   shape_model_(object_model),
   shape_update_anchor_(BicycleMotionModel::LengthUpdateAnchor::CENTER),
-  sign_belief_(
-    object_model.orientation_sign_belief, object.kinematics.orientation_availability, time)
+  sign_belief_(object.kinematics.orientation_availability, time)
 {
   // set tracker type based on object model
   switch (object_model.type) {

--- a/perception/autoware_multi_object_tracker/lib/tracker/trackers/vehicle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/trackers/vehicle_tracker.cpp
@@ -64,7 +64,8 @@ VehicleTracker::VehicleTracker(
   object_model_(object_model),
   shape_model_(object_model),
   shape_update_anchor_(BicycleMotionModel::LengthUpdateAnchor::CENTER),
-  sign_belief_(object_model.orientation_sign_belief, object.kinematics.orientation_availability)
+  sign_belief_(
+    object_model.orientation_sign_belief, object.kinematics.orientation_availability, time)
 {
   // set tracker type based on object model
   switch (object_model.type) {
@@ -257,16 +258,11 @@ bool VehicleTracker::measure(
   if (
     in_object.kinematics.orientation_availability != types::OrientationAvailability::UNAVAILABLE &&
     channel_info.trust_orientation) {
-    const double raw_yaw_diff = autoware_utils_math::normalize_radian(
-      tf2::getYaw(in_object.pose.orientation) - tracker_yaw);
+    const double raw_yaw_diff =
+      autoware_utils_math::normalize_radian(tf2::getYaw(in_object.pose.orientation) - tracker_yaw);
     sign_belief_.vote(
-      raw_yaw_diff,
+      time, raw_yaw_diff,
       in_object.kinematics.orientation_availability == types::OrientationAvailability::AVAILABLE);
-    RCLCPP_INFO(
-      logger_, "SignBelief[%s] yaw vote: yaw_diff=%.3f sign_known=%d log_odds=%.3f",
-      getUuidString().c_str(), raw_yaw_diff,
-      in_object.kinematics.orientation_availability == types::OrientationAvailability::AVAILABLE,
-      sign_belief_.logOdds());
   }
 
   const types::DynamicObject corrected = normalizeYaw(in_object, tracker_yaw);
@@ -286,21 +282,12 @@ bool VehicleTracker::measure(
   shape_model_.updateFootprint(
     corrected, time, has_pose ? std::make_optional(tracker_pose) : std::nullopt);
 
-  // The tracked longitudinal velocity votes on the heading-sign belief once per measurement.
+  // Belief-driven 180° flip on the fused posterior: yaw votes decide the sign at low speed and
+  // the instantaneous velocity sign decides above the par speed.
   const double vel_long = motion_model_.getStateElement(IDX::U);
   const double vel_var = motion_model_.getCovarianceElement(IDX::U, IDX::U);
-  sign_belief_.voteVelocity(vel_long, vel_var);
-  RCLCPP_INFO(
-    logger_, "SignBelief[%s] velocity vote: vel_long=%.3f vel_var=%.3f log_odds=%.3f",
-    getUuidString().c_str(), vel_long, vel_var, sign_belief_.logOdds());
-
-  // Belief-driven 180° flip. Velocity evidence is part of the belief, so yaw votes decide the
-  // sign at low speed and the velocity sign decides above the par speed.
-  if (sign_belief_.shouldFlip()) {
+  if (sign_belief_.shouldFlip(time, vel_long, vel_var)) {
     flipOrientationSign();
-    RCLCPP_INFO(
-      logger_, "SignBelief[%s] belief flip: log_odds=%.3f", getUuidString().c_str(),
-      sign_belief_.logOdds());
   }
 
   shape_update_anchor_ = BicycleMotionModel::LengthUpdateAnchor::CENTER;

--- a/perception/autoware_multi_object_tracker/test/test_vehicle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/test/test_vehicle_tracker.cpp
@@ -14,6 +14,7 @@
 
 #include "autoware/multi_object_tracker/object_model/object_model.hpp"
 #include "autoware/multi_object_tracker/tracker/motion_model/bicycle_motion_model.hpp"
+#include "autoware/multi_object_tracker/tracker/trackers/pedestrian_and_bicycle_tracker.hpp"
 #include "autoware/multi_object_tracker/tracker/trackers/vehicle_tracker.hpp"
 #include "autoware/multi_object_tracker/tracker/update/orientation_sign_belief.hpp"
 #include "autoware/multi_object_tracker/tracker/update/vehicle_update_strategy.hpp"
@@ -679,6 +680,32 @@ TEST(VehicleTrackerSignFlip, OpposedVotesFlipSlowTracker)
   const double deviation =
     std::abs(autoware_utils_math::normalize_radian(trackedYaw(tracker, time) - M_PI));
   EXPECT_LT(deviation, 0.1);
+}
+
+// Composite layers agree on the heading sign: the pedestrian layer never measures yaw, so a
+// bicycle-layer belief flip must carry over to the published pedestrian heading.
+TEST(PedestrianAndBicycleTrackerSignFlip, PedestrianLayerFollowsBicycleSign)
+{
+  const types::InputChannel channel{};
+  const rclcpp::Time start(0, 0, RCL_ROS_TIME);
+  auto detection = makeVehicleDetection(start, 0.0);
+  detection.classification = {{classes::Label::PEDESTRIAN, 1.0F}};
+  PedestrianAndBicycleTracker tracker(start, detection);
+
+  rclcpp::Time time = start;
+  for (int i = 1; i <= 6; ++i) {
+    time = start + rclcpp::Duration::from_seconds(0.1 * i);
+    tracker.predict(time);
+    auto measurement = makeVehicleDetection(time, M_PI);
+    measurement.classification = detection.classification;
+    tracker.measure(measurement, time, channel);
+  }
+
+  types::DynamicObject tracked;
+  ASSERT_TRUE(tracker.getTrackedObject(time, tracked));
+  const double deviation =
+    std::abs(autoware_utils_math::normalize_radian(tf2::getYaw(tracked.pose.orientation) - M_PI));
+  EXPECT_LT(deviation, M_PI_2);
 }
 
 }  // namespace autoware::multi_object_tracker

--- a/perception/autoware_multi_object_tracker/test/test_vehicle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/test/test_vehicle_tracker.cpp
@@ -14,10 +14,17 @@
 
 #include "autoware/multi_object_tracker/object_model/object_model.hpp"
 #include "autoware/multi_object_tracker/tracker/motion_model/bicycle_motion_model.hpp"
+#include "autoware/multi_object_tracker/tracker/trackers/vehicle_tracker.hpp"
+#include "autoware/multi_object_tracker/tracker/update/orientation_sign_belief.hpp"
 #include "autoware/multi_object_tracker/tracker/update/vehicle_update_strategy.hpp"
+#include "autoware/multi_object_tracker/types.hpp"
 
 #include <Eigen/Eigenvalues>
 #include <autoware_utils_geometry/msg/covariance.hpp>
+#include <autoware_utils_math/normalization.hpp>
+#include <tf2/utils.hpp>
+
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 #include <gtest/gtest.h>
 
@@ -399,6 +406,239 @@ TEST(ExportedPoseCovariance, PositiveSemiDefinite)
   Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> solver(exportedPoseBlock(makeEvolvedVehicle()));
   ASSERT_EQ(solver.info(), Eigen::Success);
   EXPECT_GE(solver.eigenvalues().minCoeff(), -1e-12);
+}
+
+// ---------------------------------------------------------------------------------------------
+// OrientationSignBelief — log-odds heading-sign evidence with flip hysteresis.
+// ---------------------------------------------------------------------------------------------
+namespace
+{
+const object_model::OrientationSignBelief & beliefParams()
+{
+  return object_model::normal_vehicle.orientation_sign_belief;
+}
+
+OrientationSignBelief seededBelief(const types::OrientationAvailability availability)
+{
+  return OrientationSignBelief(beliefParams(), availability);
+}
+}  // namespace
+
+// The seeding detection counts as one agreeing vote, weighted by its availability.
+TEST(OrientationSignBelief, SeedPerAvailability)
+{
+  EXPECT_DOUBLE_EQ(seededBelief(types::OrientationAvailability::UNAVAILABLE).logOdds(), 0.0);
+  EXPECT_DOUBLE_EQ(
+    seededBelief(types::OrientationAvailability::SIGN_UNKNOWN).logOdds(),
+    beliefParams().vote_sign_unknown);
+  EXPECT_DOUBLE_EQ(
+    seededBelief(types::OrientationAvailability::AVAILABLE).logOdds(),
+    beliefParams().vote_available);
+}
+
+// Repeated agreeing/disagreeing votes saturate at the clamp bounds.
+TEST(OrientationSignBelief, AccumulationClampsAtBounds)
+{
+  auto belief = seededBelief(types::OrientationAvailability::SIGN_UNKNOWN);
+  for (int i = 0; i < 20; ++i) {
+    belief.vote(0.0, false);
+  }
+  EXPECT_DOUBLE_EQ(belief.logOdds(), beliefParams().log_odds_max);
+
+  for (int i = 0; i < 40; ++i) {
+    belief.vote(M_PI, false);
+  }
+  EXPECT_DOUBLE_EQ(belief.logOdds(), -beliefParams().log_odds_max);
+}
+
+// Near-perpendicular measurements fall in the dead zone and leave the belief unchanged.
+TEST(OrientationSignBelief, DeadZoneSkipsVote)
+{
+  auto belief = seededBelief(types::OrientationAvailability::SIGN_UNKNOWN);
+  const double before = belief.logOdds();
+  belief.vote(M_PI * 75.0 / 180.0, false);
+  belief.vote(-M_PI * 105.0 / 180.0, false);
+  EXPECT_DOUBLE_EQ(belief.logOdds(), before);
+}
+
+// AVAILABLE votes carry the stronger weight.
+TEST(OrientationSignBelief, AvailableVotesWeighMore)
+{
+  auto belief = seededBelief(types::OrientationAvailability::UNAVAILABLE);
+  belief.vote(M_PI, true);
+  EXPECT_DOUBLE_EQ(belief.logOdds(), -beliefParams().vote_available);
+  EXPECT_GT(beliefParams().vote_available, beliefParams().vote_sign_unknown);
+}
+
+// The flip fires only past -flip_threshold, and negation on flip restores a trusted belief.
+TEST(OrientationSignBelief, FlipTriggerAndNegation)
+{
+  auto belief = seededBelief(types::OrientationAvailability::SIGN_UNKNOWN);
+  belief.vote(M_PI, false);
+  belief.vote(M_PI, false);
+  EXPECT_FALSE(belief.shouldFlip());  // -1.1 > -2.0
+  belief.vote(M_PI, false);
+  EXPECT_TRUE(belief.shouldFlip());  // -2.2 < -2.0
+
+  belief.onFlipped();
+  EXPECT_DOUBLE_EQ(belief.logOdds(), 2.0 * beliefParams().vote_sign_unknown);
+  EXPECT_FALSE(belief.shouldFlip());
+}
+
+// Alternating votes after a flip stay within one weight of the post-flip belief and can never
+// traverse from +flip_threshold to -flip_threshold.
+TEST(OrientationSignBelief, NoOscillationUnderAlternatingVotes)
+{
+  auto belief = seededBelief(types::OrientationAvailability::SIGN_UNKNOWN);
+  for (int i = 0; i < 3; ++i) {
+    belief.vote(M_PI, false);
+  }
+  ASSERT_TRUE(belief.shouldFlip());
+  belief.onFlipped();
+
+  for (int i = 0; i < 50; ++i) {
+    belief.vote(i % 2 == 0 ? M_PI : 0.0, false);
+    EXPECT_FALSE(belief.shouldFlip());
+  }
+}
+
+// ---------------------------------------------------------------------------------------------
+// BicycleMotionModel::flipOrientation — 180° heading flip of the raw state.
+// ---------------------------------------------------------------------------------------------
+namespace
+{
+void rawState(
+  const BicycleMotionModel & model, BicycleMotionModel::StateVec & x,
+  BicycleMotionModel::StateMat & p)
+{
+  model.MotionModel<6>::getPredictedState(evolvedTime(), x, p);
+}
+}  // namespace
+
+// The flip swaps the axle points and negates the longitudinal velocity; heading rotates by pi
+// while the wheelbase (and thus the tracked length) is preserved.
+TEST(FlipOrientation, SwapsAxlesAndReversesVelocity)
+{
+  BicycleMotionModel model = makeEvolvedVehicle();
+  BicycleMotionModel::StateVec x_before;
+  BicycleMotionModel::StateMat p_before;
+  rawState(model, x_before, p_before);
+  const double yaw_before = model.getYawState();
+  const double length_before = model.getLength();
+
+  EXPECT_TRUE(model.flipOrientation());
+
+  BicycleMotionModel::StateVec x_after;
+  BicycleMotionModel::StateMat p_after;
+  rawState(model, x_after, p_after);
+
+  const double yaw_jump =
+    autoware_utils_math::normalize_radian(model.getYawState() - yaw_before);
+  EXPECT_NEAR(std::abs(yaw_jump), M_PI, 1e-12);
+  EXPECT_DOUBLE_EQ(model.getLength(), length_before);
+
+  EXPECT_DOUBLE_EQ(x_after(BicycleMotionModel::X1), x_before(BicycleMotionModel::X2));
+  EXPECT_DOUBLE_EQ(x_after(BicycleMotionModel::Y1), x_before(BicycleMotionModel::Y2));
+  EXPECT_DOUBLE_EQ(x_after(BicycleMotionModel::X2), x_before(BicycleMotionModel::X1));
+  EXPECT_DOUBLE_EQ(x_after(BicycleMotionModel::Y2), x_before(BicycleMotionModel::Y1));
+  EXPECT_DOUBLE_EQ(x_after(BicycleMotionModel::U), -x_before(BicycleMotionModel::U));
+  EXPECT_DOUBLE_EQ(x_after(BicycleMotionModel::V), x_before(BicycleMotionModel::V));
+
+  EXPECT_DOUBLE_EQ(
+    p_after(BicycleMotionModel::X1, BicycleMotionModel::X1),
+    p_before(BicycleMotionModel::X2, BicycleMotionModel::X2));
+  EXPECT_DOUBLE_EQ(
+    p_after(BicycleMotionModel::Y2, BicycleMotionModel::Y2),
+    p_before(BicycleMotionModel::Y1, BicycleMotionModel::Y1));
+  EXPECT_DOUBLE_EQ(
+    p_after(BicycleMotionModel::X1, BicycleMotionModel::U),
+    p_before(BicycleMotionModel::X2, BicycleMotionModel::U));
+}
+
+// The flip is an involution: applying it twice restores state and covariance exactly.
+TEST(FlipOrientation, DoubleFlipRestoresState)
+{
+  BicycleMotionModel model = makeEvolvedVehicle();
+  BicycleMotionModel::StateVec x_before;
+  BicycleMotionModel::StateMat p_before;
+  rawState(model, x_before, p_before);
+
+  EXPECT_TRUE(model.flipOrientation());
+  EXPECT_TRUE(model.flipOrientation());
+
+  BicycleMotionModel::StateVec x_after;
+  BicycleMotionModel::StateMat p_after;
+  rawState(model, x_after, p_after);
+  EXPECT_TRUE(x_after.isApprox(x_before, 1e-15));
+  EXPECT_TRUE(p_after.isApprox(p_before, 1e-15));
+}
+
+// ---------------------------------------------------------------------------------------------
+// VehicleTracker heading-sign flip — SIGN_UNKNOWN detections opposing the tracked heading
+// accumulate belief and flip a slow tracker.
+// ---------------------------------------------------------------------------------------------
+namespace
+{
+types::DynamicObject makeVehicleDetection(const rclcpp::Time & time, const double yaw)
+{
+  types::DynamicObject object;
+  object.time = time;
+  object.channel_index = 0;
+  object.existence_probability = 0.9f;
+  object.kinematics.orientation_availability = types::OrientationAvailability::SIGN_UNKNOWN;
+  object.pose.position.x = 10.0;
+  object.pose.position.y = 5.0;
+  object.pose.position.z = 0.9;
+  tf2::Quaternion q;
+  q.setRPY(0.0, 0.0, yaw);
+  object.pose.orientation = tf2::toMsg(q);
+  object.pose_covariance = {};
+  object.pose_covariance[XYZRPY_COV_IDX::X_X] = 0.16;
+  object.pose_covariance[XYZRPY_COV_IDX::Y_Y] = 0.16;
+  object.pose_covariance[XYZRPY_COV_IDX::YAW_YAW] = 0.15;
+  object.twist_covariance = {};
+  object.shape.type = autoware_perception_msgs::msg::Shape::BOUNDING_BOX;
+  object.shape.dimensions.x = 4.5;
+  object.shape.dimensions.y = 2.0;
+  object.shape.dimensions.z = 1.8;
+  object.trust_extension = true;
+  return object;
+}
+
+double trackedYaw(const VehicleTracker & tracker, const rclcpp::Time & time)
+{
+  types::DynamicObject tracked;
+  EXPECT_TRUE(tracker.getTrackedObject(time, tracked));
+  return tf2::getYaw(tracked.pose.orientation);
+}
+}  // namespace
+
+// A stationary tracker seeded with the wrong sign flips once opposing SIGN_UNKNOWN votes cross
+// the threshold (seed +w, then -w per frame: below -2.0 on the third), and stays flipped.
+TEST(VehicleTrackerSignFlip, OpposedVotesFlipSlowTracker)
+{
+  const types::InputChannel channel{};
+  const rclcpp::Time start(0, 0, RCL_ROS_TIME);
+  VehicleTracker tracker(object_model::normal_vehicle, start, makeVehicleDetection(start, 0.0));
+
+  int flipped_at = -1;
+  rclcpp::Time time = start;
+  for (int i = 1; i <= 6; ++i) {
+    time = start + rclcpp::Duration::from_seconds(0.1 * i);
+    tracker.predict(time);
+    tracker.measure(makeVehicleDetection(time, M_PI), time, channel);
+    const double deviation =
+      std::abs(autoware_utils_math::normalize_radian(trackedYaw(tracker, time) - M_PI));
+    if (flipped_at < 0 && deviation < M_PI_2) {
+      flipped_at = i;
+    }
+  }
+  EXPECT_EQ(flipped_at, 3);
+
+  // Agreeing frames after the flip keep the corrected heading.
+  const double deviation =
+    std::abs(autoware_utils_math::normalize_radian(trackedYaw(tracker, time) - M_PI));
+  EXPECT_LT(deviation, 0.1);
 }
 
 }  // namespace autoware::multi_object_tracker

--- a/perception/autoware_multi_object_tracker/test/test_vehicle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/test/test_vehicle_tracker.cpp
@@ -414,9 +414,10 @@ TEST(ExportedPoseCovariance, PositiveSemiDefinite)
 // ---------------------------------------------------------------------------------------------
 namespace
 {
-const object_model::OrientationSignBelief & beliefParams()
+const OrientationSignBelief::Params & beliefParams()
 {
-  return object_model::normal_vehicle.orientation_sign_belief;
+  static const OrientationSignBelief::Params params{};
+  return params;
 }
 
 rclcpp::Time beliefTime(const double seconds = 0.0)
@@ -426,7 +427,7 @@ rclcpp::Time beliefTime(const double seconds = 0.0)
 
 OrientationSignBelief seededBelief(const types::OrientationAvailability availability)
 {
-  return OrientationSignBelief(beliefParams(), availability, beliefTime());
+  return OrientationSignBelief(availability, beliefTime(), beliefParams());
 }
 
 // Expected posterior of one KF update with measurement z and noise r from prior (0, Q).

--- a/perception/autoware_multi_object_tracker/test/test_vehicle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/test/test_vehicle_tracker.cpp
@@ -410,7 +410,7 @@ TEST(ExportedPoseCovariance, PositiveSemiDefinite)
 }
 
 // ---------------------------------------------------------------------------------------------
-// OrientationSignBelief — log-odds heading-sign evidence with flip hysteresis.
+// OrientationSignBelief — OU-Kalman yaw-sign evidence fused with velocity-sign evidence.
 // ---------------------------------------------------------------------------------------------
 namespace
 {
@@ -419,127 +419,150 @@ const object_model::OrientationSignBelief & beliefParams()
   return object_model::normal_vehicle.orientation_sign_belief;
 }
 
+rclcpp::Time beliefTime(const double seconds = 0.0)
+{
+  return rclcpp::Time(0, 0, RCL_ROS_TIME) + rclcpp::Duration::from_seconds(seconds);
+}
+
 OrientationSignBelief seededBelief(const types::OrientationAvailability availability)
 {
-  return OrientationSignBelief(beliefParams(), availability);
+  return OrientationSignBelief(beliefParams(), availability, beliefTime());
+}
+
+// Expected posterior of one KF update with measurement z and noise r from prior (0, Q).
+double seedAgreement(const double r)
+{
+  const double q = beliefParams().stationary_var;
+  return q / (q + r);
 }
 }  // namespace
 
 // The seeding detection counts as one agreeing vote, weighted by its availability.
 TEST(OrientationSignBelief, SeedPerAvailability)
 {
-  EXPECT_DOUBLE_EQ(seededBelief(types::OrientationAvailability::UNAVAILABLE).logOdds(), 0.0);
+  const auto unavailable = seededBelief(types::OrientationAvailability::UNAVAILABLE);
+  EXPECT_DOUBLE_EQ(unavailable.agreement(), 0.0);
+  EXPECT_DOUBLE_EQ(unavailable.variance(), beliefParams().stationary_var);
   EXPECT_DOUBLE_EQ(
-    seededBelief(types::OrientationAvailability::SIGN_UNKNOWN).logOdds(),
-    beliefParams().vote_sign_unknown);
+    seededBelief(types::OrientationAvailability::SIGN_UNKNOWN).agreement(),
+    seedAgreement(beliefParams().r_yaw_sign_unknown));
   EXPECT_DOUBLE_EQ(
-    seededBelief(types::OrientationAvailability::AVAILABLE).logOdds(),
-    beliefParams().vote_available);
+    seededBelief(types::OrientationAvailability::AVAILABLE).agreement(),
+    seedAgreement(beliefParams().r_yaw_available));
 }
 
-// Repeated agreeing/disagreeing votes saturate at the clamp bounds.
-TEST(OrientationSignBelief, AccumulationClampsAtBounds)
+// AVAILABLE votes carry more information than SIGN_UNKNOWN votes.
+TEST(OrientationSignBelief, AvailableVotesWeighMore)
 {
-  auto belief = seededBelief(types::OrientationAvailability::SIGN_UNKNOWN);
-  for (int i = 0; i < 20; ++i) {
-    belief.vote(0.0, false);
-  }
-  EXPECT_DOUBLE_EQ(belief.logOdds(), beliefParams().log_odds_max);
-
-  for (int i = 0; i < 40; ++i) {
-    belief.vote(M_PI, false);
-  }
-  EXPECT_DOUBLE_EQ(belief.logOdds(), -beliefParams().log_odds_max);
+  auto available = seededBelief(types::OrientationAvailability::UNAVAILABLE);
+  available.vote(beliefTime(), 0.0, true);
+  auto sign_unknown = seededBelief(types::OrientationAvailability::UNAVAILABLE);
+  sign_unknown.vote(beliefTime(), 0.0, false);
+  EXPECT_GT(available.agreement(), sign_unknown.agreement());
+  EXPECT_GT(sign_unknown.agreement(), 0.0);
+  EXPECT_LT(available.variance(), sign_unknown.variance());
 }
 
 // Near-perpendicular measurements fall in the dead zone and leave the belief unchanged.
 TEST(OrientationSignBelief, DeadZoneSkipsVote)
 {
   auto belief = seededBelief(types::OrientationAvailability::SIGN_UNKNOWN);
-  const double before = belief.logOdds();
-  belief.vote(M_PI * 75.0 / 180.0, false);
-  belief.vote(-M_PI * 105.0 / 180.0, false);
-  EXPECT_DOUBLE_EQ(belief.logOdds(), before);
+  const double before = belief.agreement();
+  belief.vote(beliefTime(), M_PI * 75.0 / 180.0, false);
+  belief.vote(beliefTime(), -M_PI * 105.0 / 180.0, false);
+  EXPECT_DOUBLE_EQ(belief.agreement(), before);
 }
 
-// AVAILABLE votes carry the stronger weight.
-TEST(OrientationSignBelief, AvailableVotesWeighMore)
+// Same-time contradicting votes fuse batch-equivalently: the posterior is independent of the
+// processing order, and a mixed frame pulls weaker than a unanimous one.
+TEST(OrientationSignBelief, SimultaneousVotesCompensate)
 {
-  auto belief = seededBelief(types::OrientationAvailability::UNAVAILABLE);
-  belief.vote(M_PI, true);
-  EXPECT_DOUBLE_EQ(belief.logOdds(), -beliefParams().vote_available);
-  EXPECT_GT(beliefParams().vote_available, beliefParams().vote_sign_unknown);
-}
-
-// A velocity vote weighs linearly with speed and matches an AVAILABLE yaw vote at the par speed.
-TEST(OrientationSignBelief, VelocityVoteScalesWithSpeed)
-{
-  auto belief = seededBelief(types::OrientationAvailability::UNAVAILABLE);
-  belief.voteVelocity(-beliefParams().vote_vel_par, 0.0);
-  EXPECT_DOUBLE_EQ(belief.logOdds(), -beliefParams().vote_available);
-
-  auto slow = seededBelief(types::OrientationAvailability::UNAVAILABLE);
-  slow.voteVelocity(-0.1 * beliefParams().vote_vel_par, 0.0);
-  EXPECT_DOUBLE_EQ(slow.logOdds(), -0.1 * beliefParams().vote_available);
-}
-
-// The velocity vote is discounted by the estimate variance: half weight at vote_vel_var, near
-// zero for a poorly converged velocity.
-TEST(OrientationSignBelief, VelocityVarianceWeakensVote)
-{
-  auto halved = seededBelief(types::OrientationAvailability::UNAVAILABLE);
-  halved.voteVelocity(-beliefParams().vote_vel_par, beliefParams().vote_vel_var);
-  EXPECT_DOUBLE_EQ(halved.logOdds(), -0.5 * beliefParams().vote_available);
-
-  auto uncertain = seededBelief(types::OrientationAvailability::UNAVAILABLE);
-  uncertain.voteVelocity(-beliefParams().vote_vel_par, 1e3 * beliefParams().vote_vel_var);
-  EXPECT_NEAR(uncertain.logOdds(), 0.0, 1e-2 * beliefParams().vote_available);
-}
-
-// Against an agreeing AVAILABLE yaw vote, reverse motion below the par speed keeps the sign
-// (parked vehicles maneuver in reverse) while reverse motion above it drives the belief negative.
-TEST(OrientationSignBelief, ParSpeedSetsYawVelocityPriority)
-{
-  auto slow = seededBelief(types::OrientationAvailability::UNAVAILABLE);
-  slow.vote(0.0, true);
-  slow.voteVelocity(-0.5 * beliefParams().vote_vel_par, 0.0);
-  EXPECT_GT(slow.logOdds(), 0.0);
-
-  auto fast = seededBelief(types::OrientationAvailability::UNAVAILABLE);
-  fast.vote(0.0, true);
-  fast.voteVelocity(-2.0 * beliefParams().vote_vel_par, 0.0);
-  EXPECT_LT(fast.logOdds(), 0.0);
-}
-
-// The flip fires only past -flip_threshold, and negation on flip restores a trusted belief.
-TEST(OrientationSignBelief, FlipTriggerAndNegation)
-{
-  auto belief = seededBelief(types::OrientationAvailability::SIGN_UNKNOWN);
-  belief.vote(M_PI, false);
-  belief.vote(M_PI, false);
-  EXPECT_FALSE(belief.shouldFlip());  // -1.1 > -2.0
-  belief.vote(M_PI, false);
-  EXPECT_TRUE(belief.shouldFlip());  // -2.2 < -2.0
-
-  belief.onFlipped();
-  EXPECT_DOUBLE_EQ(belief.logOdds(), 2.0 * beliefParams().vote_sign_unknown);
-  EXPECT_FALSE(belief.shouldFlip());
-}
-
-// Alternating votes after a flip stay within one weight of the post-flip belief and can never
-// traverse from +flip_threshold to -flip_threshold.
-TEST(OrientationSignBelief, NoOscillationUnderAlternatingVotes)
-{
-  auto belief = seededBelief(types::OrientationAvailability::SIGN_UNKNOWN);
-  for (int i = 0; i < 3; ++i) {
-    belief.vote(M_PI, false);
+  const std::array<std::array<double, 3>, 3> orders = {
+    {{0.0, 0.0, M_PI}, {0.0, M_PI, 0.0}, {M_PI, 0.0, 0.0}}};
+  std::array<double, 3> results{};
+  for (size_t i = 0; i < orders.size(); ++i) {
+    auto belief = seededBelief(types::OrientationAvailability::UNAVAILABLE);
+    for (const double yaw_diff : orders[i]) {
+      belief.vote(beliefTime(), yaw_diff, false);
+    }
+    results[i] = belief.agreement();
   }
-  ASSERT_TRUE(belief.shouldFlip());
+  EXPECT_NEAR(results[0], results[1], 1e-12);
+  EXPECT_NEAR(results[1], results[2], 1e-12);
+
+  auto unanimous = seededBelief(types::OrientationAvailability::UNAVAILABLE);
+  for (int i = 0; i < 3; ++i) {
+    unanimous.vote(beliefTime(), 0.0, false);
+  }
+  EXPECT_GT(results[0], 0.0);
+  EXPECT_GT(unanimous.agreement(), 2.0 * results[0]);
+}
+
+// Idle time relaxes the estimate toward the uninformed prior (0, stationary_var).
+TEST(OrientationSignBelief, DecayRelaxesTowardPrior)
+{
+  auto belief = seededBelief(types::OrientationAvailability::AVAILABLE);
+  const double seeded = belief.agreement();
+  belief.shouldFlip(beliefTime(10.0 * beliefParams().tau), 0.0, 1e3);
+  EXPECT_NEAR(belief.agreement(), 0.0, 1e-3 * seeded);
+  EXPECT_NEAR(belief.variance(), beliefParams().stationary_var, 1e-4);
+}
+
+// At standstill the velocity evidence carries no information: the fused posterior equals the
+// yaw-vote posterior.
+TEST(OrientationSignBelief, VelocityGatedOutAtStandstill)
+{
+  auto belief = seededBelief(types::OrientationAvailability::SIGN_UNKNOWN);
+  EXPECT_FALSE(belief.shouldFlip(beliefTime(), 0.0, 0.01));
+  EXPECT_DOUBLE_EQ(belief.fusedAgreement(), belief.agreement());
+  EXPECT_DOUBLE_EQ(belief.fusedVariance(), belief.variance());
+}
+
+// A certain reverse velocity at the par speed overrides weak agreeing yaw evidence, while the
+// same velocity with a poorly converged variance does not.
+TEST(OrientationSignBelief, VelocityOverridesAtSpeedUnlessUncertain)
+{
+  auto certain = seededBelief(types::OrientationAvailability::SIGN_UNKNOWN);
+  EXPECT_TRUE(certain.shouldFlip(beliefTime(), -2.0 * beliefParams().vote_vel_par, 0.01));
+
+  auto uncertain = seededBelief(types::OrientationAvailability::SIGN_UNKNOWN);
+  EXPECT_FALSE(uncertain.shouldFlip(
+    beliefTime(), -2.0 * beliefParams().vote_vel_par, 50.0 * beliefParams().vote_vel_var));
+  EXPECT_GT(uncertain.fusedAgreement(), -beliefParams().flip_min_agreement);
+}
+
+// Strong accumulated yaw evidence resists a single frame of contrary velocity.
+TEST(OrientationSignBelief, YawEvidenceResistsVelocityFrame)
+{
+  auto belief = seededBelief(types::OrientationAvailability::AVAILABLE);
+  for (int i = 0; i < 5; ++i) {
+    belief.vote(beliefTime(), 0.0, true);
+  }
+  EXPECT_FALSE(belief.shouldFlip(beliefTime(), -2.0 * beliefParams().vote_vel_par, 0.01));
+}
+
+// The flip fires only on a confidently negative fused agreement, and negation on flip restores
+// a trusted belief that alternating votes cannot re-flip.
+TEST(OrientationSignBelief, FlipNegationHysteresis)
+{
+  auto belief = seededBelief(types::OrientationAvailability::SIGN_UNKNOWN);
+  int flipped_at = -1;
+  for (int i = 1; i <= 30; ++i) {
+    belief.vote(beliefTime(), M_PI, false);
+    if (belief.shouldFlip(beliefTime(), 0.0, 1e3)) {
+      flipped_at = i;
+      break;
+    }
+  }
+  ASSERT_GT(flipped_at, 1);
+
   belief.onFlipped();
+  EXPECT_GT(belief.agreement(), 0.0);
+  EXPECT_FALSE(belief.shouldFlip(beliefTime(), 0.0, 1e3));
 
   for (int i = 0; i < 50; ++i) {
-    belief.vote(i % 2 == 0 ? M_PI : 0.0, false);
-    EXPECT_FALSE(belief.shouldFlip());
+    belief.vote(beliefTime(), i % 2 == 0 ? M_PI : 0.0, false);
+    EXPECT_FALSE(belief.shouldFlip(beliefTime(), 0.0, 1e3));
   }
 }
 
@@ -573,8 +596,7 @@ TEST(FlipOrientation, SwapsAxlesAndReversesVelocity)
   BicycleMotionModel::StateMat p_after;
   rawState(model, x_after, p_after);
 
-  const double yaw_jump =
-    autoware_utils_math::normalize_radian(model.getYawState() - yaw_before);
+  const double yaw_jump = autoware_utils_math::normalize_radian(model.getYawState() - yaw_before);
   EXPECT_NEAR(std::abs(yaw_jump), M_PI, 1e-12);
   EXPECT_DOUBLE_EQ(model.getLength(), length_before);
 
@@ -654,8 +676,8 @@ double trackedYaw(const VehicleTracker & tracker, const rclcpp::Time & time)
 }
 }  // namespace
 
-// A stationary tracker seeded with the wrong sign flips once opposing SIGN_UNKNOWN votes cross
-// the threshold (seed +w, then -w per frame: below -2.0 on the third), and stays flipped.
+// A stationary tracker seeded with the wrong sign flips once opposing SIGN_UNKNOWN votes drive
+// the agreement confidently negative, and stays flipped.
 TEST(VehicleTrackerSignFlip, OpposedVotesFlipSlowTracker)
 {
   const types::InputChannel channel{};
@@ -664,7 +686,7 @@ TEST(VehicleTrackerSignFlip, OpposedVotesFlipSlowTracker)
 
   int flipped_at = -1;
   rclcpp::Time time = start;
-  for (int i = 1; i <= 6; ++i) {
+  for (int i = 1; i <= 25; ++i) {
     time = start + rclcpp::Duration::from_seconds(0.1 * i);
     tracker.predict(time);
     tracker.measure(makeVehicleDetection(time, M_PI), time, channel);
@@ -674,7 +696,8 @@ TEST(VehicleTrackerSignFlip, OpposedVotesFlipSlowTracker)
       flipped_at = i;
     }
   }
-  EXPECT_EQ(flipped_at, 3);
+  EXPECT_GT(flipped_at, 2);
+  EXPECT_LE(flipped_at, 25);
 
   // Agreeing frames after the flip keep the corrected heading.
   const double deviation =
@@ -693,7 +716,7 @@ TEST(PedestrianAndBicycleTrackerSignFlip, PedestrianLayerFollowsBicycleSign)
   PedestrianAndBicycleTracker tracker(start, detection);
 
   rclcpp::Time time = start;
-  for (int i = 1; i <= 6; ++i) {
+  for (int i = 1; i <= 25; ++i) {
     time = start + rclcpp::Duration::from_seconds(0.1 * i);
     tracker.predict(time);
     auto measurement = makeVehicleDetection(time, M_PI);

--- a/perception/autoware_multi_object_tracker/test/test_vehicle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/test/test_vehicle_tracker.cpp
@@ -470,6 +470,33 @@ TEST(OrientationSignBelief, AvailableVotesWeighMore)
   EXPECT_GT(beliefParams().vote_available, beliefParams().vote_sign_unknown);
 }
 
+// A velocity vote weighs linearly with speed and matches an AVAILABLE yaw vote at the par speed.
+TEST(OrientationSignBelief, VelocityVoteScalesWithSpeed)
+{
+  auto belief = seededBelief(types::OrientationAvailability::UNAVAILABLE);
+  belief.voteVelocity(-beliefParams().vote_vel_par);
+  EXPECT_DOUBLE_EQ(belief.logOdds(), -beliefParams().vote_available);
+
+  auto slow = seededBelief(types::OrientationAvailability::UNAVAILABLE);
+  slow.voteVelocity(-0.1 * beliefParams().vote_vel_par);
+  EXPECT_DOUBLE_EQ(slow.logOdds(), -0.1 * beliefParams().vote_available);
+}
+
+// Against an agreeing AVAILABLE yaw vote, reverse motion below the par speed keeps the sign
+// (parked vehicles maneuver in reverse) while reverse motion above it drives the belief negative.
+TEST(OrientationSignBelief, ParSpeedSetsYawVelocityPriority)
+{
+  auto slow = seededBelief(types::OrientationAvailability::UNAVAILABLE);
+  slow.vote(0.0, true);
+  slow.voteVelocity(-0.5 * beliefParams().vote_vel_par);
+  EXPECT_GT(slow.logOdds(), 0.0);
+
+  auto fast = seededBelief(types::OrientationAvailability::UNAVAILABLE);
+  fast.vote(0.0, true);
+  fast.voteVelocity(-2.0 * beliefParams().vote_vel_par);
+  EXPECT_LT(fast.logOdds(), 0.0);
+}
+
 // The flip fires only past -flip_threshold, and negation on flip restores a trusted belief.
 TEST(OrientationSignBelief, FlipTriggerAndNegation)
 {

--- a/perception/autoware_multi_object_tracker/test/test_vehicle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/test/test_vehicle_tracker.cpp
@@ -474,12 +474,25 @@ TEST(OrientationSignBelief, AvailableVotesWeighMore)
 TEST(OrientationSignBelief, VelocityVoteScalesWithSpeed)
 {
   auto belief = seededBelief(types::OrientationAvailability::UNAVAILABLE);
-  belief.voteVelocity(-beliefParams().vote_vel_par);
+  belief.voteVelocity(-beliefParams().vote_vel_par, 0.0);
   EXPECT_DOUBLE_EQ(belief.logOdds(), -beliefParams().vote_available);
 
   auto slow = seededBelief(types::OrientationAvailability::UNAVAILABLE);
-  slow.voteVelocity(-0.1 * beliefParams().vote_vel_par);
+  slow.voteVelocity(-0.1 * beliefParams().vote_vel_par, 0.0);
   EXPECT_DOUBLE_EQ(slow.logOdds(), -0.1 * beliefParams().vote_available);
+}
+
+// The velocity vote is discounted by the estimate variance: half weight at vote_vel_var, near
+// zero for a poorly converged velocity.
+TEST(OrientationSignBelief, VelocityVarianceWeakensVote)
+{
+  auto halved = seededBelief(types::OrientationAvailability::UNAVAILABLE);
+  halved.voteVelocity(-beliefParams().vote_vel_par, beliefParams().vote_vel_var);
+  EXPECT_DOUBLE_EQ(halved.logOdds(), -0.5 * beliefParams().vote_available);
+
+  auto uncertain = seededBelief(types::OrientationAvailability::UNAVAILABLE);
+  uncertain.voteVelocity(-beliefParams().vote_vel_par, 1e3 * beliefParams().vote_vel_var);
+  EXPECT_NEAR(uncertain.logOdds(), 0.0, 1e-2 * beliefParams().vote_available);
 }
 
 // Against an agreeing AVAILABLE yaw vote, reverse motion below the par speed keeps the sign
@@ -488,12 +501,12 @@ TEST(OrientationSignBelief, ParSpeedSetsYawVelocityPriority)
 {
   auto slow = seededBelief(types::OrientationAvailability::UNAVAILABLE);
   slow.vote(0.0, true);
-  slow.voteVelocity(-0.5 * beliefParams().vote_vel_par);
+  slow.voteVelocity(-0.5 * beliefParams().vote_vel_par, 0.0);
   EXPECT_GT(slow.logOdds(), 0.0);
 
   auto fast = seededBelief(types::OrientationAvailability::UNAVAILABLE);
   fast.vote(0.0, true);
-  fast.voteVelocity(-2.0 * beliefParams().vote_vel_par);
+  fast.voteVelocity(-2.0 * beliefParams().vote_vel_par, 0.0);
   EXPECT_LT(fast.logOdds(), 0.0);
 }
 

--- a/perception/autoware_multi_object_tracker/test/test_vehicle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/test/test_vehicle_tracker.cpp
@@ -614,9 +614,14 @@ TEST(FlipOrientation, SwapsAxlesAndReversesVelocity)
   EXPECT_DOUBLE_EQ(
     p_after(BicycleMotionModel::Y2, BicycleMotionModel::Y2),
     p_before(BicycleMotionModel::Y1, BicycleMotionModel::Y1));
+  // Cross-covariances follow the error transform dU' = -dU.
+  ASSERT_NE(p_before(BicycleMotionModel::X2, BicycleMotionModel::U), 0.0);
   EXPECT_DOUBLE_EQ(
     p_after(BicycleMotionModel::X1, BicycleMotionModel::U),
-    p_before(BicycleMotionModel::X2, BicycleMotionModel::U));
+    -p_before(BicycleMotionModel::X2, BicycleMotionModel::U));
+  EXPECT_DOUBLE_EQ(
+    p_after(BicycleMotionModel::U, BicycleMotionModel::U),
+    p_before(BicycleMotionModel::U, BicycleMotionModel::U));
 }
 
 // The flip is an involution: applying it twice restores state and covariance exactly.


### PR DESCRIPTION
## Description

Vehicle (and bicycle) trackers can lock onto a heading that is 180° off when detections have ambiguous orientation. Previously the only correction was an instantaneous rule in `BicycleMotionModel::limitStates()` that flipped the state when the longitudinal velocity exceeded a reverse-velocity threshold, which reacts to a single noisy velocity estimate and can oscillate.

This PR replaces that with a probabilistic heading-sign belief (`OrientationSignBelief`) that accumulates evidence over time and flips the full tracker state only when the sign is wrong with high confidence:

- **Detection-yaw votes**: each measurement with usable orientation votes on whether its raw yaw agrees with the tracker yaw (before the yaw is normalized away). Votes accumulate in a scalar OU-Kalman agreement estimate that relaxes toward an uninformed prior, with `AVAILABLE` orientation weighted stronger than `SIGN_UNKNOWN`, and a dead zone around ±90° where boxes carry axis ambiguity instead of sign evidence.
- **Velocity evidence**: the tracked longitudinal velocity contributes memorylessly at decision time, weighted by speed and velocity certainty, so only sustained, well-estimated reverse motion can override the yaw evidence.
- **Consistent flip**: `flipOrientation()` on the bicycle/CTRV motion models applies the exact 180° state transform (axle-point swap / yaw rotation, velocity negation, covariance transform `T·P·Tᵀ` including the velocity cross-covariance signs), and the stored footprint and the belief itself are flipped together. Negation of the belief on flip provides hysteresis against oscillation.
- **Multi-layer sync**: the two layers of `MultipleVehicleTracker` are aligned to the layer with the stronger sign belief; the pedestrian layer of `PedestrianAndBicycleTracker` follows the bicycle layer.

The reverse-velocity flip rule in `limitStates()` and the corresponding footprint flip handling in `VehicleTracker::updateKinematics()` are removed.

## Related links

**Parent Issue:**

- None


[TIER IV INTERNAL ](https://tier4.atlassian.net/browse/RDDR-911)

## How was this PR tested?

* before

https://github.com/user-attachments/assets/842fa6aa-13eb-4c17-8fa1-53831e5ada6b


* after

https://github.com/user-attachments/assets/506838b3-e294-4514-9605-a9bd37d4544d


Unit tests added in `test_vehicle_tracker.cpp` covering:

- `OrientationSignBelief`: seeding per orientation availability, vote weighting, dead zone, order-independent fusion of simultaneous votes, OU decay, velocity gating at standstill, velocity override vs. uncertain velocity, resistance of accumulated yaw evidence, flip-negation hysteresis
- `BicycleMotionModel::flipOrientation` / `CTRVMotionModel::flipOrientation`: state and covariance transform correctness
- `VehicleTracker`: end-to-end flip behavior through `measure()`

```bash
colcon test --packages-select autoware_multi_object_tracker
```

## Notes for reviewers

None.

## Interface changes

None. The belief tuning constants are class-independent compile-time defaults (`OrientationSignBeliefParams`), not ROS parameters.

## Effects on system behavior

Tracked vehicle heading no longer flips on a single-frame reverse-velocity threshold; a 180° flip now requires confidently negative fused yaw/velocity evidence, reducing heading-sign oscillation for objects with ambiguous detections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
