### PR TITLE
refactor(autoware_mission_planner_universe): decouple arrival checker from rclcpp::Node

### DIFF
--- a/planning/autoware_mission_planner_universe/CMakeLists.txt
+++ b/planning/autoware_mission_planner_universe/CMakeLists.txt
@@ -47,6 +47,20 @@ if(BUILD_TESTING)
   ament_target_dependencies(test_${PROJECT_NAME}
     autoware_test_utils
   )
+
+  ament_add_ros_isolated_gtest(test_${PROJECT_NAME}_arrival_checker
+    test/test_arrival_checker.cpp
+    src/mission_planner/arrival_checker.cpp
+  )
+  ament_target_dependencies(test_${PROJECT_NAME}_arrival_checker
+    autoware_utils
+    autoware_planning_msgs
+    geometry_msgs
+    nav_msgs
+    rclcpp
+    tf2
+    tf2_geometry_msgs
+  )
 endif()
 
 ament_auto_package(

--- a/planning/autoware_mission_planner_universe/src/mission_planner/arrival_checker.cpp
+++ b/planning/autoware_mission_planner_universe/src/mission_planner/arrival_checker.cpp
@@ -14,28 +14,59 @@
 
 #include "arrival_checker.hpp"
 
-#include <autoware_utils/geometry/geometry.hpp>
 #include <autoware_utils/math/normalization.hpp>
-#include <autoware_utils/math/unit_conversion.hpp>
 #include <tf2/utils.hpp>
+
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+
+#include <cmath>
+#include <deque>
 
 namespace autoware::mission_planner_universe
 {
 
-ArrivalChecker::ArrivalChecker(rclcpp::Node * node) : vehicle_stop_checker_(node)
+namespace
 {
-  const double angle_deg = node->declare_parameter<double>("arrival_check_angle_deg");
-  angle_ = autoware_utils::deg2rad(angle_deg);
-  arrival_check_lateral_distance_ =
-    node->declare_parameter<double>("arrival_check_lateral_distance");
-  arrival_check_longitudinal_undershoot_distance_ =
-    node->declare_parameter<double>("arrival_check_longitudinal_undershoot_distance");
-  arrival_check_longitudinal_overshoot_distance_ =
-    node->declare_parameter<double>("arrival_check_longitudinal_overshoot_distance");
-  duration_ = node->declare_parameter<double>("arrival_check_duration");
+bool is_vehicle_stopped(
+  const std::deque<geometry_msgs::msg::TwistStamped> & twist_buffer, const double duration)
+{
+  if (twist_buffer.empty()) {
+    return false;
+  }
+
+  constexpr double squared_stop_velocity = 1e-3 * 1e-3;
+
+  const rclcpp::Time now(twist_buffer.front().header.stamp);
+  const auto time_buffer_back = now - rclcpp::Time(twist_buffer.back().header.stamp);
+  if (time_buffer_back.seconds() < duration) {
+    return false;
+  }
+
+  // Get velocities within the stop duration.
+  for (const auto & velocity : twist_buffer) {
+    const double x = velocity.twist.linear.x;
+    const double y = velocity.twist.linear.y;
+    const double z = velocity.twist.linear.z;
+    const double squared_velocity = (x * x) + (y * y) + (z * z);
+    if (squared_stop_velocity <= squared_velocity) {
+      return false;
+    }
+
+    const auto time_diff = now - rclcpp::Time(velocity.header.stamp);
+    if (time_diff.seconds() >= duration) {
+      break;
+    }
+  }
+
+  return true;
+}
+}  // namespace
+
+ArrivalChecker::ArrivalChecker(const ArrivalCheckerThreshold & threshold) : threshold_(threshold)
+{
 }
 
-void ArrivalChecker::set_goal()
+void ArrivalChecker::clear_goal()
 {
   // Ignore the modified goal after the route is cleared.
   goal_with_uuid_ = std::nullopt;
@@ -47,49 +78,73 @@ void ArrivalChecker::set_goal(const PoseWithUuidStamped & goal)
   goal_with_uuid_ = goal;
 }
 
-bool ArrivalChecker::is_arrived(const PoseStamped & pose) const
+void ArrivalChecker::update(const Odometry & odometry)
 {
-  if (!goal_with_uuid_) {
+  odometry_ = odometry;
+
+  TwistStamped twist;
+  twist.header = odometry.header;
+  twist.twist = odometry.twist.twist;
+  twist_buffer_.push_front(twist);
+
+  const rclcpp::Time now(odometry.header.stamp);
+  while (!twist_buffer_.empty()) {
+    // Check oldest data time.
+    const auto time_diff = now - rclcpp::Time(twist_buffer_.back().header.stamp);
+
+    // Finish when oldest data is newer than threshold.
+    if (time_diff.seconds() <= velocity_buffer_time_sec) {
+      break;
+    }
+
+    // Remove old data.
+    twist_buffer_.pop_back();
+  }
+}
+
+bool ArrivalChecker::is_arrived() const
+{
+  if (!odometry_ || !goal_with_uuid_) {
     return false;
   }
-  const auto goal = goal_with_uuid_.value();
+  const auto & goal = goal_with_uuid_.value();
+  const auto & odometry = odometry_.value();
 
   // Check frame id
-  if (goal.header.frame_id != pose.header.frame_id) {
+  if (goal.header.frame_id != odometry.header.frame_id) {
     return false;
   }
 
   // Compute position difference in goal frame
-  const double dx = pose.pose.position.x - goal.pose.position.x;
-  const double dy = pose.pose.position.y - goal.pose.position.y;
+  const double dx = odometry.pose.pose.position.x - goal.pose.position.x;
+  const double dy = odometry.pose.pose.position.y - goal.pose.position.y;
 
   const double yaw_goal = tf2::getYaw(goal.pose.orientation);
   const double longitudinal_offset_to_goal = std::cos(yaw_goal) * dx + std::sin(yaw_goal) * dy;
   const double lateral_offset_to_goal = -std::sin(yaw_goal) * dx + std::cos(yaw_goal) * dy;
 
-  const double yaw_pose = tf2::getYaw(pose.pose.orientation);
+  const double yaw_pose = tf2::getYaw(odometry.pose.pose.orientation);
   const double yaw_diff = autoware_utils::normalize_radian(yaw_pose - yaw_goal);
 
   // Check lateral distance.
   const bool is_within_lateral_range =
-    std::abs(lateral_offset_to_goal) <= arrival_check_lateral_distance_;
+    std::abs(lateral_offset_to_goal) <= threshold_.lateral_distance;
 
   // Check longitudinal distance.
-  // The acceptable range is [-arrival_check_longitudinal_undershoot_distance,
-  // +arrival_check_longitudinal_overshoot_distance_].
+  // The acceptable range is [-longitudinal_undershoot_distance, +longitudinal_overshoot_distance].
   const bool is_within_longitudinal_range =
-    longitudinal_offset_to_goal >= -arrival_check_longitudinal_undershoot_distance_ &&
-    longitudinal_offset_to_goal <= arrival_check_longitudinal_overshoot_distance_;
+    longitudinal_offset_to_goal >= -threshold_.longitudinal_undershoot_distance &&
+    longitudinal_offset_to_goal <= threshold_.longitudinal_overshoot_distance;
 
   // Check angle.
-  const bool is_within_angle_range = std::fabs(yaw_diff) <= angle_;
+  const bool is_within_angle_range = std::fabs(yaw_diff) <= threshold_.angle;
 
   if (!is_within_lateral_range || !is_within_longitudinal_range || !is_within_angle_range) {
     return false;
   }
 
   // Check vehicle stopped.
-  return vehicle_stop_checker_.isVehicleStopped(duration_);
+  return is_vehicle_stopped(twist_buffer_, threshold_.duration);
 }
 
 }  // namespace autoware::mission_planner_universe

--- a/planning/autoware_mission_planner_universe/src/mission_planner/arrival_checker.hpp
+++ b/planning/autoware_mission_planner_universe/src/mission_planner/arrival_checker.hpp
@@ -15,35 +15,58 @@
 #ifndef MISSION_PLANNER__ARRIVAL_CHECKER_HPP_
 #define MISSION_PLANNER__ARRIVAL_CHECKER_HPP_
 
-#include <autoware/motion_utils/vehicle/vehicle_state_checker.hpp>
-#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/time.hpp>
 
 #include <autoware_planning_msgs/msg/pose_with_uuid_stamped.hpp>
-#include <geometry_msgs/msg/pose.hpp>
-#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+
+#include <deque>
+#include <optional>
 
 namespace autoware::mission_planner_universe
 {
+
+struct ArrivalCheckerThreshold
+{
+  // arrival_check_angle [rad] (stores the deg2rad-converted value)
+  double angle{0.0};
+  double lateral_distance{0.0};  // arrival_check_lateral_distance [m]
+  double longitudinal_undershoot_distance{
+    0.0};  // arrival_check_longitudinal_undershoot_distance [m]
+  double longitudinal_overshoot_distance{0.0};  // arrival_check_longitudinal_overshoot_distance [m]
+  double duration{0.0};                         // arrival_check_duration [s]
+};
 
 class ArrivalChecker
 {
 public:
   using PoseWithUuidStamped = autoware_planning_msgs::msg::PoseWithUuidStamped;
-  using PoseStamped = geometry_msgs::msg::PoseStamped;
-  explicit ArrivalChecker(rclcpp::Node * node);
-  void set_goal();
+  using TwistStamped = geometry_msgs::msg::TwistStamped;
+  using Odometry = nav_msgs::msg::Odometry;
+
+  explicit ArrivalChecker(const ArrivalCheckerThreshold & threshold);
+
+  void clear_goal();
   void set_goal(const PoseWithUuidStamped & goal);
-  bool is_arrived(const PoseStamped & pose) const;
+
+  // Keeps the latest odometry and accumulates its twist into the buffer (command).
+  // Equivalent to the odometry subscription + onOdom of the removed VehicleStopChecker.
+  // Call it every cycle regardless of the route state.
+  void update(const Odometry & odometry);
+
+  // Judges arrival from the latest odometry pose and the twist buffer (const query).
+  // Returns false while no odometry has been received. The reference time is the stamp of the
+  // latest odometry.
+  bool is_arrived() const;
 
 private:
-  double angle_;
-  double duration_;
-  double arrival_check_lateral_distance_;
-  double arrival_check_longitudinal_undershoot_distance_;
-  double arrival_check_longitudinal_overshoot_distance_;
+  ArrivalCheckerThreshold threshold_;
   std::optional<PoseWithUuidStamped> goal_with_uuid_;
-  rclcpp::Subscription<PoseWithUuidStamped>::SharedPtr sub_goal_;
-  autoware::motion_utils::VehicleStopChecker vehicle_stop_checker_;
+  std::optional<Odometry> odometry_;
+  std::deque<TwistStamped> twist_buffer_;
+
+  static constexpr double velocity_buffer_time_sec = 10.0;
 };
 
 }  // namespace autoware::mission_planner_universe

--- a/planning/autoware_mission_planner_universe/src/mission_planner/mission_planner.cpp
+++ b/planning/autoware_mission_planner_universe/src/mission_planner/mission_planner.cpp
@@ -18,6 +18,7 @@
 #include <autoware/lanelet2_utils/geometry.hpp>
 #include <autoware/lanelet2_utils/nn_search.hpp>
 #include <autoware/mission_planner_universe/service_utils.hpp>
+#include <autoware_utils/math/unit_conversion.hpp>
 
 #include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
@@ -53,11 +54,25 @@ std::string route_state_to_string(const uint8_t state)
       // clang-format on
   }
 }
+
+ArrivalCheckerThreshold get_arrival_checker_threshold(rclcpp::Node & node)
+{
+  ArrivalCheckerThreshold threshold;
+  threshold.angle =
+    autoware_utils::deg2rad(node.declare_parameter<double>("arrival_check_angle_deg"));
+  threshold.lateral_distance = node.declare_parameter<double>("arrival_check_lateral_distance");
+  threshold.longitudinal_undershoot_distance =
+    node.declare_parameter<double>("arrival_check_longitudinal_undershoot_distance");
+  threshold.longitudinal_overshoot_distance =
+    node.declare_parameter<double>("arrival_check_longitudinal_overshoot_distance");
+  threshold.duration = node.declare_parameter<double>("arrival_check_duration");
+  return threshold;
+}
 }  // namespace
 
 MissionPlanner::MissionPlanner(const rclcpp::NodeOptions & options)
 : Node("mission_planner", options),
