### PR TITLE
refactor(pid_logitudinal_controller): cleanup core logic

### DIFF
--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
@@ -252,8 +252,6 @@ private:
   // control state
   ControlState m_control_state{ControlState::STOPPED};
 
-  std::optional<double> m_prev_nearest_time{std::nullopt};
-
   // drive
   PIDController m_pid_vel;
   std::shared_ptr<LowpassFilter1d> m_lpf_vel_error{nullptr};

--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
@@ -333,14 +333,6 @@ private:
   Motion calcCtrlCmd(const ControlData & control_data);
 
   /**
-   * @brief create the control command message
-   * @param [in] ctrl_cmd calculated control command to control velocity
-   * @param [in] current_time time captured once per control cycle in run()
-   */
-  autoware_control_msgs::msg::Longitudinal createCtrlCmdMsg(
-    const Motion & ctrl_cmd, const rclcpp::Time & current_time) const;
-
-  /**
    * @brief update debug values
    * @param [in] ctrl_cmd calculated control command to control velocity
    * @param [in] control_data data for control calculation

--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
@@ -289,9 +289,7 @@ private:
 
   std::optional<MarkerArray> m_virtual_wall_marker{std::nullopt};
 
-  // time captured once per control cycle in run(), and whether the lateral controller has
-  // converged its steering for this cycle
-  rclcpp::Time m_current_time{};
+  // whether the lateral controller has converged its steering for this cycle
   bool m_is_steer_converged{false};
 
   // error causes raised during this run(), to be logged by the caller

--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
@@ -354,23 +354,10 @@ private:
   double getDt(const rclcpp::Time & current_time);
 
   /**
-   * @brief calculate current velocity and acceleration
-   */
-  Motion getCurrentMotion() const;
-
-  /**
    * @brief calculate direction (forward or backward) that vehicle moves
    * @param [in] control_data data for control calculation
    */
   enum Shift getCurrentShift(const ControlData & control_data) const;
-
-  /**
-   * @brief filter acceleration command with limitation of acceleration and jerk, and slope
-   * compensation
-   * @param [in] raw_acc acceleration before filtered
-   * @param [in] control_data data for control calculation
-   */
-  double calcFilteredAcc(const double raw_acc, const ControlData & control_data);
 
   /**
    * @brief store acceleration command before slope compensation

--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
@@ -287,9 +287,6 @@ private:
 
   std::optional<MarkerArray> m_virtual_wall_marker{std::nullopt};
 
-  // error causes raised during this run(), to be logged by the caller
-  std::optional<std::string> m_emergency_stop_reason{std::nullopt};
-
   struct ResultWithReason
   {
     bool result{false};
@@ -315,15 +312,19 @@ private:
    * @brief change control state
    * @param [in] new state
    * @param [in] reason to change control state
+   * @return reason for entering the emergency state, if the new state is EMERGENCY
    */
-  void changeControlState(const ControlState & control_state, const std::string & reason = "");
+  std::optional<std::string> changeControlState(
+    const ControlState & control_state, const std::string & reason = "");
 
   /**
    * @brief update control state according to the current situation
    * @param [in] control_data control data
    * @param [in] is_steer_converged whether the lateral controller has converged its steering
+   * @return reason for entering the emergency state, if it was entered during this call
    */
-  void updateControlState(const ControlData & control_data, const bool is_steer_converged);
+  std::optional<std::string> updateControlState(
+    const ControlData & control_data, const bool is_steer_converged);
 
   /**
    * @brief calculate control command based on the current control state

--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
@@ -288,7 +288,6 @@ private:
   std::optional<MarkerArray> m_virtual_wall_marker{std::nullopt};
 
   // error causes raised during this run(), to be logged by the caller
-  bool m_received_invalid_trajectory{false};
   std::optional<std::string> m_emergency_stop_reason{std::nullopt};
 
   struct ResultWithReason

--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
@@ -338,7 +338,7 @@ private:
    * @param [in] current_time time captured once per control cycle in run()
    */
   autoware_control_msgs::msg::Longitudinal createCtrlCmdMsg(
-    const Motion & ctrl_cmd, const rclcpp::Time & current_time);
+    const Motion & ctrl_cmd, const rclcpp::Time & current_time) const;
 
   /**
    * @brief update debug values
@@ -429,7 +429,7 @@ private:
    * @brief calculate elapsed time since the vehicle entered autoware control
    * @param [in] current_time time captured once per control cycle in run()
    */
