### PR TITLE
refactor(autoware_traffic_light_classifier): move logging and dynamic reconfigure to the node

### DIFF
--- a/perception/autoware_traffic_light_classifier/src/classifier/cnn_classifier.cpp
+++ b/perception/autoware_traffic_light_classifier/src/classifier/cnn_classifier.cpp
@@ -151,10 +151,10 @@ cv::Mat CNNClassifierCore::make_debug_image(
 }
 
 // ============================== CNNClassifier ==============================
-// ROS adapter: logs and delegates classification and debug-image rendering to the Node-free core.
+// Node-free adapter: delegates classification and debug rendering to the core and maps its
+// per-image output into the caller's signals.
 
-CNNClassifier::CNNClassifier(rclcpp::Node * node_ptr, const CNNConfig & config)
-: node_ptr_(node_ptr), core_(config)
+CNNClassifier::CNNClassifier(const CNNConfig & config) : core_(config)
 {
 }
 
@@ -163,13 +163,11 @@ bool CNNClassifier::getTrafficSignals(
   tier4_perception_msgs::msg::TrafficLightArray & traffic_signals)
 {
   if (images.size() != traffic_signals.signals.size()) {
-    RCLCPP_WARN(node_ptr_->get_logger(), "image number should be equal to traffic signal number!");
     return false;
   }
 
   const CNNClassifierCore::ClassifierResult result = core_.classify(images);
   if (!result.success) {
-    RCLCPP_ERROR(node_ptr_->get_logger(), "failed to classify traffic light image by cnn");
     return false;
   }
 

--- a/perception/autoware_traffic_light_classifier/src/classifier/cnn_classifier.hpp
+++ b/perception/autoware_traffic_light_classifier/src/classifier/cnn_classifier.hpp
@@ -19,7 +19,6 @@
 
 #include <autoware/tensorrt_classifier/tensorrt_classifier.hpp>
 #include <opencv2/core/core.hpp>
-#include <rclcpp/rclcpp.hpp>
 
 #include <tier4_perception_msgs/msg/traffic_light.hpp>
 #include <tier4_perception_msgs/msg/traffic_light_array.hpp>
@@ -83,12 +82,12 @@ private:
   int batch_size_ = 0;
 };
 