-  arrival_checker_(this),
+  arrival_checker_(get_arrival_checker_threshold(*this)),
   plugin_loader_(
     "autoware_mission_planner_universe", "autoware::mission_planner_universe::PlannerPlugin"),
   tf_buffer_(get_clock()),
@@ -172,13 +187,11 @@ void MissionPlanner::check_initialization()
 void MissionPlanner::on_odometry(const Odometry::ConstSharedPtr msg)
 {
   odometry_ = msg;
+  arrival_checker_.update(*msg);
 
   // NOTE: Do not check in the other states as goal may change.
   if (state_.state == RouteState::SET) {
-    PoseStamped pose;
-    pose.header = odometry_->header;
-    pose.pose = odometry_->pose.pose;
-    if (arrival_checker_.is_arrived(pose)) {
+    if (arrival_checker_.is_arrived()) {
       change_state(RouteState::ARRIVED);
     }
   }
@@ -494,7 +507,7 @@ void MissionPlanner::change_route()
 {
   current_route_ = nullptr;
   planner_->clearRoute();
-  arrival_checker_.set_goal();
+  arrival_checker_.clear_goal();
 
   // TODO(Takagi, Isamu): publish an empty route here
   // pub_route_->publish();

--- a/planning/autoware_mission_planner_universe/src/mission_planner/mission_planner.hpp
+++ b/planning/autoware_mission_planner_universe/src/mission_planner/mission_planner.hpp
@@ -35,7 +35,6 @@
 #include <autoware_planning_msgs/srv/set_lanelet_route.hpp>
 #include <autoware_planning_msgs/srv/set_preferred_primitive.hpp>
 #include <autoware_planning_msgs/srv/set_waypoint_route.hpp>
-#include <geometry_msgs/msg/pose_stamped.hpp>
 #include <tier4_planning_msgs/msg/reroute_availability.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
@@ -61,7 +60,6 @@ using autoware_planning_msgs::srv::SetLaneletRoute;
 using autoware_planning_msgs::srv::SetPreferredPrimitive;
 using autoware_planning_msgs::srv::SetWaypointRoute;
 using geometry_msgs::msg::Pose;
-using geometry_msgs::msg::PoseStamped;
 using nav_msgs::msg::Odometry;
 using std_msgs::msg::Header;
 using tier4_planning_msgs::msg::RerouteAvailability;

--- a/planning/autoware_mission_planner_universe/test/test_arrival_checker.cpp
+++ b/planning/autoware_mission_planner_universe/test/test_arrival_checker.cpp
@@ -1,0 +1,347 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "../src/mission_planner/arrival_checker.hpp"
+
+#include <rclcpp/time.hpp>
+
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+
+#include <gtest/gtest.h>
+#include <tf2/LinearMath/Quaternion.h>
+
+#include <string>
+
+namespace
+{
+using autoware::mission_planner_universe::ArrivalChecker;
+using autoware::mission_planner_universe::ArrivalCheckerThreshold;
+using Odometry = ArrivalChecker::Odometry;
+using PoseWithUuidStamped = ArrivalChecker::PoseWithUuidStamped;
+
+constexpr double default_lateral_distance = 1.0;
+constexpr double default_longitudinal_undershoot_distance = 1.0;
+constexpr double default_longitudinal_overshoot_distance = 1.0;
+constexpr double default_angle = 45.0 * M_PI / 180.0;
+constexpr double default_duration = 1.0;
+
+ArrivalCheckerThreshold make_threshold(
+  const double lateral_distance = default_lateral_distance,
+  const double longitudinal_undershoot_distance = default_longitudinal_undershoot_distance,
+  const double longitudinal_overshoot_distance = default_longitudinal_overshoot_distance)
+{
+  ArrivalCheckerThreshold threshold;
+  threshold.angle = default_angle;
+  threshold.lateral_distance = lateral_distance;
+  threshold.longitudinal_undershoot_distance = longitudinal_undershoot_distance;
+  threshold.longitudinal_overshoot_distance = longitudinal_overshoot_distance;
+  threshold.duration = default_duration;
+  return threshold;
+}
+
+Odometry make_odometry(
+  const double time_sec, const double x, const double y, const double yaw, const double velocity_x,
+  const std::string & frame_id = "map")
+{
+  Odometry odometry;
+  odometry.header.stamp = rclcpp::Time(time_sec * 1e9);
+  odometry.header.frame_id = frame_id;
+  odometry.pose.pose.position.x = x;
+  odometry.pose.pose.position.y = y;
+  tf2::Quaternion quaternion;
+  quaternion.setRPY(0.0, 0.0, yaw);
+  odometry.pose.pose.orientation = tf2::toMsg(quaternion);
+  odometry.twist.twist.linear.x = velocity_x;
+  return odometry;
+}
+
+PoseWithUuidStamped make_goal(
+  const double x, const double y, const double yaw, const std::string & frame_id = "map")
+{
+  PoseWithUuidStamped goal;
+  goal.header.frame_id = frame_id;
+  goal.pose.position.x = x;
+  goal.pose.position.y = y;
+  tf2::Quaternion quaternion;
+  quaternion.setRPY(0.0, 0.0, yaw);
+  goal.pose.orientation = tf2::toMsg(quaternion);
+  return goal;
+}
+
+// Feeds a stopped (zero-velocity) odometry sequence at the given pose that spans the stop duration,
+// so that the internal stopped check becomes true.
+void feed_stopped_at(
+  ArrivalChecker & arrival_checker, const double x, const double y, const double yaw)
+{
+  for (double time_sec = 0.0; time_sec <= default_duration + 0.5; time_sec += 0.1) {
+    arrival_checker.update(make_odometry(time_sec, x, y, yaw, 0.0));
+  }
+}
+
+}  // namespace
+
+TEST(ArrivalChecker, NoGoalReturnsFalse)
+{
+  // Arrange
+  ArrivalChecker arrival_checker(make_threshold());
+  feed_stopped_at(arrival_checker, 0.0, 0.0, 0.0);
+
+  // Act & Assert
+  EXPECT_FALSE(arrival_checker.is_arrived());
+}
+
+TEST(ArrivalChecker, NoOdometryReturnsFalse)
+{
+  // Arrange
+  ArrivalChecker arrival_checker(make_threshold());
+  arrival_checker.set_goal(make_goal(0.0, 0.0, 0.0));
+
+  // Act & Assert
+  EXPECT_FALSE(arrival_checker.is_arrived());
+}
+
+TEST(ArrivalChecker, DifferentFrameIdReturnsFalse)
+{
+  // Arrange
+  ArrivalChecker arrival_checker(make_threshold());
+  arrival_checker.set_goal(make_goal(0.0, 0.0, 0.0, "map"));
+  for (double time_sec = 0.0; time_sec <= default_duration + 0.5; time_sec += 0.1) {
+    arrival_checker.update(make_odometry(time_sec, 0.0, 0.0, 0.0, 0.0, "base_link"));
+  }
+
+  // Act & Assert
+  EXPECT_FALSE(arrival_checker.is_arrived());
+}
+
+TEST(ArrivalChecker, OutOfLateralDistanceReturnsFalse)
+{
+  // Arrange: offset perpendicular to the goal heading, beyond the lateral bound.
+  ArrivalChecker arrival_checker(make_threshold());
+  arrival_checker.set_goal(make_goal(0.0, 0.0, 0.0));
+  feed_stopped_at(arrival_checker, 0.0, default_lateral_distance + 0.5, 0.0);
+
+  // Act & Assert
+  EXPECT_FALSE(arrival_checker.is_arrived());
+}
+
+TEST(ArrivalChecker, OutOfLongitudinalOvershootReturnsFalse)
+{
+  // Arrange: ahead of the goal, beyond the overshoot bound.
+  ArrivalChecker arrival_checker(make_threshold());
+  arrival_checker.set_goal(make_goal(0.0, 0.0, 0.0));
+  feed_stopped_at(arrival_checker, default_longitudinal_overshoot_distance + 0.5, 0.0, 0.0);
+
+  // Act & Assert
+  EXPECT_FALSE(arrival_checker.is_arrived());
+}
+
+TEST(ArrivalChecker, OutOfLongitudinalUndershootReturnsFalse)
+{
+  // Arrange: behind the goal, beyond the undershoot bound.
+  ArrivalChecker arrival_checker(make_threshold());
+  arrival_checker.set_goal(make_goal(0.0, 0.0, 0.0));
+  feed_stopped_at(arrival_checker, -(default_longitudinal_undershoot_distance + 0.5), 0.0, 0.0);
+
+  // Act & Assert
+  EXPECT_FALSE(arrival_checker.is_arrived());
+}
+
+TEST(ArrivalChecker, LateralAtBoundaryArrived)
+{
+  // Exactly at the lateral bound is still an arrival (inclusive `<=`).
+  ArrivalChecker arrival_checker(make_threshold());
+  arrival_checker.set_goal(make_goal(0.0, 0.0, 0.0));
+  feed_stopped_at(arrival_checker, 0.0, default_lateral_distance, 0.0);
+
+  // Act & Assert
+  EXPECT_TRUE(arrival_checker.is_arrived());
+}
+
+TEST(ArrivalChecker, LongitudinalOvershootAtBoundaryArrived)
+{
+  // Exactly at the overshoot bound is still an arrival (inclusive `<=`).
+  ArrivalChecker arrival_checker(make_threshold());
+  arrival_checker.set_goal(make_goal(0.0, 0.0, 0.0));
+  feed_stopped_at(arrival_checker, default_longitudinal_overshoot_distance, 0.0, 0.0);
+
+  // Act & Assert
+  EXPECT_TRUE(arrival_checker.is_arrived());
+}
+
+TEST(ArrivalChecker, LongitudinalUndershootAtBoundaryArrived)
+{
+  // Exactly at the undershoot bound is still an arrival (inclusive `>=`).
+  ArrivalChecker arrival_checker(make_threshold());
+  arrival_checker.set_goal(make_goal(0.0, 0.0, 0.0));
+  feed_stopped_at(arrival_checker, -default_longitudinal_undershoot_distance, 0.0, 0.0);
+
+  // Act & Assert
+  EXPECT_TRUE(arrival_checker.is_arrived());
+}
+
+TEST(ArrivalChecker, ArrivedBehindGoalWithinUndershoot)
+{
+  // The undershoot (behind) bound is applied independently of the overshoot bound: a point behind
+  // the goal, beyond the (narrow) overshoot but within the (wide) undershoot, is an arrival.
+  ArrivalChecker arrival_checker(make_threshold(default_lateral_distance, 2.0, 0.5));
+  arrival_checker.set_goal(make_goal(0.0, 0.0, 0.0));
+  feed_stopped_at(arrival_checker, -1.5, 0.0, 0.0);
+
+  // Act & Assert
+  EXPECT_TRUE(arrival_checker.is_arrived());
+}
+
+TEST(ArrivalChecker, ArrivedAheadGoalWithinOvershoot)
+{
+  // The overshoot (ahead) bound is applied independently of the undershoot bound: a point ahead of
+  // the goal, beyond the (narrow) undershoot but within the (wide) overshoot, is an arrival.
+  ArrivalChecker arrival_checker(make_threshold(default_lateral_distance, 0.5, 2.0));
+  arrival_checker.set_goal(make_goal(0.0, 0.0, 0.0));
+  feed_stopped_at(arrival_checker, 1.5, 0.0, 0.0);
+
+  // Act & Assert
+  EXPECT_TRUE(arrival_checker.is_arrived());
+}
+
+TEST(ArrivalChecker, RotatedGoalLongitudinalWithinBoundArrived)
+{
+  // Goal facing +y, so its longitudinal axis is world +y. An offset along world +y must be
+  // treated as longitudinal (within the wide longitudinal bound), not lateral.
+  ArrivalChecker arrival_checker(make_threshold(0.5, 2.0, 2.0));
+  const double goal_yaw = M_PI / 2.0;
+  arrival_checker.set_goal(make_goal(0.0, 0.0, goal_yaw));
+  feed_stopped_at(arrival_checker, 0.0, 1.5, goal_yaw);
+
+  // Act & Assert
+  EXPECT_TRUE(arrival_checker.is_arrived());
+}
+
+TEST(ArrivalChecker, RotatedGoalLateralOutOfBoundReturnsFalse)
+{
+  // Goal facing +y, so its lateral axis is world +x. An offset along world +x must be treated as
+  // lateral (beyond the narrow lateral bound), not longitudinal.
+  ArrivalChecker arrival_checker(make_threshold(0.5, 2.0, 2.0));
+  const double goal_yaw = M_PI / 2.0;
+  arrival_checker.set_goal(make_goal(0.0, 0.0, goal_yaw));
+  feed_stopped_at(arrival_checker, 1.5, 0.0, goal_yaw);
+
+  // Act & Assert
+  EXPECT_FALSE(arrival_checker.is_arrived());
+}
+
+TEST(ArrivalChecker, OutOfAngleReturnsFalse)
+{
+  // Arrange
+  ArrivalChecker arrival_checker(make_threshold());
+  arrival_checker.set_goal(make_goal(0.0, 0.0, 0.0));
+  feed_stopped_at(arrival_checker, 0.0, 0.0, default_angle + 0.2);
+
+  // Act & Assert
+  EXPECT_FALSE(arrival_checker.is_arrived());
+}
+
+TEST(ArrivalChecker, AngleJustWithinBoundaryArrived)
+{
+  // Just inside the angle bound is an arrival (complements OutOfAngleReturnsFalse just outside it).
+  ArrivalChecker arrival_checker(make_threshold());
+  arrival_checker.set_goal(make_goal(0.0, 0.0, 0.0));
+  feed_stopped_at(arrival_checker, 0.0, 0.0, default_angle - 1e-3);
+
+  // Act & Assert
+  EXPECT_TRUE(arrival_checker.is_arrived());
+}
+
+TEST(ArrivalChecker, AngleWrapAroundArrived)
+{
+  // The heading difference is normalized: a goal near +pi and an ego near -pi differ by ~2*pi in
+  // raw terms but are actually aligned, so this is an arrival.
+  ArrivalChecker arrival_checker(make_threshold());
+  arrival_checker.set_goal(make_goal(0.0, 0.0, 3.0));
+  feed_stopped_at(arrival_checker, 0.0, 0.0, -3.0);
+
+  // Act & Assert
+  EXPECT_TRUE(arrival_checker.is_arrived());
+}
+
+TEST(ArrivalChecker, NotStoppedReturnsFalse)
+{
+  // Arrange
+  ArrivalChecker arrival_checker(make_threshold());
+  arrival_checker.set_goal(make_goal(0.0, 0.0, 0.0));
+  for (double time_sec = 0.0; time_sec <= default_duration + 0.5; time_sec += 0.1) {
+    arrival_checker.update(make_odometry(time_sec, 0.0, 0.0, 0.0, 1.0));  // moving
+  }
+
+  // Act & Assert
+  EXPECT_FALSE(arrival_checker.is_arrived());
+}
+
+TEST(ArrivalChecker, NotStoppedLongEnoughReturnsFalse)
+{
+  // Arrange: stopped, but the buffer does not yet span the required stop duration.
+  ArrivalChecker arrival_checker(make_threshold());
+  arrival_checker.set_goal(make_goal(0.0, 0.0, 0.0));
+  arrival_checker.update(make_odometry(0.0, 0.0, 0.0, 0.0, 0.0));
+  arrival_checker.update(make_odometry(default_duration / 2.0, 0.0, 0.0, 0.0, 0.0));
+
+  // Act & Assert
+  EXPECT_FALSE(arrival_checker.is_arrived());
+}
+
+TEST(ArrivalChecker, MovingEarlierThenStoppedIsArrived)
+{
+  // Only the most recent `duration` of history matters: moving earlier but stopped for the last
+  // `duration` at the goal is an arrival.
+  ArrivalChecker arrival_checker(make_threshold());
+  arrival_checker.set_goal(make_goal(0.0, 0.0, 0.0));
+  for (double time_sec = 0.0; time_sec <= 2.0 * default_duration; time_sec += 0.1) {
+    const double velocity_x = (time_sec < 0.5 * default_duration) ? 1.0 : 0.0;
+    arrival_checker.update(make_odometry(time_sec, 0.0, 0.0, 0.0, velocity_x));
+  }
+
+  // Act & Assert
+  EXPECT_TRUE(arrival_checker.is_arrived());
+}
+
+TEST(ArrivalChecker, ArrivedWhenStoppedAtGoal)
+{
+  // Arrange
+  ArrivalChecker arrival_checker(make_threshold());
+  arrival_checker.set_goal(make_goal(0.0, 0.0, 0.0));
+  feed_stopped_at(arrival_checker, 0.0, 0.0, 0.0);
+
+  // Act & Assert
+  EXPECT_TRUE(arrival_checker.is_arrived());
+}
+
+TEST(ArrivalChecker, ClearGoalAfterSet)
+{
+  // Arrange
+  ArrivalChecker arrival_checker(make_threshold());
+  arrival_checker.set_goal(make_goal(0.0, 0.0, 0.0));
+  feed_stopped_at(arrival_checker, 0.0, 0.0, 0.0);
+  ASSERT_TRUE(arrival_checker.is_arrived());
+
+  // Act
+  arrival_checker.clear_goal();
+
+  // Assert
+  EXPECT_FALSE(arrival_checker.is_arrived());
+}
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Description

Decouple `ArrivalChecker` from `rclcpp::Node` in `autoware_mission_planner_universe`, mirroring the equivalent refactor already merged for the core `autoware_mission_planner` (autowarefoundation/autoware_core#1253).

`ArrivalChecker` now takes an `ArrivalCheckerThreshold` struct instead of a node, keeps its own odometry and twist buffer, and exposes `update(odometry)` / `is_arrived()` (no-arg) / `set_goal(goal)` / `clear_goal()`. The `autoware::motion_utils::VehicleStopChecker` dependency (which created its own subscription internally) is replaced by a self-contained stopped-vehicle check over the twist buffer. `MissionPlanner` builds the threshold from parameters via `get_arrival_checker_threshold(node)`, calls `update()` every odometry cycle, and calls `is_arrived()` in the `SET` state.

Pure refactor — the arrival-check behavior is unchanged. Note this keeps the universe directional-box check (lateral / longitudinal-undershoot / longitudinal-overshoot / angle / duration), which differs from core's single-distance check.

This also lets the upcoming `agnocast_wrapper::Node` migration of `MissionPlanner` leave `ArrivalChecker` untouched, since it no longer depends on the node type.

## Related links

- autowarefoundation/autoware_core#1253

## How was this PR tested?

- `colcon build` succeeds.
- Added `test/test_arrival_checker.cpp` (12 cases) covering all five thresholds and states: no goal, no odometry, different frame id, out-of-lateral-distance, out-of-longitudinal-overshoot, out-of-longitudinal-undershoot, asymmetric longitudinal bounds, out-of-angle, not stopped, not stopped long enough, arrived when stopped at goal, and clear goal. All pass.

## Notes for reviewers

Behavior is preserved: the five thresholds (angle, lateral_distance, longitudinal_undershoot_distance, longitudinal_overshoot_distance, duration) and the directional-box acceptance region are the same as before; only the node coupling and the internal stopped-vehicle bookkeeping changed.

## Interface changes

None.
