### PR TITLE
feat(euclidean_cluster): apply agnocast_wrapper::Node to label_based_euclidean_cluster

### DIFF
--- a/perception/autoware_euclidean_cluster/CMakeLists.txt
+++ b/perception/autoware_euclidean_cluster/CMakeLists.txt
@@ -86,7 +86,7 @@ autoware_agnocast_wrapper_setup(${PROJECT_NAME}_label_based_node_core)
 autoware_agnocast_wrapper_register_node(${PROJECT_NAME}_label_based_node_core
   PLUGIN "autoware::euclidean_cluster::LabelBasedEuclideanClusterNode"
   EXECUTABLE label_based_euclidean_cluster_node
-  AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
   ROS2_EXECUTOR SingleThreadedExecutor
 )
 

--- a/perception/autoware_euclidean_cluster/CMakeLists.txt
+++ b/perception/autoware_euclidean_cluster/CMakeLists.txt
@@ -101,15 +101,17 @@ if(BUILD_TESTING)
   target_link_libraries(test_label_based_euclidean_cluster
     ${PROJECT_NAME}_lib
   )
-  ament_auto_add_gtest(test_label_based_euclidean_cluster_node
-    test/test_label_based_euclidean_cluster_node.cpp
-  )
-  target_include_directories(test_label_based_euclidean_cluster_node PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/src
-  )
-  target_link_libraries(test_label_based_euclidean_cluster_node
-    ${PROJECT_NAME}_label_based_node_core
-  )
+  if(NOT "$ENV{ENABLE_AGNOCAST}" STREQUAL "1")
+    ament_auto_add_gtest(test_label_based_euclidean_cluster_node
+      test/test_label_based_euclidean_cluster_node.cpp
+    )
+    target_include_directories(test_label_based_euclidean_cluster_node PRIVATE
+      ${CMAKE_CURRENT_SOURCE_DIR}/src
+    )
+    target_link_libraries(test_label_based_euclidean_cluster_node
+      ${PROJECT_NAME}_label_based_node_core
+    )
+  endif()
 endif()
 
 autoware_ament_auto_package(INSTALL_TO_SHARE

--- a/perception/autoware_euclidean_cluster/launch/label_based_euclidean_cluster.launch.py
+++ b/perception/autoware_euclidean_cluster/launch/label_based_euclidean_cluster.launch.py
@@ -18,17 +18,11 @@ from dataclasses import field
 import launch
 from launch.actions import DeclareLaunchArgument
 from launch.actions import IncludeLaunchDescription
-from launch.actions import OpaqueFunction
-from launch.conditions import IfCondition
-from launch.conditions import UnlessCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from launch.substitutions import PathJoinSubstitution
-from launch_ros.actions import ComposableNodeContainer
-from launch_ros.actions import LoadComposableNodes
-from launch_ros.descriptions import ComposableNode
+from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
-import yaml
 
 
 @dataclass(frozen=True)
@@ -55,7 +49,7 @@ class LaunchArgument:
 
 # === Node information ===
 PACKAGE_NAME = "autoware_euclidean_cluster"
-PLUGIN_NAME = "autoware::euclidean_cluster::LabelBasedEuclideanClusterNode"
+EXECUTABLE_NAME = "label_based_euclidean_cluster_node"
 NODE_NAME = "label_based_euclidean_cluster"
 
 # === Launch arguments ===
@@ -71,58 +65,9 @@ PARAM_PATH = LaunchArgument(
     ],
 )
 
-USE_POINTCLOUD_CONTAINER = LaunchArgument("use_pointcloud_container", "false")
-POINTCLOUD_CONTAINER_NAME = LaunchArgument("pointcloud_container_name", "pointcloud_container")
-
-
-def launch_setup(context, *args, **kwargs):
-    def load_composable_node_param(param_path):
-        with open(LaunchConfiguration(param_path).perform(context), "r") as f:
-            return yaml.safe_load(f)["/**"]["ros__parameters"]
-
-    ns = ""
-    component = ComposableNode(
-        package=PACKAGE_NAME,
-        namespace=ns,
-        plugin=PLUGIN_NAME,
-        name=NODE_NAME,
-        remappings=[
-            INPUT_POINTCLOUD.remapping,
-            OUTPUT_OBJECTS.remapping,
-            OUTPUT_POINTCLOUD.remapping,
-        ],
-        parameters=[load_composable_node_param(PARAM_PATH.name)],
-    )
-
-    container = ComposableNodeContainer(
-        name=POINTCLOUD_CONTAINER_NAME.name,
-        namespace=ns,
-        package=LaunchConfiguration("container_package"),
-        executable=LaunchConfiguration("container_executable"),
-        composable_node_descriptions=[],
-        output="screen",
-        condition=UnlessCondition(USE_POINTCLOUD_CONTAINER.config),
-        additional_env={
-            "LD_PRELOAD": LaunchConfiguration("ld_preload_value"),
-        },
-    )
-
-    target_container = (
-        POINTCLOUD_CONTAINER_NAME.config
-        if IfCondition(USE_POINTCLOUD_CONTAINER.config).evaluate(context)
-        else container
-    )
-
-    loader = LoadComposableNodes(
-        composable_node_descriptions=[component],
-        target_container=target_container,
-    )
-
-    return [container, loader]
-
 
 def generate_launch_description():
