### PR TITLE
fix(autoware_planning_evaluator): use Newest polling policy for route/vector_map

### DIFF
--- a/evaluator/autoware_planning_evaluator/include/autoware/planning_evaluator/planning_evaluator_node.hpp
+++ b/evaluator/autoware_planning_evaluator/include/autoware/planning_evaluator/planning_evaluator_node.hpp
@@ -200,14 +200,16 @@ private:
   autoware::agnocast_wrapper::polling::PollingSubscriber<Odometry>::SharedPtr odometry_sub_ =
     autoware::agnocast_wrapper::polling::create_polling_subscriber<Odometry>(
       this, "~/input/odometry");
-  autoware::agnocast_wrapper::polling::PollingSubscriber<LaneletRoute>::SharedPtr
-    route_subscriber_ =
-      autoware::agnocast_wrapper::polling::create_polling_subscriber<LaneletRoute>(
-        this, "~/input/route", rclcpp::QoS{1}.transient_local());
-  autoware::agnocast_wrapper::polling::PollingSubscriber<LaneletMapBin>::SharedPtr
-    vector_map_subscriber_ =
-      autoware::agnocast_wrapper::polling::create_polling_subscriber<LaneletMapBin>(
-        this, "~/input/vector_map", rclcpp::QoS{1}.transient_local());
+  autoware::agnocast_wrapper::polling::PollingSubscriber<
+    LaneletRoute, autoware_utils::polling_policy::Newest>::SharedPtr route_subscriber_ =
+    autoware::agnocast_wrapper::polling::create_polling_subscriber<
+      LaneletRoute, autoware_utils::polling_policy::Newest>(
+      this, "~/input/route", rclcpp::QoS{1}.transient_local());
+  autoware::agnocast_wrapper::polling::PollingSubscriber<
+    LaneletMapBin, autoware_utils::polling_policy::Newest>::SharedPtr vector_map_subscriber_ =
+    autoware::agnocast_wrapper::polling::create_polling_subscriber<
+      LaneletMapBin, autoware_utils::polling_policy::Newest>(
+      this, "~/input/vector_map", rclcpp::QoS{1}.transient_local());
   autoware::agnocast_wrapper::polling::PollingSubscriber<AccelWithCovarianceStamped>::SharedPtr
     accel_sub_ =
       autoware::agnocast_wrapper::polling::create_polling_subscriber<AccelWithCovarianceStamped>(


### PR DESCRIPTION
## Description

Before the `agnocast_wrapper::Node` migration (#12966 / #13035), `route_subscriber_` and `vector_map_subscriber_` used `polling_policy::Newest`. The migration dropped the explicit policy, so both fell back to the default `polling_policy::Latest`, whose `take_data()` re-delivers the cached message on every call. Because `getRouteData()` has no "already set" guard, `RouteHandler::setMap()` (and `setRoute()`) then rebuild the lanelet2 routing graph **every cycle**, which greatly increases the node's processing time.

This restores `polling_policy::Newest` for both subscribers so `setMap()` / `setRoute()` run only when a new map / route actually arrives, matching the pre-migration behavior.

## Related links

None.

## How was this PR tested?

Built successfully with both `ENABLE_AGNOCAST=0` and `ENABLE_AGNOCAST=1` (wrapper build/install removed and rebuilt before each).

## Notes for reviewers

The map/route are latched (`transient_local`); `Newest` still delivers the latched sample once on subscription match, so `setMap()`/`setRoute()` are invoked exactly once per new message instead of every cycle.

## Interface changes

None.

## Effects on system behavior

Fixes a processing-time regression: the lanelet2 routing graph is no longer rebuilt every cycle, only on a new map/route.
