### PR TITLE
feat(simple_trajectory_ranker): apply agnocast_wrapper::Node to simple_trajectory_ranker

### DIFF
--- a/planning/autoware_trajectory_ranker/CMakeLists.txt
+++ b/planning/autoware_trajectory_ranker/CMakeLists.txt
@@ -42,7 +42,7 @@ autoware_agnocast_wrapper_register_node(simple_trajectory_ranker_node
   PLUGIN "autoware::trajectory_ranker::SimpleTrajectoryRanker"
   EXECUTABLE simple_trajectory_ranker
   ROS2_EXECUTOR SingleThreadedExecutor
-  AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
 )
 
 ament_auto_add_library(autoware_trajectory_ranker_plugins SHARED
@@ -94,12 +94,14 @@ if(BUILD_TESTING)
     autoware_trajectory_ranker_plugins
   )
 
-  ament_add_gtest(test_simple_trajectory_ranker_node
-    test/simple_trajectory_ranker_node_test.cpp
-  )
-  target_link_libraries(test_simple_trajectory_ranker_node
-    simple_trajectory_ranker_node
-  )
+  if(NOT "$ENV{ENABLE_AGNOCAST}" STREQUAL "1")
+    ament_add_gtest(test_simple_trajectory_ranker_node
+      test/simple_trajectory_ranker_node_test.cpp
+    )
+    target_link_libraries(test_simple_trajectory_ranker_node
+      simple_trajectory_ranker_node
+    )
+  endif()
 endif()
 
 ament_auto_package(

--- a/planning/autoware_trajectory_ranker/include/autoware/trajectory_ranker/simple_trajectory_ranker_node.hpp
+++ b/planning/autoware_trajectory_ranker/include/autoware/trajectory_ranker/simple_trajectory_ranker_node.hpp
@@ -37,7 +37,8 @@ public:
 private:
   void trajectories_callback(
     const AUTOWARE_MESSAGE_CONST_SHARED_PTR(
-      autoware_internal_planning_msgs::msg::CandidateTrajectories) & msg);
+      autoware_internal_planning_msgs::msg::CandidateTrajectories) &
+    msg);
 
   AUTOWARE_SUBSCRIPTION_PTR(autoware_internal_planning_msgs::msg::CandidateTrajectories)
   sub_trajectories_;

--- a/planning/autoware_trajectory_ranker/include/autoware/trajectory_ranker/simple_trajectory_ranker_node.hpp
+++ b/planning/autoware_trajectory_ranker/include/autoware/trajectory_ranker/simple_trajectory_ranker_node.hpp
@@ -15,6 +15,7 @@
 #ifndef AUTOWARE__TRAJECTORY_RANKER__SIMPLE_TRAJECTORY_RANKER_NODE_HPP_
 #define AUTOWARE__TRAJECTORY_RANKER__SIMPLE_TRAJECTORY_RANKER_NODE_HPP_
 
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <autoware_utils_debug/time_keeper.hpp>
 #include <rclcpp/rclcpp.hpp>
 
@@ -28,21 +29,22 @@
 namespace autoware::trajectory_ranker
 {
 
-class SimpleTrajectoryRanker : public rclcpp::Node
+class SimpleTrajectoryRanker : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit SimpleTrajectoryRanker(const rclcpp::NodeOptions & options);
 
 private:
   void trajectories_callback(
-    const autoware_internal_planning_msgs::msg::CandidateTrajectories::ConstSharedPtr msg);
+    const AUTOWARE_MESSAGE_CONST_SHARED_PTR(
+      autoware_internal_planning_msgs::msg::CandidateTrajectories) & msg);
 
-  rclcpp::Subscription<autoware_internal_planning_msgs::msg::CandidateTrajectories>::SharedPtr
-    sub_trajectories_;
-  rclcpp::Publisher<autoware_internal_planning_msgs::msg::ScoredCandidateTrajectories>::SharedPtr
-    pub_trajectories_;
-  rclcpp::Publisher<autoware_utils_debug::ProcessingTimeDetail>::SharedPtr
-    debug_processing_time_detail_pub_;
+  AUTOWARE_SUBSCRIPTION_PTR(autoware_internal_planning_msgs::msg::CandidateTrajectories)
+  sub_trajectories_;
+  AUTOWARE_PUBLISHER_PTR(autoware_internal_planning_msgs::msg::ScoredCandidateTrajectories)
+  pub_trajectories_;
+  AUTOWARE_PUBLISHER_PTR(autoware_utils_debug::ProcessingTimeDetail)
+  debug_processing_time_detail_pub_;
   mutable std::shared_ptr<autoware_utils_debug::TimeKeeper> time_keeper_{nullptr};
   std::vector<std::string> ranked_generator_name_prefixes_;
 };