-    # Resolve LD_PRELOAD / container package / container executable based on ENABLE_AGNOCAST.
+    # Resolve LD_PRELOAD based on ENABLE_AGNOCAST.
     agnocast_env = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             PathJoinSubstitution(
@@ -135,6 +80,23 @@ def generate_launch_description():
         ),
     )
 
+    node = Node(
+        package=PACKAGE_NAME,
+        executable=EXECUTABLE_NAME,
+        name=NODE_NAME,
+        namespace="",
+        remappings=[
+            INPUT_POINTCLOUD.remapping,
+            OUTPUT_OBJECTS.remapping,
+            OUTPUT_POINTCLOUD.remapping,
+        ],
+        parameters=[PARAM_PATH.config],
+        output="screen",
+        additional_env={
+            "LD_PRELOAD": LaunchConfiguration("ld_preload_value"),
+        },
+    )
+
     return launch.LaunchDescription(
         [
             agnocast_env,
@@ -144,9 +106,6 @@ def generate_launch_description():
             OUTPUT_POINTCLOUD.declare(),
             # Parameters
             PARAM_PATH.declare(),
-            # Container
-            USE_POINTCLOUD_CONTAINER.declare(),
-            POINTCLOUD_CONTAINER_NAME.declare(),
-            OpaqueFunction(function=launch_setup),
+            node,
         ]
     )

--- a/perception/autoware_euclidean_cluster/launch/label_based_euclidean_cluster.launch.xml
+++ b/perception/autoware_euclidean_cluster/launch/label_based_euclidean_cluster.launch.xml
@@ -5,15 +5,10 @@
 
   <arg name="param_path" default="$(find-pkg-share autoware_euclidean_cluster)/config/label_based_euclidean_cluster.param.yaml"/>
 
-  <arg name="use_pointcloud_container" default="false"/>
-  <arg name="pointcloud_container_name" default="pointcloud_container"/>
-
   <include file="$(find-pkg-share autoware_euclidean_cluster)/launch/label_based_euclidean_cluster.launch.py">
     <arg name="input/pointcloud" value="$(var input/pointcloud)"/>
     <arg name="output/objects" value="$(var output/objects)"/>
     <arg name="output/pointcloud" value="$(var output/pointcloud)"/>
     <arg name="param_path" value="$(var param_path)"/>
-    <arg name="use_pointcloud_container" value="$(var use_pointcloud_container)"/>
-    <arg name="pointcloud_container_name" value="$(var pointcloud_container_name)"/>
   </include>
 </launch>

--- a/perception/autoware_euclidean_cluster/src/label_based_euclidean_cluster_node.cpp
+++ b/perception/autoware_euclidean_cluster/src/label_based_euclidean_cluster_node.cpp
@@ -84,16 +84,17 @@ std::optional<NestedOverrideName> parse_nested_override_name(
   return NestedOverrideName{rest.substr(0, dot_pos), rest.substr(dot_pos + 1)};
 }
 