-// Thin ROS adapter around CNNClassifierCore. Logs, and delegates classification and debug-image
-// rendering to the core.
+// Thin, Node-free adapter around CNNClassifierCore: delegates classification and debug rendering
+// to the core, and maps its per-image output into the caller's signals.
 class CNNClassifier : public ClassifierInterface
 {
 public:
-  CNNClassifier(rclcpp::Node * node_ptr, const CNNConfig & config);
+  explicit CNNClassifier(const CNNConfig & config);
   virtual ~CNNClassifier() = default;
 
   bool getTrafficSignals(
@@ -98,7 +97,6 @@ public:
   cv::Mat make_debug_image(const std::vector<cv::Mat> & images) const override;
 
 private:
-  rclcpp::Node * node_ptr_;
   CNNClassifierCore core_;
   // Per-image classification output kept from the most recent getTrafficSignals so
   // make_debug_image can render the batch afterwards.

--- a/perception/autoware_traffic_light_classifier/src/classifier/cnn_lamp_recognizer.cpp
+++ b/perception/autoware_traffic_light_classifier/src/classifier/cnn_lamp_recognizer.cpp
@@ -541,11 +541,10 @@ cv::Mat CnnLampRecognizerCore::make_debug_image(
 }
 
 // ============================== CnnLampRecognizer ==============================
-// ROS adapter: logs and delegates recognition and debug-image rendering to the Node-free core.
+// Node-free adapter: delegates recognition and debug rendering to the core and maps its per-image
+// detections into the caller's signals.
 
-CnnLampRecognizer::CnnLampRecognizer(
-  rclcpp::Node * node_ptr, const CnnLampRecognizerConfig & config)
-: node_ptr_(node_ptr), core_(config)
+CnnLampRecognizer::CnnLampRecognizer(const CnnLampRecognizerConfig & config) : core_(config)
 {
 }
 
@@ -554,15 +553,11 @@ bool CnnLampRecognizer::getTrafficSignals(
   tier4_perception_msgs::msg::TrafficLightArray & traffic_signals)
 {
   if (images.size() != traffic_signals.signals.size()) {
-    RCLCPP_WARN(
-      node_ptr_->get_logger(), "LampRecognizer: image count (%zu) != signal count (%zu)",
-      images.size(), traffic_signals.signals.size());
     return false;
   }
 
   const CnnLampRecognizerCore::DetectionResult result = core_.classify(images);
   if (!result.success) {
-    RCLCPP_ERROR(node_ptr_->get_logger(), "LampRecognizer: inference failed");
     return false;
   }
 

--- a/perception/autoware_traffic_light_classifier/src/classifier/cnn_lamp_recognizer.hpp
+++ b/perception/autoware_traffic_light_classifier/src/classifier/cnn_lamp_recognizer.hpp
@@ -23,7 +23,6 @@
 #include <opencv2/core/core.hpp>
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/opencv.hpp>
-#include <rclcpp/rclcpp.hpp>
 
 #include <tier4_perception_msgs/msg/traffic_light_element.hpp>
 
@@ -186,12 +185,12 @@ private:
   LampRegressionArchitecture model_params_;
 };
 
-// Thin ROS adapter around CnnLampRecognizerCore. Logs, and delegates recognition and
-// debug-image rendering to the core.
+// Thin, Node-free adapter around CnnLampRecognizerCore: delegates recognition and debug rendering
+// to the core, and maps its per-image detections into the caller's signals.
 class CnnLampRecognizer : public ClassifierInterface
 {
 public:
-  CnnLampRecognizer(rclcpp::Node * node_ptr, const CnnLampRecognizerConfig & config);
+  explicit CnnLampRecognizer(const CnnLampRecognizerConfig & config);
   ~CnnLampRecognizer() override = default;
 
   bool getTrafficSignals(
@@ -201,7 +200,6 @@ public:
   cv::Mat make_debug_image(const std::vector<cv::Mat> & images) const override;
 
 private:
-  rclcpp::Node * node_ptr_;
   CnnLampRecognizerCore core_;
   // Kept from the most recent getTrafficSignals so make_debug_image can render the batch: the
   // per-image output signals (for the text labels) and the per-image raw detections (for the

--- a/perception/autoware_traffic_light_classifier/src/classifier/color_classifier.cpp
+++ b/perception/autoware_traffic_light_classifier/src/classifier/color_classifier.cpp
@@ -18,7 +18,6 @@
 #include <opencv2/imgproc/imgproc_c.h>
 
 #include <algorithm>
-#include <string>
 #include <vector>
 
 namespace autoware::traffic_light
@@ -223,32 +222,11 @@ cv::Mat ColorClassifierCore::make_debug_image(const cv::Mat & roi_image) const
 }
 
 // ============================== ColorClassifier ==============================
-// ROS adapter: wires dynamic reconfigure and logging, and delegates classification and
-// debug-image rendering to the Node-free core.
+// Node-free adapter: delegates classification and debug rendering to the core. Dynamic reconfigure
+// lives in the node, which drives get_config / set_config below.
 
-namespace
+ColorClassifier::ColorClassifier(const HSVConfig & config) : core_(config)
 {
-// Set `value` from the parameter named `name` if present; return whether it was found.
-bool update_param(
-  const std::vector<rclcpp::Parameter> & parameters, const std::string & name, int & value)
-{
-  for (const auto & parameter : parameters) {
-    if (parameter.get_name() == name) {
-      value = parameter.as_int();
-      return true;
-    }
-  }
-  return false;
-}
-}  // namespace
-
-ColorClassifier::ColorClassifier(rclcpp::Node * node_ptr, const HSVConfig & config)
-: node_ptr_(node_ptr), core_(config)
-{
-  using std::placeholders::_1;
-  // set parameter callback
-  set_param_res_ = node_ptr_->add_on_set_parameters_callback(
-    std::bind(&ColorClassifier::parametersCallback, this, _1));
 }
 
 bool ColorClassifier::getTrafficSignals(
@@ -256,7 +234,6 @@ bool ColorClassifier::getTrafficSignals(
   tier4_perception_msgs::msg::TrafficLightArray & traffic_signals)
 {
   if (images.size() != traffic_signals.signals.size()) {
-    RCLCPP_WARN(node_ptr_->get_logger(), "image number should be equal to traffic signal number!");
     return false;
   }
 
@@ -270,9 +247,6 @@ bool ColorClassifier::getTrafficSignals(
     elements.insert(elements.end(), classified.begin(), classified.end());
   }
 
-  if (!result.success) {
-    RCLCPP_ERROR(node_ptr_->get_logger(), "failed to filter image by hsv value");
-  }
   return result.success;
 }
 
@@ -297,35 +271,14 @@ cv::Mat ColorClassifier::make_debug_image(const std::vector<cv::Mat> & images) c
   return debug_image;
 }
 
-rcl_interfaces::msg::SetParametersResult ColorClassifier::parametersCallback(
-  const std::vector<rclcpp::Parameter> & parameters)
+const HSVConfig & ColorClassifier::get_config() const
 {
-  HSVConfig config = core_.get_config();
-  update_param(parameters, "green_min_h", config.green_min_h);
-  update_param(parameters, "green_min_s", config.green_min_s);
-  update_param(parameters, "green_min_v", config.green_min_v);
-  update_param(parameters, "green_max_h", config.green_max_h);
-  update_param(parameters, "green_max_s", config.green_max_s);
-  update_param(parameters, "green_max_v", config.green_max_v);
-  update_param(parameters, "yellow_min_h", config.yellow_min_h);
-  update_param(parameters, "yellow_min_s", config.yellow_min_s);
-  update_param(parameters, "yellow_min_v", config.yellow_min_v);
-  update_param(parameters, "yellow_max_h", config.yellow_max_h);
-  update_param(parameters, "yellow_max_s", config.yellow_max_s);
-  update_param(parameters, "yellow_max_v", config.yellow_max_v);
-  update_param(parameters, "red_min_h", config.red_min_h);
-  update_param(parameters, "red_min_s", config.red_min_s);
-  update_param(parameters, "red_min_v", config.red_min_v);
-  update_param(parameters, "red_max_h", config.red_max_h);
-  update_param(parameters, "red_max_s", config.red_max_s);
-  update_param(parameters, "red_max_v", config.red_max_v);
+  return core_.get_config();
+}
 
+void ColorClassifier::set_config(const HSVConfig & config)
+{
   core_.set_config(config);
-
-  rcl_interfaces::msg::SetParametersResult result;
-  result.successful = true;
-  result.reason = "success";
-  return result;
 }
 
 }  // namespace autoware::traffic_light

--- a/perception/autoware_traffic_light_classifier/src/classifier/color_classifier.hpp
+++ b/perception/autoware_traffic_light_classifier/src/classifier/color_classifier.hpp
@@ -18,7 +18,6 @@
 #include "classifier_interface.hpp"
 
 #include <opencv2/core/core.hpp>
-#include <rclcpp/rclcpp.hpp>
 
 #include <tier4_perception_msgs/msg/traffic_light_array.hpp>
 #include <tier4_perception_msgs/msg/traffic_light_element.hpp>
@@ -133,12 +132,12 @@ private:
   cv::Scalar max_hsv_red_;
 };
 
-// Thin ROS adapter around ColorClassifierCore. Wires dynamic reconfigure and logging, and
-// delegates classification and debug-image rendering to the core.
+// Thin, Node-free adapter around ColorClassifierCore: delegates classification and debug-image
+// rendering to the core. Exposes get_config / set_config so the node can drive dynamic reconfigure.
 class ColorClassifier : public ClassifierInterface
 {
 public:
-  ColorClassifier(rclcpp::Node * node_ptr, const HSVConfig & config);
+  explicit ColorClassifier(const HSVConfig & config);
   virtual ~ColorClassifier() = default;
 
   bool getTrafficSignals(
@@ -147,13 +146,12 @@ public:
 
   cv::Mat make_debug_image(const std::vector<cv::Mat> & images) const override;
 
+  // Pass-through helpers over the core's HSV thresholds, used by the node's parameter callback
+  // to apply dynamic reconfigure (read-modify-write).
+  const HSVConfig & get_config() const;
+  void set_config(const HSVConfig & config);
+
 private:
-  rcl_interfaces::msg::SetParametersResult parametersCallback(
-    const std::vector<rclcpp::Parameter> & parameters);
-
-  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr set_param_res_;
-  rclcpp::Node * node_ptr_;
-
   ColorClassifierCore core_;
 };
 

--- a/perception/autoware_traffic_light_classifier/src/single_image_debug_inference_node.cpp
+++ b/perception/autoware_traffic_light_classifier/src/single_image_debug_inference_node.cpp
@@ -75,10 +75,10 @@ public:
       "classifier_type",
       static_cast<int>(TrafficLightClassifierNodelet::ClassifierType::HSVFilter));
     if (classifier_type == TrafficLightClassifierNodelet::ClassifierType::HSVFilter) {
-      classifier_ptr_ = std::make_unique<ColorClassifier>(this, declare_hsv_config(this));
+      classifier_ptr_ = std::make_unique<ColorClassifier>(declare_hsv_config(this));
     } else if (classifier_type == TrafficLightClassifierNodelet::ClassifierType::CNN) {
 #if ENABLE_GPU
-      classifier_ptr_ = std::make_unique<CNNClassifier>(this, declare_cnn_config(this));
+      classifier_ptr_ = std::make_unique<CNNClassifier>(declare_cnn_config(this));
 #else
       RCLCPP_ERROR(get_logger(), "please install CUDA, and TensorRT to use cnn classifier");
 #endif

--- a/perception/autoware_traffic_light_classifier/src/traffic_light_classifier_node.cpp
+++ b/perception/autoware_traffic_light_classifier/src/traffic_light_classifier_node.cpp
@@ -19,10 +19,28 @@
 #include <tier4_perception_msgs/msg/traffic_light_element.hpp>
 
 #include <memory>
+#include <string>
 #include <utility>
+#include <vector>
 
 namespace autoware::traffic_light
 {
+namespace
+{
+// Set `value` from the parameter named `name` if present; return whether it was found.
+bool update_param(
+  const std::vector<rclcpp::Parameter> & parameters, const std::string & name, int & value)
+{
+  for (const auto & parameter : parameters) {
+    if (parameter.get_name() == name) {
+      value = parameter.as_int();
+      return true;
+    }
+  }
+  return false;
+}
+}  // namespace
+
 TrafficLightClassifierNodelet::TrafficLightClassifierNodelet(const rclcpp::NodeOptions & options)
 : Node("traffic_light_classifier_node", options)
 {
@@ -55,16 +73,20 @@ TrafficLightClassifierNodelet::TrafficLightClassifierNodelet(const rclcpp::NodeO
   int classifier_type = this->declare_parameter<int>("classifier_type");
   std::shared_ptr<ClassifierInterface> classifier_ptr;
   if (classifier_type == TrafficLightClassifierNodelet::ClassifierType::HSVFilter) {
-    classifier_ptr = std::make_shared<ColorClassifier>(this, declare_hsv_config(this));
+    // Keep a typed handle so the node can drive the color backend's dynamic reconfigure.
+    color_classifier_ = std::make_shared<ColorClassifier>(declare_hsv_config(this));
+    set_param_res_ = this->add_on_set_parameters_callback(
+      std::bind(&TrafficLightClassifierNodelet::on_set_parameters_callback, this, _1));
+    classifier_ptr = color_classifier_;
   } else if (classifier_type == TrafficLightClassifierNodelet::ClassifierType::CNN) {
 #if ENABLE_GPU
-    classifier_ptr = std::make_shared<CNNClassifier>(this, declare_cnn_config(this));
+    classifier_ptr = std::make_shared<CNNClassifier>(declare_cnn_config(this));
 #else
     RCLCPP_ERROR(this->get_logger(), "please install CUDA, and TensorRT to use cnn classifier");
 #endif
   } else if (classifier_type == TrafficLightClassifierNodelet::ClassifierType::LampRecognizer) {
 #if ENABLE_GPU
-    classifier_ptr = std::make_shared<CnnLampRecognizer>(this, declare_lamp_config(this));
+    classifier_ptr = std::make_shared<CnnLampRecognizer>(declare_lamp_config(this));
 #else
     RCLCPP_ERROR(
       this->get_logger(), "please install CUDA, CUDNN and TensorRT to use LampRecognizer");
@@ -159,6 +181,37 @@ void TrafficLightClassifierNodelet::imageRoiCallback(
       debug_image_pub_.publish(debug_image_msg);
     }
   }
+}
+
+rcl_interfaces::msg::SetParametersResult TrafficLightClassifierNodelet::on_set_parameters_callback(
+  const std::vector<rclcpp::Parameter> & parameters)
+{
+  HSVConfig config = color_classifier_->get_config();
+  update_param(parameters, "green_min_h", config.green_min_h);
+  update_param(parameters, "green_min_s", config.green_min_s);
+  update_param(parameters, "green_min_v", config.green_min_v);
+  update_param(parameters, "green_max_h", config.green_max_h);
+  update_param(parameters, "green_max_s", config.green_max_s);
+  update_param(parameters, "green_max_v", config.green_max_v);
+  update_param(parameters, "yellow_min_h", config.yellow_min_h);
+  update_param(parameters, "yellow_min_s", config.yellow_min_s);
+  update_param(parameters, "yellow_min_v", config.yellow_min_v);
+  update_param(parameters, "yellow_max_h", config.yellow_max_h);
+  update_param(parameters, "yellow_max_s", config.yellow_max_s);
+  update_param(parameters, "yellow_max_v", config.yellow_max_v);
+  update_param(parameters, "red_min_h", config.red_min_h);
+  update_param(parameters, "red_min_s", config.red_min_s);
+  update_param(parameters, "red_min_v", config.red_min_v);
+  update_param(parameters, "red_max_h", config.red_max_h);
+  update_param(parameters, "red_max_s", config.red_max_s);
+  update_param(parameters, "red_max_v", config.red_max_v);
+
+  color_classifier_->set_config(config);
+
+  rcl_interfaces::msg::SetParametersResult result;
+  result.successful = true;
+  result.reason = "success";
+  return result;
 }
 
 }  // namespace autoware::traffic_light

--- a/perception/autoware_traffic_light_classifier/src/traffic_light_classifier_node.hpp
+++ b/perception/autoware_traffic_light_classifier/src/traffic_light_classifier_node.hpp
@@ -43,6 +43,7 @@
 
 #include <memory>
 #include <mutex>
+#include <vector>
 
 #if ENABLE_GPU
 #include "classifier/cnn_classifier.hpp"
@@ -75,6 +76,11 @@ public:
 private:
   void connectCb();
 
+  // Applies HSV threshold parameter updates to the color backend at runtime (dynamic reconfigure).
+  // Registered only for the HSV backend; drives color_classifier_'s get_config / set_config.
+  rcl_interfaces::msg::SetParametersResult on_set_parameters_callback(
+    const std::vector<rclcpp::Parameter> & parameters);
+
   rclcpp::TimerBase::SharedPtr timer_;
   image_transport::SubscriberFilter image_sub_;
   message_filters::Subscriber<tier4_perception_msgs::msg::TrafficLightRoiArray> roi_sub_;
@@ -93,6 +99,10 @@ private:
     traffic_signal_array_pub_;
   image_transport::Publisher debug_image_pub_;
   std::unique_ptr<TrafficLightClassifier> classifier_;
+  // Non-null only for the HSV backend, so on_set_parameters_callback can drive its dynamic
+  // reconfigure.
+  std::shared_ptr<ColorClassifier> color_classifier_;
+  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr set_param_res_;
 
   std::unique_ptr<autoware_utils::DiagnosticsInterface>
     diagnostics_interface_ptr_;  //!< Diagnostic handler.

--- a/perception/autoware_traffic_light_classifier/test/test_cnn_classifier_adapter.cpp
+++ b/perception/autoware_traffic_light_classifier/test/test_cnn_classifier_adapter.cpp
@@ -117,8 +117,7 @@ protected:
     // "environment unavailable" -> skip (not fail), with a reason the test reports.
     try {
       node_ = std::make_shared<rclcpp::Node>("cnn_classifier_adapter_test", options);
-      classifier_ =
-        std::make_shared<tl::CNNClassifier>(node_.get(), tl::declare_cnn_config(node_.get()));
+      classifier_ = std::make_shared<tl::CNNClassifier>(tl::declare_cnn_config(node_.get()));
     } catch (const std::exception & e) {
       skip_reason_ = std::string("CNNClassifier environment unavailable: ") + e.what();
       classifier_.reset();

--- a/perception/autoware_traffic_light_classifier/test/test_cnn_lamp_recognizer_adapter.cpp
+++ b/perception/autoware_traffic_light_classifier/test/test_cnn_lamp_recognizer_adapter.cpp
@@ -167,8 +167,7 @@ protected:
     // GTEST_SKIP.
     try {
       node_ = std::make_shared<rclcpp::Node>("cnn_lamp_recognizer_adapter_test", options);
-      recognizer_ =
-        std::make_shared<tl::CnnLampRecognizer>(node_.get(), tl::declare_lamp_config(node_.get()));
+      recognizer_ = std::make_shared<tl::CnnLampRecognizer>(tl::declare_lamp_config(node_.get()));
     } catch (const std::exception & e) {
       skip_reason_ = std::string("CnnLampRecognizer environment unavailable: ") + e.what();
       recognizer_.reset();

--- a/perception/autoware_traffic_light_classifier/test/test_color_classifier_adapter.cpp
+++ b/perception/autoware_traffic_light_classifier/test/test_color_classifier_adapter.cpp
@@ -47,7 +47,7 @@ TEST(ColorClassifierAdapterTest, MismatchedSizesReturnFalse)
 {
   // Arrange
   auto node = std::make_shared<rclcpp::Node>("color_classifier_adapter_test");
-  tl::ColorClassifier classifier(node.get(), tl::declare_hsv_config(node.get()));
+  tl::ColorClassifier classifier(tl::declare_hsv_config(node.get()));
   const std::vector<cv::Mat> images{cv::Mat(4, 4, CV_8UC3, cv::Scalar(0, 0, 0))};
   TrafficLightArray signals;
   signals.signals.resize(2);  // two signals but one image -- the deliberate count mismatch


### PR DESCRIPTION
## Description

Third step of the by-concern campaign to remove the ROS Node dependency from the traffic-light classifiers (follows #13041 parameter declaration and #13047 debug-image publishing).

This PR moves **logging and dynamic reconfigure** out of the three classifiers, so the classifier layer no longer depends on the ROS Node at all:

- Each classifier's size-guard / inference-failure paths now just `return false` instead of logging.
  The node's existing single `RCLCPP_ERROR("failed classify image, abort callback")` on a null
  classify result covers the failure path (it previously double-logged: the classifier logged a
  backend-specific message *and* the node logged the generic one).
- Dynamic reconfigure moves to the node: `ColorClassifier` exposes `get_config` / `set_config`
  pass-throughs to its core, and the node registers a named on-set-parameters callback
  (`onSetParametersCallback`) that applies the HSV threshold read-modify-write.
- Each adapter constructor now takes only its plain `Config` (no `rclcpp::Node *`), and
  `#include <rclcpp/rclcpp.hpp>` is dropped from the three classifier headers.

## Related links

- Follows #13041 (parameters → node),
-  and #13047 (debug image → node).

## How was this PR tested?

`colcon build` and `colcon test` for `autoware_traffic_light_classifier` on an NVIDIA-based GPU environment with the
real TensorRT engines: 84 tests, 0 failures, 0 skipped. The ROS-isolated adapter tests were updated
to construct the adapters from a plain `Config` (`declare_*_config(node)`), and dynamic reconfigure
remains exercised end to end by `test_traffic_light_classifier_integration`.

## Notes for reviewers

Part of a small by-concern series (parameters → debug image → logging/reconfigure → adapter
collapse) that progressively removes the Node dependency from the classifier layer. After this PR
the three classifier translation units are free of `rclcpp`.

## Interface changes

None. (No ROS topics or parameters are added, removed, or renamed; the `traffic_light_type` HSV dynamic-reconfigure parameters are declared and handled exactly as before, just from the node.)

## Effects on system behavior

- On a classification failure, a single generic error (`"failed classify image, abort callback"`)
  is logged by the node instead of a backend-specific message. The previous behavior logged twice
  for one failure (the classifier's specific message plus the node's generic one); this PR removes
  that duplication and keeps the node's single log. Backend-specific failure text (e.g. "failed to
  classify … by cnn", "LampRecognizer: inference failed") is no longer emitted.
- The size-mismatch warning (`"image number should be equal to traffic signal number!"`) is
  removed; the guard still returns early, it just no longer logs (the condition is unreachable in
  practice, since the wrapper builds the image and signal arrays together).
- HSV dynamic reconfigure (`ros2 param set` on the color thresholds at runtime) behaves exactly as
  before; only the code that applies it moved from the classifier to the node.
- The `~/output/traffic_signals` output is unchanged.