--- a/planning/autoware_trajectory_ranker/launch/simple_trajectory_ranker.launch.xml
+++ b/planning/autoware_trajectory_ranker/launch/simple_trajectory_ranker.launch.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<launch>
+  <arg name="trajectory_ranker_param_path" default="$(find-pkg-share autoware_trajectory_ranker)/config/simple_trajectory_ranker.param.yaml"/>
+  <arg name="input_trajectories" default="~/input/trajectories"/>
+  <arg name="output_trajectories" default="~/output/trajectories"/>
+
+  <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
+
+  <node pkg="autoware_trajectory_ranker" exec="simple_trajectory_ranker" name="trajectory_ranker_node" output="screen">
+    <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
+    <param from="$(var trajectory_ranker_param_path)" allow_substs="true"/>
+    <param from="$(find-pkg-share autoware_trajectory_ranker)/config/metrics/trajectory_consistency.param.yaml"/>
+
+    <remap from="~/input/candidate_trajectories" to="$(var input_trajectories)"/>
+    <remap from="~/output/scored_trajectories" to="$(var output_trajectories)"/>
+  </node>
+</launch>

--- a/planning/autoware_trajectory_ranker/src/simple_trajectory_ranker_node.cpp
+++ b/planning/autoware_trajectory_ranker/src/simple_trajectory_ranker_node.cpp
@@ -30,10 +30,10 @@ SimpleTrajectoryRanker::SimpleTrajectoryRanker(const rclcpp::NodeOptions & optio
   sub_trajectories_ =
     create_subscription<autoware_internal_planning_msgs::msg::CandidateTrajectories>(
       "~/input/candidate_trajectories", 1,
-      [this](const AUTOWARE_MESSAGE_CONST_SHARED_PTR(
-        autoware_internal_planning_msgs::msg::CandidateTrajectories) & msg) {
-        trajectories_callback(msg);
-      });
+      [this](
+        const AUTOWARE_MESSAGE_CONST_SHARED_PTR(
+          autoware_internal_planning_msgs::msg::CandidateTrajectories) &
+        msg) { trajectories_callback(msg); });
 
   // Setup publishers
   pub_trajectories_ =