-/// @brief Extract per-label parameter prefixes from nested overrides.
+/// @brief Extract per-label parameter prefixes from declared parameters.
 std::unordered_map<std::string, std::string> load_label_cluster_parameter_prefixes(
-  const rclcpp::NodeOptions & options)
+  autoware::agnocast_wrapper::Node & node)
 {
   constexpr std::string_view prefix = "label_cluster_params.";
 
   std::unordered_map<std::string, std::string> outputs;
 
-  for (const auto & parameter : options.parameter_overrides()) {
-    const auto nested_name = parse_nested_override_name(parameter.get_name(), prefix);
+  const auto listed = node.list_parameters({"label_cluster_params"}, 0);
+  for (const auto & parameter_name : listed.names) {
+    const auto nested_name = parse_nested_override_name(parameter_name, prefix);
     if (!nested_name) {
       continue;
     }
@@ -104,19 +105,21 @@ std::unordered_map<std::string, std::string> load_label_cluster_parameter_prefix
   return outputs;
 }
 
-/// @brief Parse confusable_label_groups.* parameters from NodeOptions overrides.
-std::vector<ConfusableLabelGroup> load_confusable_groups(const rclcpp::NodeOptions & options)
+/// @brief Parse confusable_label_groups.* parameters from declared parameters.
+std::vector<ConfusableLabelGroup> load_confusable_groups(autoware::agnocast_wrapper::Node & node)
 {
   constexpr std::string_view prefix = "confusable_label_groups.";
   std::unordered_map<std::string, ConfusableLabelGroup> groups_map;
   std::unordered_set<std::string> provided_keys;
 
-  for (const auto & param : options.parameter_overrides()) {
-    const auto nested_name = parse_nested_override_name(param.get_name(), prefix);
+  const auto listed = node.list_parameters({"confusable_label_groups"}, 0);
+  for (const auto & parameter_name : listed.names) {
+    const auto nested_name = parse_nested_override_name(parameter_name, prefix);
     if (!nested_name) {
       continue;
     }
 
+    const auto param = node.get_parameter(parameter_name);
     const auto & group_name = nested_name->group_name;
     const auto & key = nested_name->key;
     auto & group = groups_map[group_name];
@@ -195,7 +198,7 @@ LabelBasedEuclideanClusterNode::LabelBasedEuclideanClusterNode(const rclcpp::Nod
   std::unordered_map<std::uint8_t, std::shared_ptr<EuclideanClusterInterface>>
     label_cluster_executers;
   {
-    for (const auto & entry : load_label_cluster_parameter_prefixes(options)) {
+    for (const auto & entry : load_label_cluster_parameter_prefixes(*this)) {
       const auto & label_name = entry.first;
       const auto & label_prefix = entry.second;
       auto has = [&](const std::string & key) { return this->has_parameter(label_prefix + key); };
@@ -250,7 +253,7 @@ LabelBasedEuclideanClusterNode::LabelBasedEuclideanClusterNode(const rclcpp::Nod
     autoware_utils_rclcpp::get_or_declare_parameter<bool>(*this, "use_boost_bbox_optimizer"));
 
   // Load confusable label groups
-  const auto confusable_groups = load_confusable_groups(options);
+  const auto confusable_groups = load_confusable_groups(*this);
 
   // Create the core clustering processor
   processor_ = std::make_unique<LabelBasedEuclideanCluster>(
@@ -262,20 +265,22 @@ LabelBasedEuclideanClusterNode::LabelBasedEuclideanClusterNode(const rclcpp::Nod
   pointcloud_sub_ = this->create_subscription<sensor_msgs::msg::PointCloud2>(
     "input/pointcloud", rclcpp::SensorDataQoS().keep_last(1),
     std::bind(&LabelBasedEuclideanClusterNode::on_pointcloud, this, _1));
-  objects_pub_ = AUTOWARE_CREATE_PUBLISHER2(
-    autoware_perception_msgs::msg::DetectedObjects, "output/objects", rclcpp::QoS{1});
+  objects_pub_ = this->create_publisher<autoware_perception_msgs::msg::DetectedObjects>(
+    "output/objects", rclcpp::QoS{1});
   segments_pub_ =
-    AUTOWARE_CREATE_PUBLISHER2(sensor_msgs::msg::PointCloud2, "output/pointcloud", rclcpp::QoS{1});
+    this->create_publisher<sensor_msgs::msg::PointCloud2>("output/pointcloud", rclcpp::QoS{1});
 
   // Initialize timing and debug
   stop_watch_ptr_ = std::make_unique<autoware_utils::StopWatch<std::chrono::milliseconds>>();
-  debug_publisher_ = std::make_unique<autoware_utils::DebugPublisher>(this, "~/debug");
+  debug_publisher_ =
+    std::make_unique<autoware_utils::BasicDebugPublisher<autoware::agnocast_wrapper::Node>>(
+      this, "~/debug");
   stop_watch_ptr_->tic("cyclic_time");
   stop_watch_ptr_->tic("processing_time");
 }
 
 void LabelBasedEuclideanClusterNode::on_pointcloud(
-  sensor_msgs::msg::PointCloud2::ConstSharedPtr input_msg)
+  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(sensor_msgs::msg::PointCloud2) & input_msg)
 {
   stop_watch_ptr_->toc("processing_time", true);
 
@@ -294,8 +299,8 @@ void LabelBasedEuclideanClusterNode::on_pointcloud(
   output.segments.header = input_msg->header;
 
   // Publish the result
-  objects_pub_->publish(std::move(output.objects));
-  segments_pub_->publish(std::move(output.segments));
+  objects_pub_->publish(output.objects);
+  segments_pub_->publish(output.segments);
 
   // Handle timing and debug output
   if (debug_publisher_) {

--- a/perception/autoware_euclidean_cluster/src/label_based_euclidean_cluster_node.hpp
+++ b/perception/autoware_euclidean_cluster/src/label_based_euclidean_cluster_node.hpp
@@ -16,7 +16,7 @@
 
 #include "autoware/euclidean_cluster/label_based_euclidean_cluster.hpp"
 
-#include <autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp>
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <autoware_utils/ros/debug_publisher.hpp>
 #include <autoware_utils/system/stop_watch.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -37,7 +37,7 @@ namespace autoware::euclidean_cluster
 ///
 /// This node wraps the core LabelBasedEuclideanCluster class, handling ROS-specific concerns
 /// like parameter loading, pub/sub lifecycle, and timing instrumentation.
-class LabelBasedEuclideanClusterNode : public rclcpp::Node
+class LabelBasedEuclideanClusterNode : public autoware::agnocast_wrapper::Node
 {
 public:
   /// @brief Construct the node and initialize parameters, publishers, subscribers, and core
@@ -48,10 +48,11 @@ public:
 private:
   /// @brief Process an input semantic point cloud and publish detected objects.
   /// @param input_msg Input point cloud containing xyz and optionally class_id / probability.
-  void on_pointcloud(sensor_msgs::msg::PointCloud2::ConstSharedPtr input_msg);
+  void on_pointcloud(
+    const AUTOWARE_MESSAGE_CONST_SHARED_PTR(sensor_msgs::msg::PointCloud2) & input_msg);
 
   // Publishers and subscribers
-  rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr pointcloud_sub_;
+  AUTOWARE_SUBSCRIPTION_PTR(sensor_msgs::msg::PointCloud2) pointcloud_sub_;
   AUTOWARE_PUBLISHER_PTR(autoware_perception_msgs::msg::DetectedObjects) objects_pub_;
   AUTOWARE_PUBLISHER_PTR(sensor_msgs::msg::PointCloud2) segments_pub_;
 
@@ -60,6 +61,7 @@ private:
 
   // Timing and debug instrumentation
   std::unique_ptr<autoware_utils::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_;
-  std::unique_ptr<autoware_utils::DebugPublisher> debug_publisher_;
+  std::unique_ptr<autoware_utils::BasicDebugPublisher<autoware::agnocast_wrapper::Node>>
+    debug_publisher_;
 };
 }  // namespace autoware::euclidean_cluster

--- a/perception/autoware_euclidean_cluster/test/test_label_based_euclidean_cluster_node.cpp
+++ b/perception/autoware_euclidean_cluster/test/test_label_based_euclidean_cluster_node.cpp
@@ -257,7 +257,7 @@ TEST_F(LabelClusterConfigBehavior, PublishesDetectedObjectsForSemanticInput)
     "/input/pointcloud", rclcpp::SensorDataQoS());
 
   rclcpp::executors::SingleThreadedExecutor executor;
-  executor.add_node(cluster_node);
+  executor.add_node(cluster_node->get_node_base_interface());
   executor.add_node(helper_node);
 
   std::thread spin_thread([&executor]() { executor.spin(); });
@@ -310,7 +310,7 @@ TEST_F(LabelClusterConfigBehavior, PublishesSemanticNonObjectsAsSegments)
     "/input/pointcloud", rclcpp::SensorDataQoS());
 
   rclcpp::executors::SingleThreadedExecutor executor;
-  executor.add_node(cluster_node);
+  executor.add_node(cluster_node->get_node_base_interface());
   executor.add_node(helper_node);
 
   std::thread spin_thread([&executor]() { executor.spin(); });


### PR DESCRIPTION
## Description

Apply `agnocast_wrapper::Node` to `label_based_euclidean_cluster` in `autoware_euclidean_cluster`.
Please read https://github.com/autowarefoundation/autoware/issues/7007 for the context and review guidelines of `autoware_agnocast_wrapper` adoption. Also, please refer to https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/docs/review_guide.md for the review guide of `autoware_agnocast_wrapper` application PR. FYI: This node takes [Method2](https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/docs/review_guide.md#method-2-agnocast_wrappernode-inheritance) of two integration methods.

**AgnocastOnlyCallbackIsolatedExecutor:**
  When built and run with `ENABLE_AGNOCAST=1`, the node runs on an `AgnocastOnlyCallbackIsolatedExecutor` (CIE), the standard executor for `agnocast_wrapper::Node`. Please check for potential race conditions only if the node meets **all** of the following:

  1. It was originally running on a `SingleThreadedExecutor`.
  2. It has multiple callback groups (the default is one).
  3. Shared variables are accessed across those callback groups without mutex protection.

The CMake/`package.xml` wiring for the Agnocast wrapper is already on `main`, so this PR only converts the node itself and adjusts how it is launched.

Changes:

- The publishers are created with `this->create_publisher<T>()` instead of `AUTOWARE_CREATE_PUBLISHER2`, and the two outputs are published with `publish(const &)` instead of `publish(std::move(...))`. See "Notes for reviewers".
- The per-label parameters (`label_cluster_params.*`, `confusable_label_groups.*`) are read from the node's declared parameters via `list_parameters()` instead of scanning `rclcpp::NodeOptions::parameter_overrides()`. See "Notes for reviewers".
- The node is launched as a standalone node instead of a composable node: `label_based_euclidean_cluster.launch.py` now declares a single `launch_ros.actions.Node` and keeps including `agnocast_env.launch.py`, and the container-related arguments are dropped from `label_based_euclidean_cluster.launch.xml`. The topic argument names are unchanged, so callers need no modification.
- The node-level test target is excluded at CMake configuration time when `ENABLE_AGNOCAST=1`; the pure-logic tests are still built and run in both configurations.

## Related links

- Supersedes #12857

## How was this PR tested?

- **Build**: Confirmed the package builds successfully with both `ENABLE_AGNOCAST=0` and `ENABLE_AGNOCAST=1` (clean build for each configuration). Also confirmed that the package and its downstream packages (`autoware_detection_by_tracker`, `autoware_image_projection_based_fusion`, `tier4_perception_launch`, `tier4_simulator_launch`, `autoware_launch`) build with `ENABLE_AGNOCAST=1`.
- **Unit tests**: With `ENABLE_AGNOCAST=0`, the node-level tests pass (8/8) along with the pure-logic tests and the lint tests. With `ENABLE_AGNOCAST=1`, the node-level test target is not generated as intended, and the pure-logic tests pass.
- **Standalone launch**: Confirmed the node starts under `ENABLE_AGNOCAST=1` as a standalone node and resolves the parameters from `--params-file` correctly with the `AgnocastOnly` executor.
- **Runtime (upstream)**: This node is only launched when `use_semantic_segmentation_ptv3` is enabled, so it is not exercised by the default logging simulator pipeline. Instead it was driven directly under `ENABLE_AGNOCAST=1` by injecting a synthetic segmented point cloud (`x`/`y`/`z` plus `class_id` and `probability`) containing four labelled clusters (`CAR`, `CAR`, `PEDESTRIAN`, `VEGETATION`). Both outputs behaved as expected and were published continuously: `output/objects` carried three objects with labels `PEDESTRIAN`, `CAR`, `CAR`, and `output/pointcloud` carried the `VEGETATION` points as segments. `ros2 topic list_agnocast` shows the input and both outputs registered as Agnocast enabled.
- **Regression (LSim)**: Confirmed the logging simulator with the sample rosbag starts and runs under `ENABLE_AGNOCAST=1` with no additional node failures compared to the same run without this PR.

## Notes for reviewers

- **Why nested parameters are read with `list_parameters()`**: As a standalone node, the contents of `--params-file` do not appear in `rclcpp::NodeOptions::parameter_overrides()`; the previous design relied on the container launch script loading the YAML in Python and passing `parameters=[dict]`. Reading the declared parameters instead keeps the same YAML layout working in both configurations.

## Interface changes

None.

## Effects on system behavior

None.
