### PR TITLE
feat(lane_change): add overhang_tolerance param for stop point planning

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/README.md
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/README.md
@@ -1225,6 +1225,7 @@ The following parameters are configurable in [lane_change.param.yaml](https://gi
 | `backward_length_buffer_for_blocking_object` | [m]    | double | The end of lane buffer to ensure ego vehicle has enough distance to start lane change when there is an object in front | 3.0                |
 | `backward_length_from_intersection`          | [m]    | double | Distance threshold from the last intersection to invalidate or cancel the lane change path                             | 5.0                |
 | `enable_stopped_vehicle_buffer`              | [-]    | bool   | If true, will keep enough distance from current lane front stopped object to perform lane change when possible         | true               |
+| `overhang_tolerance`                         | [m]    | double | Tolerance for ego footprint overflow outside lane polygon during stop point planning                                   | 0.0                |
 | `trajectory.max_prepare_duration`            | [s]    | double | The maximum preparation time for the ego vehicle to be ready to perform lane change.                                   | 4.0                |
 | `trajectory.min_prepare_duration`            | [s]    | double | The minimum preparation time for the ego vehicle to be ready to perform lane change.                                   | 2.0                |
 | `trajectory.lateral_jerk`                    | [m/s3] | double | Lateral jerk value for lane change path generation                                                                     | 0.5                |

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/config/lane_change.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/config/lane_change.param.yaml
@@ -7,6 +7,7 @@
       backward_length_buffer_for_blocking_object: 3.0 # [m]
       backward_length_from_intersection: 5.0 # [m]
       enable_stopped_vehicle_buffer: true
+      overhang_tolerance: 0.0 # [m]
 
       # turn signal
       min_length_for_turn_signal_activation: 10.0 # [m]

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/structs/parameters.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/structs/parameters.hpp
@@ -169,6 +169,7 @@ struct Parameters
   double backward_length_buffer_for_blocking_object{0.0};
   double backward_length_from_intersection{5.0};
   bool enable_stopped_vehicle_buffer{false};
+  double overhang_tolerance{0.0};
 
   // parked vehicle
   double object_check_min_road_shoulder_width{0.5};

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/manager.cpp
@@ -205,6 +205,7 @@ LCParamPtr LaneChangeModuleManager::set_params(rclcpp::Node * node, const std::s
     get_or_declare_parameter<double>(*node, parameter("backward_length_from_intersection"));
   p.enable_stopped_vehicle_buffer =
     get_or_declare_parameter<bool>(*node, parameter("enable_stopped_vehicle_buffer"));
+  p.overhang_tolerance = get_or_declare_parameter<double>(*node, parameter("overhang_tolerance"));
 
   if (p.backward_length_buffer_for_end_of_lane < 1.0) {
     RCLCPP_WARN_STREAM(

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
@@ -582,7 +582,9 @@ void NormalLaneChange::insert_stop_point_on_current_lanes(
   const auto & bpp_param_ptr = common_data_ptr_->bpp_param_ptr;
   const auto dist_to_terminal_stop = std::invoke([&]() -> double {
     const auto & curr_lanes_poly = common_data_ptr_->lanes_polygon_ptr->current;
-    if (!utils::isEgoWithinOriginalLane(curr_lanes_poly, getEgoPose(), *bpp_param_ptr)) {
+    if (!utils::isEgoWithinOriginalLane(
+          curr_lanes_poly, getEgoPose(), *bpp_param_ptr,
+          lane_change_parameters_->overhang_tolerance)) {
       return dist_from_path_front + dist_to_terminal_start;
     }
 


### PR DESCRIPTION
## Description

This PR adds `overhang_tolerance` parameter to lane change module for stop point planning.

When the ego vehicle is near the end of its current lane and attempting a lane change, the stop point placement depends on whether the ego is still within the original lane.

If the ego's dimensions are big, and footprint exceeds the lanelet, ego got stuck and fail to complete a valid lane change even when the merging lane was safe.

In the project case, the side mirror of ego bus exceeds the lanelet.

The PR makes that tolerance configurable via a new `overhang_tolerance` parameter.

## Related links

**Corresponding launch PR:**
- https://github.com/autowarefoundation/autoware_launch/pull/1926

**Parent Issue:**

- [TIER IV Ticket](https://tier4.atlassian.net/browse/ISUZU-359)

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

**Scenario Test:**
Scenario and map info can be found under the ticket.

- **Before**: ego stuck at lane end, unable to complete lane change 

https://github.com/user-attachments/assets/6263d4c7-370b-478d-9758-2441a67f8401

- **After**: ego successfully changes lane when merging lane is safe

https://github.com/user-attachments/assets/1f8198d1-5327-43d3-a0dd-46e52bbee804

## Notes for reviewers

None.

## Interface changes

### ROS Parameter Changes

#### Additions and removals

| Change type | Parameter Name | Type | Default | Description |
|:------------|:---------------|:-----|:--------|:------------|
| Added | `lane_change.overhang_tolerance` | `double` | `0.0` | Tolerance for ego footprint overflow outside lane polygon during stop point planning |

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |


#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |



#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->


## Effects on system behavior

None.