@@ -54,7 +54,8 @@ SimpleTrajectoryRanker::SimpleTrajectoryRanker(const rclcpp::NodeOptions & optio
 
 void SimpleTrajectoryRanker::trajectories_callback(
   const AUTOWARE_MESSAGE_CONST_SHARED_PTR(
-    autoware_internal_planning_msgs::msg::CandidateTrajectories) & msg)
+    autoware_internal_planning_msgs::msg::CandidateTrajectories) &
+  msg)
 {
   autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
 

--- a/planning/autoware_trajectory_ranker/src/simple_trajectory_ranker_node.cpp
+++ b/planning/autoware_trajectory_ranker/src/simple_trajectory_ranker_node.cpp
@@ -30,8 +30,8 @@ SimpleTrajectoryRanker::SimpleTrajectoryRanker(const rclcpp::NodeOptions & optio
   sub_trajectories_ =
     create_subscription<autoware_internal_planning_msgs::msg::CandidateTrajectories>(
       "~/input/candidate_trajectories", 1,
-      [this](
-        const autoware_internal_planning_msgs::msg::CandidateTrajectories::ConstSharedPtr msg) {
+      [this](const AUTOWARE_MESSAGE_CONST_SHARED_PTR(
+        autoware_internal_planning_msgs::msg::CandidateTrajectories) & msg) {
         trajectories_callback(msg);
       });
 
@@ -53,7 +53,8 @@ SimpleTrajectoryRanker::SimpleTrajectoryRanker(const rclcpp::NodeOptions & optio
 }
 
 void SimpleTrajectoryRanker::trajectories_callback(
-  const autoware_internal_planning_msgs::msg::CandidateTrajectories::ConstSharedPtr msg)
+  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(
+    autoware_internal_planning_msgs::msg::CandidateTrajectories) & msg)
 {
   autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
 

--- a/planning/autoware_trajectory_ranker/test/simple_trajectory_ranker_node_test.cpp
+++ b/planning/autoware_trajectory_ranker/test/simple_trajectory_ranker_node_test.cpp
@@ -77,7 +77,7 @@ protected:
     rclcpp::WallRate rate(10);
     int count = 0;
     while (!output_msg && count < 100) {  // Spin for a limited time to avoid infinite loop
-      rclcpp::spin_some(node);
+      rclcpp::spin_some(node->get_rclcpp_node());
       rate.sleep();
       count++;
     }


### PR DESCRIPTION
## Description

Apply `agnocast_wrapper::Node` to the `SimpleTrajectoryRanker` node in `autoware_trajectory_ranker`.
Please read https://github.com/autowarefoundation/autoware/issues/7007 for the context and review guidelines of `autoware_agnocast_wrapper` adoption. Also, please refer to https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/docs/review_guide.md for the review guide of `autoware_agnocast_wrapper` application PR. FYI: This node takes [Method2](https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/docs/review_guide.md#method-2-agnocast_wrappernode-inheritance) of two integration methods.

**AgnocastOnlyCallbackIsolatedExecutor:**
  When built and run with `ENABLE_AGNOCAST=1`, the node runs on an `AgnocastOnlyCallbackIsolatedExecutor` (CIE), the standard executor for `agnocast_wrapper::Node`. Please check for potential race conditions only if the node meets **all** of the following:

  1. It was originally running on a `SingleThreadedExecutor`.
  2. It has multiple callback groups (the default is one).
  3. Shared variables are accessed across those callback groups without mutex protection.

Only `SimpleTrajectoryRanker` is converted in this PR. The `TrajectoryRanker` node in the same package remains a plain `rclcpp::Node` and is out of scope.

Main changes:

- `SimpleTrajectoryRanker` now derives from `agnocast_wrapper::Node`; its subscription/publisher use the Agnocast wrapper types (`AUTOWARE_SUBSCRIPTION_PTR`, `AUTOWARE_PUBLISHER_PTR`).
- `AGNOCAST_EXECUTOR` is set to `AgnocastOnlyCallbackIsolatedExecutor`, which is required for Method-2 (`agnocast_wrapper::Node`) nodes.
- The node is launched as a standalone node (not inside a component container).

## Related links

## How was this PR tested?

- **Build**: Confirmed the `autoware_trajectory_ranker` package builds successfully with both `ENABLE_AGNOCAST=0` and `ENABLE_AGNOCAST=1`.
- **Runtime (LSim)**: On an autoware-based product, confirmed via the logging simulator that the node runs under `ENABLE_AGNOCAST=1` and relays messages, publishing `ScoredCandidateTrajectories` in response to the incoming `CandidateTrajectories`.
- **Unit tests**: With `ENABLE_AGNOCAST=0`, all tests pass, including the node integration test that launches the node and checks the published `ScoredCandidateTrajectories`. With `ENABLE_AGNOCAST=1`, the pure-logic tests pass and the node-launching integration test is skipped at the CMake build stage.
- **Standalone launch**: Confirmed the node starts under `ENABLE_AGNOCAST=1` as a standalone node and resolves its parameters correctly with the `AgnocastOnly` executor.

## Notes for reviewers
- **Node integration test**: Since `SimpleTrajectoryRanker` now derives from `agnocast_wrapper::Node`, the test's spin call was adapted from `rclcpp::spin_some(node)` to `rclcpp::spin_some(node->get_rclcpp_node())` (required to compile under `ENABLE_AGNOCAST=0`). The node-launching test is excluded at the CMake build stage under `ENABLE_AGNOCAST=1`, while the pure-logic tests continue to run under both flags. The verification logic of the tests is unchanged.

## Interface changes

None.

## Effects on system behavior

None.