-  double getTimeUnderControl(const rclcpp::Time & current_time);
+  double getTimeUnderControl(const rclcpp::Time & current_time) const;
 };
 }  // namespace autoware::motion::control::pid_longitudinal_controller
 

--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
@@ -287,9 +287,6 @@ private:
 
   std::optional<MarkerArray> m_virtual_wall_marker{std::nullopt};
 
-  // whether the lateral controller has converged its steering for this cycle
-  bool m_is_steer_converged{false};
-
   // error causes raised during this run(), to be logged by the caller
   bool m_received_invalid_trajectory{false};
   std::optional<std::string> m_emergency_stop_reason{std::nullopt};
@@ -325,8 +322,9 @@ private:
   /**
    * @brief update control state according to the current situation
    * @param [in] control_data control data
+   * @param [in] is_steer_converged whether the lateral controller has converged its steering
    */
-  void updateControlState(const ControlData & control_data);
+  void updateControlState(const ControlData & control_data, const bool is_steer_converged);
 
   /**
    * @brief calculate control command based on the current control state

--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
@@ -210,6 +210,12 @@ private:
     double vel{0.0};
     double acc{0.0};
   };
+  // entry of the sent-acceleration-command history buffer used for delay compensation
+  struct TimestampedAcceleration
+  {
+    rclcpp::Time stamp;
+    double acceleration{0.0};
+  };
   struct StateAfterDelay
   {
     StateAfterDelay(const double velocity, const double acceleration, const double distance)
@@ -266,7 +272,7 @@ private:
   std::optional<double> m_previous_slope_angle{std::nullopt};
 
   // buffer of send command
-  std::vector<autoware_control_msgs::msg::Longitudinal> m_ctrl_cmd_vec;
+  std::vector<TimestampedAcceleration> m_ctrl_cmd_vec;
 
   // for calculating dt
   std::shared_ptr<rclcpp::Time> m_prev_control_time{nullptr};

--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -182,7 +182,8 @@ PidLongitudinalController::ControlData PidLongitudinalController::getControlData
   autoware_planning_msgs::msg::TrajectoryPoint target_point;
 
   if (config.use_temporal_trajectory) {
-    const rclcpp::Time traj_stamp(m_last_valid_trajectory.header.stamp);
+    const rclcpp::Time traj_stamp(
+      m_last_valid_trajectory.header.stamp, current_time.get_clock_type());
     const double elapsed_time = (current_time - traj_stamp).seconds();
     const double nearest_time = std::clamp(elapsed_time, traj_start_time, traj_end_time);
     control_data.temporal_predicted_time = nearest_time;
@@ -692,13 +693,7 @@ enum PidLongitudinalController::Shift PidLongitudinalController::getCurrentShift
 void PidLongitudinalController::storeAccelCmd(const double accel, const rclcpp::Time & current_time)
 {
   if (m_control_state == ControlState::DRIVE) {
-    // convert format
-    autoware_control_msgs::msg::Longitudinal cmd;
-    cmd.stamp = current_time;
-    cmd.acceleration = static_cast<decltype(cmd.acceleration)>(accel);
-
-    // store published ctrl cmd
-    m_ctrl_cmd_vec.emplace_back(cmd);
+    m_ctrl_cmd_vec.push_back(TimestampedAcceleration{current_time, accel});
   } else {
     // reset command
     m_ctrl_cmd_vec.clear();
@@ -811,9 +806,7 @@ PidLongitudinalController::StateAfterDelay PidLongitudinalController::predictedS
               (control_data.current_time - m_ctrl_cmd_vec.back().stamp).seconds(),
               delay_compensation_time)
           : std::min(
-              (rclcpp::Time(m_ctrl_cmd_vec.at(i + 1).stamp) -
-               rclcpp::Time(m_ctrl_cmd_vec.at(i).stamp))
-                .seconds(),
+              (m_ctrl_cmd_vec.at(i + 1).stamp - m_ctrl_cmd_vec.at(i).stamp).seconds(),
               delay_compensation_time);
       const double acc = m_ctrl_cmd_vec.at(i).acceleration;
       // because acc_cmd is positive when vehicle is running backward

--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -79,8 +79,6 @@ PidLongitudinalControllerResult PidLongitudinalController::run(
   const trajectory_follower::InputData & input_data, const rclcpp::Time & current_time,
   const bool is_steer_converged)
 {
-  // capture the lateral convergence state once for this control cycle
-  m_is_steer_converged = is_steer_converged;
   m_received_invalid_trajectory = false;
   m_emergency_stop_reason = std::nullopt;
 
@@ -93,7 +91,7 @@ PidLongitudinalControllerResult PidLongitudinalController::run(
   const auto control_data = getControlData(input_data, current_time);
 
   // update control state
-  updateControlState(control_data);
+  updateControlState(control_data, is_steer_converged);
 
   // calculate control command
   const Motion ctrl_cmd = calcCtrlCmd(control_data);
@@ -349,7 +347,8 @@ void PidLongitudinalController::changeControlState(
   m_control_state = control_state;
 }
 
-void PidLongitudinalController::updateControlState(const ControlData & control_data)
+void PidLongitudinalController::updateControlState(
+  const ControlData & control_data, const bool is_steer_converged)
 {
   const double current_vel = control_data.current_motion.vel;
   const double stop_dist = control_data.stop_dist;
@@ -473,9 +472,9 @@ void PidLongitudinalController::updateControlState(const ControlData & control_d
     if (departure_condition_from_stopped) {
       // Let vehicle start after the steering is converged for dry steering
       const bool current_keep_stopped_condition =
-        std::fabs(current_vel) < vel_epsilon && !m_is_steer_converged;
+        std::fabs(current_vel) < vel_epsilon && !is_steer_converged;
       // NOTE: Dry steering is considered unnecessary when the steering is converged twice in a
-      //       row. This is because m_is_steer_converged is not the current but
+      //       row. This is because is_steer_converged is not the current but
       //       the previous value due to the order controllers' run and sync functions.
       const bool keep_stopped_condition =
         !m_prev_keep_stopped_condition ||

--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -173,7 +173,6 @@ PidLongitudinalController::ControlData PidLongitudinalController::getControlData
     const double nearest_time = std::clamp(elapsed_time, traj_start_time, traj_end_time);
     control_data.temporal_predicted_time = nearest_time;
     control_data.temporal_fused_time = nearest_time;
-    m_prev_nearest_time = nearest_time;
 
     const auto nearest_interpolated_point = longitudinal_utils::lerpTrajectoryPointByTime(
       control_data.interpolated_traj.points, nearest_time);
@@ -239,7 +238,6 @@ PidLongitudinalController::ControlData PidLongitudinalController::getControlData
   // ==========================================================================================
   // Spatial-only de-duplication and index re-acquisition after inserting interpolated points.
   if (!config.use_temporal_trajectory) {
-    m_prev_nearest_time.reset();
     control_data.interpolated_traj.points =
       autoware::motion_utils::removeOverlapPoints(control_data.interpolated_traj.points);
     control_data.nearest_idx = autoware::motion_utils::findFirstNearestIndexWithSoftConstraints(

--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -99,13 +99,11 @@ PidLongitudinalControllerResult PidLongitudinalController::run(
   const trajectory_follower::InputData & input_data, const rclcpp::Time & current_time,
   const bool is_steer_converged)
 {
-  m_emergency_stop_reason = std::nullopt;
-
   // calculate control data
   const auto control_data = getControlData(input_data, current_time);
 
   // update control state
-  updateControlState(control_data, is_steer_converged);
+  const auto emergency_stop_reason = updateControlState(control_data, is_steer_converged);
 
   // calculate control command
   const Motion ctrl_cmd = calcCtrlCmd(control_data);
@@ -135,7 +133,7 @@ PidLongitudinalControllerResult PidLongitudinalController::run(
   }
   result.received_invalid_trajectory =
     !is_valid_trajectory(input_data.current_trajectory, config.use_temporal_trajectory);
-  result.emergency_stop_reason = m_emergency_stop_reason;
+  result.emergency_stop_reason = emergency_stop_reason;
 
   return result;
 }
@@ -344,18 +342,20 @@ PidLongitudinalController::Motion PidLongitudinalController::calcEmergencyCtrlCm
   return raw_ctrl_cmd;
 }
 
-void PidLongitudinalController::changeControlState(
+std::optional<std::string> PidLongitudinalController::changeControlState(
   const ControlState & control_state, const std::string & reason)
 {
+  std::optional<std::string> emergency_stop_reason{std::nullopt};
   if (control_state != m_control_state) {
     if (control_state == ControlState::EMERGENCY) {
-      m_emergency_stop_reason = reason;
+      emergency_stop_reason = reason;
     }
   }
   m_control_state = control_state;
+  return emergency_stop_reason;
 }
 
-void PidLongitudinalController::updateControlState(
+std::optional<std::string> PidLongitudinalController::updateControlState(
   const ControlData & control_data, const bool is_steer_converged)
 {
   const double current_vel = control_data.current_motion.vel;
@@ -450,7 +450,7 @@ void PidLongitudinalController::updateControlState(
         return changeControlState(ControlState::STOPPED);
       }
     }
-    return;
+    return std::nullopt;
   }
 
   // in STOPPING state
@@ -469,13 +469,13 @@ void PidLongitudinalController::updateControlState(
       m_prev_raw_ctrl_cmd.acc = std::max(0.0, m_prev_raw_ctrl_cmd.acc);
       return changeControlState(ControlState::DRIVE);
     }
-    return;
+    return std::nullopt;
   }
 
   // in STOPPED state
   if (m_control_state == ControlState::STOPPED) {
     // keep STOPPED if is_under_control is false
-    if (!is_under_control && stopped_condition) return;
+    if (!is_under_control && stopped_condition) return std::nullopt;
 
     if (departure_condition_from_stopped) {
       // Let vehicle start after the steering is converged for dry steering
@@ -497,7 +497,7 @@ void PidLongitudinalController::updateControlState(
         }
 
         // keep STOPPED
-        return;
+        return std::nullopt;
       }
 
       m_pid_vel.reset();
@@ -506,7 +506,7 @@ void PidLongitudinalController::updateControlState(
       return changeControlState(ControlState::DRIVE);
     }
 
-    return;
+    return std::nullopt;
   }
 
   // in EMERGENCY state
@@ -521,11 +521,12 @@ void PidLongitudinalController::updateControlState(
         return changeControlState(ControlState::DRIVE);
       }
     }
-    return;
+    return std::nullopt;
   }
 
   // NOTE: unreachable. ControlState has only DRIVE, STOPPING, STOPPED, and EMERGENCY, and every
   // branch above returns.
+  return std::nullopt;
 }
 
 PidLongitudinalController::Motion PidLongitudinalController::calcCtrlCmd(

--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -79,8 +79,7 @@ PidLongitudinalControllerResult PidLongitudinalController::run(
   const trajectory_follower::InputData & input_data, const rclcpp::Time & current_time,
   const bool is_steer_converged)
 {
-  // capture the time and lateral convergence state once for this control cycle
-  m_current_time = current_time;
+  // capture the lateral convergence state once for this control cycle
   m_is_steer_converged = is_steer_converged;
   m_received_invalid_trajectory = false;
   m_emergency_stop_reason = std::nullopt;

--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -619,19 +619,19 @@ PidLongitudinalController::Motion PidLongitudinalController::calcCtrlCmd(
   // update debug visualization
   updateDebugVelAcc(control_data);
 
+  m_prev_ctrl_cmd = ctrl_cmd_as_pedal_pos;
+
   return ctrl_cmd_as_pedal_pos;
 }
 
 // Do not use nearest_idx here
 autoware_control_msgs::msg::Longitudinal PidLongitudinalController::createCtrlCmdMsg(
-  const Motion & ctrl_cmd, const rclcpp::Time & current_time)
+  const Motion & ctrl_cmd, const rclcpp::Time & current_time) const
 {
   autoware_control_msgs::msg::Longitudinal cmd{};
   cmd.stamp = current_time;
   cmd.velocity = static_cast<decltype(cmd.velocity)>(ctrl_cmd.vel);
   cmd.acceleration = static_cast<decltype(cmd.acceleration)>(ctrl_cmd.acc);
-
-  m_prev_ctrl_cmd = ctrl_cmd;
 
   return cmd;
 }
@@ -923,7 +923,7 @@ void PidLongitudinalController::updateDebugVelAcc(const ControlData & control_da
       control_data.current_motion.vel);
 }
 
-double PidLongitudinalController::getTimeUnderControl(const rclcpp::Time & current_time)
+double PidLongitudinalController::getTimeUnderControl(const rclcpp::Time & current_time) const
 {
   if (!m_under_control_starting_time) return 0.0;
   return (current_time - *m_under_control_starting_time).seconds();

--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -43,6 +43,26 @@ bool is_valid_trajectory(
 
   return true;
 }
+
+autoware_internal_debug_msgs::msg::Float32MultiArrayStamped createDebugMessage(
+  const rclcpp::Time & current_time, const DebugValues & debug_values)
+{
+  autoware_internal_debug_msgs::msg::Float32MultiArrayStamped debug_message{};
+  debug_message.stamp = current_time;
+  for (const auto & v : debug_values.getValues()) {
+    debug_message.data.push_back(static_cast<decltype(debug_message.data)::value_type>(v));
+  }
+  return debug_message;
+}
+
+autoware_internal_debug_msgs::msg::Float32MultiArrayStamped createSlopeMessage(
+  const rclcpp::Time & current_time, const double slope_angle)
+{
+  autoware_internal_debug_msgs::msg::Float32MultiArrayStamped slope_message{};
+  slope_message.stamp = current_time;
+  slope_message.data.push_back(static_cast<decltype(slope_message.data)::value_type>(slope_angle));
+  return slope_message;
+}
 }  // namespace
 
 PidLongitudinalController::PidLongitudinalController(const PidLongitudinalControllerConfig & cfg)
@@ -106,15 +126,8 @@ PidLongitudinalControllerResult PidLongitudinalController::run(
   result.output = output;
   result.control_state = m_control_state;
 
-  result.debug_message.stamp = current_time;
-  for (const auto & v : m_debug_values.getValues()) {
-    result.debug_message.data.push_back(
-      static_cast<decltype(result.debug_message.data)::value_type>(v));
-  }
-
-  result.slope_message.stamp = current_time;
-  result.slope_message.data.push_back(
-    static_cast<decltype(result.slope_message.data)::value_type>(control_data.slope_angle));
+  result.debug_message = createDebugMessage(current_time, m_debug_values);
+  result.slope_message = createSlopeMessage(current_time, control_data.slope_angle);
 
   if (m_virtual_wall_marker) {
     result.virtual_wall_marker = m_virtual_wall_marker;

--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -79,13 +79,7 @@ PidLongitudinalControllerResult PidLongitudinalController::run(
   const trajectory_follower::InputData & input_data, const rclcpp::Time & current_time,
   const bool is_steer_converged)
 {
-  m_received_invalid_trajectory = false;
   m_emergency_stop_reason = std::nullopt;
-
-  // check input data
-  if (!is_valid_trajectory(input_data.current_trajectory, config.use_temporal_trajectory)) {
-    m_received_invalid_trajectory = true;
-  }
 
   // calculate control data
   const auto control_data = getControlData(input_data, current_time);
@@ -126,7 +120,8 @@ PidLongitudinalControllerResult PidLongitudinalController::run(
     result.virtual_wall_marker = m_virtual_wall_marker;
     m_virtual_wall_marker.reset();
   }
-  result.received_invalid_trajectory = m_received_invalid_trajectory;
+  result.received_invalid_trajectory =
+    !is_valid_trajectory(input_data.current_trajectory, config.use_temporal_trajectory);
   result.emergency_stop_reason = m_emergency_stop_reason;
 
   return result;

--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -63,6 +63,16 @@ autoware_internal_debug_msgs::msg::Float32MultiArrayStamped createSlopeMessage(
   slope_message.data.push_back(static_cast<decltype(slope_message.data)::value_type>(slope_angle));
   return slope_message;
 }
+
+autoware_control_msgs::msg::Longitudinal createCtrlCmdMsg(
+  const rclcpp::Time & current_time, const double velocity, const double acceleration)
+{
+  autoware_control_msgs::msg::Longitudinal cmd{};
+  cmd.stamp = current_time;
+  cmd.velocity = static_cast<decltype(cmd.velocity)>(velocity);
+  cmd.acceleration = static_cast<decltype(cmd.acceleration)>(acceleration);
+  return cmd;
+}
 }  // namespace
 
 PidLongitudinalController::PidLongitudinalController(const PidLongitudinalControllerConfig & cfg)
@@ -109,7 +119,7 @@ PidLongitudinalControllerResult PidLongitudinalController::run(
   const Motion ctrl_cmd = calcCtrlCmd(control_data);
 
   // create control command
-  const auto cmd_msg = createCtrlCmdMsg(ctrl_cmd, current_time);
+  const auto cmd_msg = createCtrlCmdMsg(current_time, ctrl_cmd.vel, ctrl_cmd.acc);
   trajectory_follower::LongitudinalOutput output;
   output.control_cmd = cmd_msg;
 
@@ -622,18 +632,6 @@ PidLongitudinalController::Motion PidLongitudinalController::calcCtrlCmd(
   m_prev_ctrl_cmd = ctrl_cmd_as_pedal_pos;
 
   return ctrl_cmd_as_pedal_pos;
-}
-
-// Do not use nearest_idx here
-autoware_control_msgs::msg::Longitudinal PidLongitudinalController::createCtrlCmdMsg(
-  const Motion & ctrl_cmd, const rclcpp::Time & current_time) const
-{
-  autoware_control_msgs::msg::Longitudinal cmd{};
-  cmd.stamp = current_time;
-  cmd.velocity = static_cast<decltype(cmd.velocity)>(ctrl_cmd.vel);
-  cmd.acceleration = static_cast<decltype(cmd.acceleration)>(ctrl_cmd.acc);
-
-  return cmd;
 }
 
 void PidLongitudinalController::setDebugValues(

--- a/control/autoware_pid_longitudinal_controller/test/test_pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/test/test_pid_longitudinal_controller.cpp
@@ -36,11 +36,11 @@ using autoware_planning_msgs::msg::TrajectoryPoint;
 
 // Helper function that builds an rclcpp::Time from a plain seconds value (e.g. 1.03), so call
 // sites read as a point in time rather than an opaque (seconds, nanoseconds) pair.
-rclcpp::Time make_time(const double seconds, const rcl_clock_type_t clock_type = RCL_SYSTEM_TIME)
+rclcpp::Time make_time(const double seconds)
 {
   const auto whole_seconds = static_cast<int32_t>(std::floor(seconds));
   const auto nanoseconds = static_cast<uint32_t>(std::llround((seconds - whole_seconds) * 1e9));
-  return rclcpp::Time(whole_seconds, nanoseconds, clock_type);
+  return rclcpp::Time(whole_seconds, nanoseconds);
 }
 
 // Helper function that builds a fully-populated, valid config equivalent to the shipped
@@ -375,11 +375,11 @@ TEST(PidLongitudinalController, PredictsStateFromCommandHistoryWhenAutonomous)
   auto config = make_default_config();
   PidLongitudinalController controller(config);
   const auto trajectory = make_straight_trajectory(30, 5.0);
-  controller.run(make_input_data(trajectory, 3.0, 0.0, true), make_time(0.0, RCL_ROS_TIME), true);
+  controller.run(make_input_data(trajectory, 3.0, 0.0, true), make_time(0.0), true);
 
   // Act
   const auto result =
-    controller.run(make_input_data(trajectory, 3.0, 1.0, true), make_time(0.1, RCL_ROS_TIME), true);
+    controller.run(make_input_data(trajectory, 3.0, 1.0, true), make_time(0.1), true);
 
   // Assert
   EXPECT_EQ(result.control_state, ControlState::DRIVE);
@@ -479,11 +479,11 @@ TEST(PidLongitudinalController, KeepStoppedShowsVirtualWallUnderAutonomousContro
   config.enable_keep_stopped_until_steer_convergence = true;
   PidLongitudinalController controller(config);
   const auto trajectory = make_straight_trajectory(20, 5.0);
-  controller.run(make_input_data(trajectory, 0.0, 0.0, true), make_time(0.0, RCL_ROS_TIME), false);
+  controller.run(make_input_data(trajectory, 0.0, 0.0, true), make_time(0.0), false);
 
   // Act
-  const auto result = controller.run(
-    make_input_data(trajectory, 0.0, 0.0, true), make_time(1.0, RCL_ROS_TIME), false);
+  const auto result =
+    controller.run(make_input_data(trajectory, 0.0, 0.0, true), make_time(1.0), false);
 
   // Assert
   EXPECT_EQ(result.control_state, ControlState::STOPPED);
@@ -579,16 +579,13 @@ TEST(PidLongitudinalController, StaysInEmergencyWhileOvershootPersistsUnderContr
   auto config = make_default_config();
   PidLongitudinalController controller(config);
   controller.run(
-    make_input_data(make_straight_trajectory(20, 5.0), 0.0, 0.0, true),
-    make_time(0.0, RCL_ROS_TIME), true);
+    make_input_data(make_straight_trajectory(20, 5.0), 0.0, 0.0, true), make_time(0.0), true);
   controller.run(
-    make_input_data(make_straight_trajectory(20, 0.0), 0.0, 10.0, true),
-    make_time(0.03, RCL_ROS_TIME), true);
+    make_input_data(make_straight_trajectory(20, 0.0), 0.0, 10.0, true), make_time(0.03), true);
 
   // Act
   const auto result = controller.run(
-    make_input_data(make_straight_trajectory(20, 0.0), 0.0, 10.0, true),
-    make_time(0.06, RCL_ROS_TIME), true);
+    make_input_data(make_straight_trajectory(20, 0.0), 0.0, 10.0, true), make_time(0.06), true);
 
   // Assert
   EXPECT_EQ(result.control_state, ControlState::EMERGENCY);
@@ -610,7 +607,7 @@ TEST(PidLongitudinalController, TemporalTrajectoryProducesValidCommand)
 
   // Act
   const auto result =
-    controller.run(make_input_data(temporal_trajectory, 3.0), make_time(0.5, RCL_ROS_TIME), true);
+    controller.run(make_input_data(temporal_trajectory, 3.0), make_time(0.5), true);
 
   // Assert
   EXPECT_FALSE(result.received_invalid_trajectory);


### PR DESCRIPTION
## Description

This PR refactors `PidLongitudinalController` to remove per-cycle state that was being smuggled through member variables instead of being passed as parameters/return values, and fixes a clock-type bug uncovered in the process.

- Removed unused members: `m_current_time`, `m_prev_nearest_time`, and the unimplemented member function declarations `getCurrentMotion()` / `calcFilteredAcc()`.
- Removed `m_received_invalid_trajectory`, `m_is_steer_converged`, and `m_emergency_stop_reason`, which were only ever set and read within a single `run()` call. These are now local variables / function parameters / return values instead of persistent state.
- Extracted `createDebugMessage()`, `createSlopeMessage()`, and `createCtrlCmdMsg()` into free helper functions in the anonymous namespace, since none of them need access to member state.
- Moved the `m_prev_ctrl_cmd` update out of `createCtrlCmdMsg` (which should only format the output message) into `calcCtrlCmd`, where the state transition belongs. This allowed `createCtrlCmdMsg` and `getTimeUnderControl` to be marked `const`.
- **Bug fix:** `PidLongitudinalController` compared `current_time` (whose clock type is caller-supplied) against timestamps implicitly converted from `builtin_interfaces::msg::Time`, which defaults to `RCL_ROS_TIME`. When `current_time` used a different clock type, `rclcpp::Time` subtraction threw `"can't subtract times with different time sources"`. Fixed by:
  - Replacing the ROS-message-backed `m_ctrl_cmd_vec` with a dedicated `TimestampedAcceleration` struct that stores `rclcpp::Time` directly, so stored stamps always share `current_time`'s clock type.
  - Converting the remaining message-derived timestamp (trajectory header stamp) using `current_time.get_clock_type()` instead of the implicit `RCL_ROS_TIME` default.
  - Updated `test_pid_longitudinal_controller.cpp` accordingly: `make_time()` no longer needs an `rcl_clock_type_t` parameter, since no test needs to force `RCL_ROS_TIME` anymore.

No behavior change is intended other than the clock-type fix, which only affects callers that pass a non-`RCL_ROS_TIME` clock.


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

`colcon build --packages-select autoware_pid_longitudinal_controller && colcon test --packages-select autoware_pid_longitudinal_controller --event-handlers console_cohesion+` passes, including the updated unit tests in `test_pid_longitudinal_controller.cpp`.

Evaluator Link (TIER IV internal)
https://evaluation.tier4.jp/evaluation/reports/bbe87235-3f33-59db-820a-0529a24855ac/?project_id=autoware_dev
https://evaluation.tier4.jp/evaluation/reports/e29489d2-7f0c-5d4c-b34c-22906ee6da0d/?project_id=autoware_dev
https://evaluation.tier4.jp/evaluation/reports/723cfcfb-4899-59bb-9884-64d6f508420d/?project_id=autoware_dev

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
