### PR TITLE
feat(autoware_obstacle_grid_utils): add obstacle-grid consumer helper

### DIFF
--- a/common/autoware_obstacle_grid_utils/CMakeLists.txt
+++ b/common/autoware_obstacle_grid_utils/CMakeLists.txt
@@ -4,6 +4,10 @@ project(autoware_obstacle_grid_utils)
 find_package(autoware_cmake REQUIRED)
 autoware_package()
 
+ament_auto_add_library(${PROJECT_NAME} SHARED
+  src/obstacle_grid_utils.cpp
+)
+
 if(BUILD_TESTING)
   ament_auto_add_gtest(test_${PROJECT_NAME}
     test/test_obstacle_grid_utils.cpp

--- a/common/autoware_obstacle_grid_utils/CMakeLists.txt
+++ b/common/autoware_obstacle_grid_utils/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.14)
+project(autoware_obstacle_grid_utils)
+
+find_package(autoware_cmake REQUIRED)
+autoware_package()
+
+if(BUILD_TESTING)
+  ament_auto_add_gtest(test_${PROJECT_NAME}
+    test/test_obstacle_grid_utils.cpp
+  )
+endif()
+
+ament_auto_package()

--- a/common/autoware_obstacle_grid_utils/README.md
+++ b/common/autoware_obstacle_grid_utils/README.md
@@ -1,6 +1,6 @@
 # autoware_obstacle_grid_utils
 
-Header-only consumer helpers for the obstacle grid published on
+Consumer helpers for the obstacle grid published on
 `/sensing/obstacle_segmentation/obstacle_grid` (`grid_map_msgs/msg/GridMap`, frame `base_link`,
 layers `max_height` / `min_height` / `point_count`, `NaN` = empty cell).
 
@@ -18,16 +18,16 @@ all-`NaN` grid with a fresh stamp is a valid alive heartbeat.
 
 ## Helpers
 
-All helpers live in namespace `autoware::obstacle_grid_utils` in
-`include/autoware/obstacle_grid_utils/obstacle_grid_utils.hpp`.
+All helpers are declared in namespace `autoware::obstacle_grid_utils` in
+`include/autoware/obstacle_grid_utils/obstacle_grid_utils.hpp` and implemented in
+`src/obstacle_grid_utils.cpp`. The cell footprint box that makes the distance queries edge-aware
+is an implementation detail of that translation unit, not part of the public surface.
 
-| Helper                                       | Purpose                                                                                                                                                                                                                                                                                      |
-| -------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Gate{min_point_count_cell, min_height}`     | Per-cell qualification threshold: a cell qualifies iff `point_count >= min_point_count_cell && max_height >= min_height`. Height is `max_height`-based.                                                                                                                                      |
-| `cell_qualifies(grid, index, gate)`          | Whether one cell passes the gate (`NaN`-safe).                                                                                                                                                                                                                                               |
-| `cell_footprint(center, resolution)`         | The cell's footprint box as a polygon, so distances to it are edge-aware.                                                                                                                                                                                                                    |
-| `cell_corners(center, resolution)`           | The 4 corner points of the cell footprint (min-min, min-max, max-max, max-min) for edge-conservative corridor/lane membership.                                                                                                                                                               |
-| `nearest_distance(grid, ego_polygon, gate)`  | Edge-aware 2D distance from `ego_polygon` to the nearest qualifying cell; `+inf` when nothing qualifies inside the ROI.                                                                                                                                                                      |
-| `nearest_cell(grid, ego_polygon, gate)`      | Same edge-aware distance **and** where the nearest qualifying cell is (`std::optional<NearestCell{distance, position, index}>`, `std::nullopt` when nothing qualifies). On a distance tie the first cell reached by the grid iterator wins (either-of).                                      |
-| `cells_in_polygon(grid, lane_polygon, gate)` | Centers of qualifying cells inside a polygon.                                                                                                                                                                                                                                                |
-| `connected_components(grid, qualifying)`     | 8-connected labeling of the **caller-supplied** qualifying cell indices; returns `std::vector<CellComponent{cells, point_sum}>` with `point_sum` the sum of `point_count` over each component. Does not gate — the caller applies its `Gate` first. Components come out in first-seen order. |
+| Helper                                      | Purpose                                                                                                                                                                                                                                                                                      |
+| ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Gate{min_point_count_cell, min_height}`    | Per-cell qualification threshold: a cell qualifies iff `point_count >= min_point_count_cell && max_height >= min_height`. Height is `max_height`-based.                                                                                                                                      |
+| `cell_qualifies(grid, index, gate)`         | Whether one cell passes the gate (`NaN`-safe).                                                                                                                                                                                                                                               |
+| `cell_corners(center, resolution)`          | The 4 corner points of the cell footprint (min-min, min-max, max-max, max-min) for edge-conservative corridor/lane membership.                                                                                                                                                               |
+| `nearest_distance(grid, ego_polygon, gate)` | Edge-aware 2D distance from `ego_polygon` to the nearest qualifying cell; `+inf` when nothing qualifies inside the ROI.                                                                                                                                                                      |
+| `nearest_cell(grid, ego_polygon, gate)`     | Same edge-aware distance **and** where the nearest qualifying cell is (`std::optional<NearestCell{distance, position, index}>`, `std::nullopt` when nothing qualifies). On a distance tie the first cell reached by the grid iterator wins (either-of).                                      |
+| `connected_components(grid, qualifying)`    | 8-connected labeling of the **caller-supplied** qualifying cell indices; returns `std::vector<CellComponent{cells, point_sum}>` with `point_sum` the sum of `point_count` over each component. Does not gate — the caller applies its `Gate` first. Components come out in first-seen order. |

--- a/common/autoware_obstacle_grid_utils/README.md
+++ b/common/autoware_obstacle_grid_utils/README.md
@@ -1,0 +1,33 @@
+# autoware_obstacle_grid_utils
+
+Header-only consumer helpers for the obstacle grid published on
+`/sensing/obstacle_segmentation/obstacle_grid` (`grid_map_msgs/msg/GridMap`, frame `base_link`,
+layers `max_height` / `min_height` / `point_count` / `low_max_height`, `NaN` = empty cell).
+
+The grid is a shared last-resort safety product. These helpers exist so every consumer
+(collision_detector, surround_obstacle_checker, obstacle_collision_checker, planning_validator,
+trajectory ObstacleStop, AEB, ...) queries the grid through one reviewed implementation instead of
+hand-copying the same per-cell math.
+
+## Contract reminder
+
+Consumers must validate `frame_id == base_link` and the presence of the required layers on intake,
+and treat any contract violation or a stale stamp as **unavailable** (never as "clear"). Staleness
+is a per-consumer stamp-age watchdog (`obstacle_grid_timeout_sec`, default 0.5 s); an all-`NaN`
+grid with a fresh stamp is a valid alive heartbeat.
+
+## Helpers
+
+All helpers live in namespace `autoware::obstacle_grid_utils` in
+`include/autoware/obstacle_grid_utils/obstacle_grid_utils.hpp`.
+
+| Helper                                       | Purpose                                                                                                                                                                                                                                                                                      |
+| -------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Gate{min_point_count_cell, min_height}`     | Per-cell qualification threshold: a cell qualifies iff `point_count >= min_point_count_cell && max_height >= min_height`. Height is `max_height`-based; height-braking consumers read `low_max_height` directly.                                                                             |
+| `cell_qualifies(grid, index, gate)`          | Whether one cell passes the gate (`NaN`-safe).                                                                                                                                                                                                                                               |
+| `cell_footprint(center, resolution)`         | The cell's footprint box as a polygon, so distances to it are edge-aware.                                                                                                                                                                                                                    |
+| `cell_corners(center, resolution)`           | The 4 corner points of the cell footprint (min-min, min-max, max-max, max-min) for edge-conservative corridor/lane membership.                                                                                                                                                               |
+| `nearest_distance(grid, ego_polygon, gate)`  | Edge-aware 2D distance from `ego_polygon` to the nearest qualifying cell; `+inf` when nothing qualifies inside the ROI.                                                                                                                                                                      |
+| `nearest_cell(grid, ego_polygon, gate)`      | Same edge-aware distance **and** where the nearest qualifying cell is (`std::optional<NearestCell{distance, position, index}>`, `std::nullopt` when nothing qualifies). On a distance tie the first cell reached by the grid iterator wins (either-of).                                      |
+| `cells_in_polygon(grid, lane_polygon, gate)` | Centers of qualifying cells inside a polygon.                                                                                                                                                                                                                                                |
+| `connected_components(grid, qualifying)`     | 8-connected labeling of the **caller-supplied** qualifying cell indices; returns `std::vector<CellComponent{cells, point_sum}>` with `point_sum` the sum of `point_count` over each component. Does not gate — the caller applies its `Gate` first. Components come out in first-seen order. |

--- a/common/autoware_obstacle_grid_utils/README.md
+++ b/common/autoware_obstacle_grid_utils/README.md
@@ -2,7 +2,7 @@
 
 Header-only consumer helpers for the obstacle grid published on
 `/sensing/obstacle_segmentation/obstacle_grid` (`grid_map_msgs/msg/GridMap`, frame `base_link`,
-layers `max_height` / `min_height` / `point_count` / `low_max_height`, `NaN` = empty cell).
+layers `max_height` / `min_height` / `point_count`, `NaN` = empty cell).
 
 The grid is a shared last-resort safety product. These helpers exist so every consumer
 (collision_detector, surround_obstacle_checker, obstacle_collision_checker, planning_validator,
@@ -13,8 +13,8 @@ hand-copying the same per-cell math.
 
 Consumers must validate `frame_id == base_link` and the presence of the required layers on intake,
 and treat any contract violation or a stale stamp as **unavailable** (never as "clear"). Staleness
-is a per-consumer stamp-age watchdog (`obstacle_grid_timeout_sec`, default 0.5 s); an all-`NaN`
-grid with a fresh stamp is a valid alive heartbeat.
+is a per-consumer stamp-age watchdog (parameter name and default timeout TBD per consumer); an
+all-`NaN` grid with a fresh stamp is a valid alive heartbeat.
 
 ## Helpers
 
@@ -23,7 +23,7 @@ All helpers live in namespace `autoware::obstacle_grid_utils` in
 
 | Helper                                       | Purpose                                                                                                                                                                                                                                                                                      |
 | -------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Gate{min_point_count_cell, min_height}`     | Per-cell qualification threshold: a cell qualifies iff `point_count >= min_point_count_cell && max_height >= min_height`. Height is `max_height`-based; height-braking consumers read `low_max_height` directly.                                                                             |
+| `Gate{min_point_count_cell, min_height}`     | Per-cell qualification threshold: a cell qualifies iff `point_count >= min_point_count_cell && max_height >= min_height`. Height is `max_height`-based.                                                                                                                                      |
 | `cell_qualifies(grid, index, gate)`          | Whether one cell passes the gate (`NaN`-safe).                                                                                                                                                                                                                                               |
 | `cell_footprint(center, resolution)`         | The cell's footprint box as a polygon, so distances to it are edge-aware.                                                                                                                                                                                                                    |
 | `cell_corners(center, resolution)`           | The 4 corner points of the cell footprint (min-min, min-max, max-max, max-min) for edge-conservative corridor/lane membership.                                                                                                                                                               |

--- a/common/autoware_obstacle_grid_utils/include/autoware/obstacle_grid_utils/obstacle_grid_utils.hpp
+++ b/common/autoware_obstacle_grid_utils/include/autoware/obstacle_grid_utils/obstacle_grid_utils.hpp
@@ -1,0 +1,103 @@
+// Copyright 2026 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef AUTOWARE__OBSTACLE_GRID_UTILS__OBSTACLE_GRID_UTILS_HPP_
+#define AUTOWARE__OBSTACLE_GRID_UTILS__OBSTACLE_GRID_UTILS_HPP_
+
+#include <autoware_utils_geometry/boost_geometry.hpp>
+#include <grid_map_core/grid_map_core.hpp>
+
+#include <boost/geometry.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <vector>
+
+namespace autoware::obstacle_grid_utils
+{
+using autoware_utils_geometry::Point2d;
+using autoware_utils_geometry::Polygon2d;
+
+/// A cell qualifies iff point_count >= min_point_count_cell && max_height >= min_height.
+struct Gate
+{
+  std::uint32_t min_point_count_cell;
+  double min_height;
+};
+
+inline bool cell_qualifies(
+  const grid_map::GridMap & grid, const grid_map::Index & idx, const Gate & gate)
+{
+  const float cnt = grid.at("point_count", idx);
+  if (std::isnan(cnt) || static_cast<std::uint32_t>(cnt) < gate.min_point_count_cell) {
+    return false;
+  }
+  const float hi = grid.at("max_height", idx);
+  return !std::isnan(hi) && static_cast<double>(hi) >= gate.min_height;
+}
+
+/// Footprint box of one cell (areas, so distance to it is edge-aware by construction).
+inline Polygon2d cell_footprint(const grid_map::Position & c, double res)
+{
+  const double h = 0.5 * res;
+  Polygon2d box;
+  boost::geometry::append(box.outer(), Point2d(c.x() - h, c.y() - h));
+  boost::geometry::append(box.outer(), Point2d(c.x() - h, c.y() + h));
+  boost::geometry::append(box.outer(), Point2d(c.x() + h, c.y() + h));
+  boost::geometry::append(box.outer(), Point2d(c.x() + h, c.y() - h));
+  boost::geometry::correct(box);
+  return box;
+}
+
+/// 2D distance from ego_polygon to the nearest qualifying cell footprint. Returns
+/// +inf when nothing qualifies inside the ROI (caller treats that as "clear within ROI").
+inline double nearest_distance(
+  const grid_map::GridMap & grid, const Polygon2d & ego_polygon, const Gate & gate)
+{
+  double best = std::numeric_limits<double>::infinity();
+  const double res = grid.getResolution();
+  for (grid_map::GridMapIterator it(grid); !it.isPastEnd(); ++it) {
+    if (!cell_qualifies(grid, *it, gate)) {
+      continue;
+    }
+    grid_map::Position c;
+    grid.getPosition(*it, c);
+    best = std::min(best, boost::geometry::distance(ego_polygon, cell_footprint(c, res)));
+  }
+  return best;
+}
+
+/// Qualifying cell centers inside a polygon (each lanelet/traj consumer re-crops here).
+inline std::vector<grid_map::Position> cells_in_polygon(
+  const grid_map::GridMap & grid, const Polygon2d & lane_polygon, const Gate & gate)
+{
+  grid_map::Polygon gm;
+  gm.setFrameId(grid.getFrameId());
+  for (const auto & pt : lane_polygon.outer()) {
+    gm.addVertex(grid_map::Position(pt.x(), pt.y()));
+  }
+  std::vector<grid_map::Position> out;
+  for (grid_map::PolygonIterator it(grid, gm); !it.isPastEnd(); ++it) {
+    if (!cell_qualifies(grid, *it, gate)) {
+      continue;
+    }
+    grid_map::Position c;
+    grid.getPosition(*it, c);
+    out.push_back(c);
+  }
+  return out;
+}
+}  // namespace autoware::obstacle_grid_utils
+#endif  // AUTOWARE__OBSTACLE_GRID_UTILS__OBSTACLE_GRID_UTILS_HPP_

--- a/common/autoware_obstacle_grid_utils/include/autoware/obstacle_grid_utils/obstacle_grid_utils.hpp
+++ b/common/autoware_obstacle_grid_utils/include/autoware/obstacle_grid_utils/obstacle_grid_utils.hpp
@@ -17,17 +17,9 @@
 #include <autoware_utils_geometry/boost_geometry.hpp>
 #include <grid_map_core/grid_map_core.hpp>
 
-#include <boost/geometry.hpp>
-
-#include <algorithm>
 #include <array>
-#include <cmath>
 #include <cstdint>
-#include <limits>
 #include <optional>
-#include <unordered_map>
-#include <unordered_set>
-#include <utility>
 #include <vector>
 
 namespace autoware::obstacle_grid_utils
@@ -42,59 +34,6 @@ struct Gate
   double min_height;
 };
 
-inline bool cell_qualifies(
-  const grid_map::GridMap & grid, const grid_map::Index & idx, const Gate & gate)
-{
-  const float cnt = grid.at("point_count", idx);
-  if (std::isnan(cnt) || static_cast<std::uint32_t>(cnt) < gate.min_point_count_cell) {
-    return false;
-  }
-  const float hi = grid.at("max_height", idx);
-  return !std::isnan(hi) && static_cast<double>(hi) >= gate.min_height;
-}
-
-/// Footprint box of one cell (areas, so distance to it is edge-aware by construction).
-inline Polygon2d cell_footprint(const grid_map::Position & c, double res)
-{
-  const double h = 0.5 * res;
-  Polygon2d box;
-  boost::geometry::append(box.outer(), Point2d(c.x() - h, c.y() - h));
-  boost::geometry::append(box.outer(), Point2d(c.x() - h, c.y() + h));
-  boost::geometry::append(box.outer(), Point2d(c.x() + h, c.y() + h));
-  boost::geometry::append(box.outer(), Point2d(c.x() + h, c.y() - h));
-  boost::geometry::correct(box);
-  return box;
-}
-
-/// The 4 corner points of a cell footprint box, in the same winding as cell_footprint
-/// (min-min, min-max, max-max, max-min). Emitting corners rather than the center keeps
-/// corridor/lane membership edge-conservative: a cell counts as inside if any corner is.
-inline std::array<Point2d, 4> cell_corners(const grid_map::Position & center, double resolution)
-{
-  const double h = 0.5 * resolution;
-  return {
-    Point2d(center.x() - h, center.y() - h), Point2d(center.x() - h, center.y() + h),
-    Point2d(center.x() + h, center.y() + h), Point2d(center.x() + h, center.y() - h)};
-}
-
-/// 2D distance from ego_polygon to the nearest qualifying cell footprint. Returns
-/// +inf when nothing qualifies inside the ROI (caller treats that as "clear within ROI").
-inline double nearest_distance(
-  const grid_map::GridMap & grid, const Polygon2d & ego_polygon, const Gate & gate)
-{
-  double best = std::numeric_limits<double>::infinity();
-  const double res = grid.getResolution();
-  for (grid_map::GridMapIterator it(grid); !it.isPastEnd(); ++it) {
-    if (!cell_qualifies(grid, *it, gate)) {
-      continue;
-    }
-    grid_map::Position c;
-    grid.getPosition(*it, c);
-    best = std::min(best, boost::geometry::distance(ego_polygon, cell_footprint(c, res)));
-  }
-  return best;
-}
-
 /// Nearest qualifying cell together with WHERE it is. distance is edge-aware (to the cell
 /// footprint box, identical semantics to nearest_distance); position is the cell center and
 /// index its grid index, for debug markers / SafetyFactor.points / StopObstacle.nearest_point.
@@ -105,49 +44,6 @@ struct NearestCell
   grid_map::Index index;
 };
 
-/// std::nullopt when nothing qualifies inside the ROI (the nullopt <-> +inf analog of
-/// nearest_distance; a consumer treats nullopt as "clear within ROI"). On a distance tie the
-/// first cell encountered by the grid iterator wins (either-of; callers must not rely on which).
-inline std::optional<NearestCell> nearest_cell(
-  const grid_map::GridMap & grid, const Polygon2d & ego_polygon, const Gate & gate)
-{
-  std::optional<NearestCell> best;
-  const double res = grid.getResolution();
-  for (grid_map::GridMapIterator it(grid); !it.isPastEnd(); ++it) {
-    if (!cell_qualifies(grid, *it, gate)) {
-      continue;
-    }
-    grid_map::Position c;
-    grid.getPosition(*it, c);
-    const double d = boost::geometry::distance(ego_polygon, cell_footprint(c, res));
-    if (!best || d < best->distance) {
-      best = NearestCell{d, c, *it};
-    }
-  }
-  return best;
-}
-
-/// Qualifying cell centers inside a polygon (each lanelet/traj consumer re-crops here).
-inline std::vector<grid_map::Position> cells_in_polygon(
-  const grid_map::GridMap & grid, const Polygon2d & lane_polygon, const Gate & gate)
-{
-  grid_map::Polygon gm;
-  gm.setFrameId(grid.getFrameId());
-  for (const auto & pt : lane_polygon.outer()) {
-    gm.addVertex(grid_map::Position(pt.x(), pt.y()));
-  }
-  std::vector<grid_map::Position> out;
-  for (grid_map::PolygonIterator it(grid, gm); !it.isPastEnd(); ++it) {
-    if (!cell_qualifies(grid, *it, gate)) {
-      continue;
-    }
-    grid_map::Position c;
-    grid.getPosition(*it, c);
-    out.push_back(c);
-  }
-  return out;
-}
-
 /// One 8-connected component of qualifying cells; point_sum is the sum of the point_count layer
 /// over its cells (the grid analog of a Euclidean cluster's point total, gated by the caller).
 struct CellComponent
@@ -156,84 +52,42 @@ struct CellComponent
   double point_sum;
 };
 
+/// Whether one cell passes the gate. NaN-safe: a NaN point_count or a NaN max_height rejects.
+bool cell_qualifies(
+  const grid_map::GridMap & grid, const grid_map::Index & index, const Gate & gate);
+
+/// The 4 corner points of a cell's footprint box, wound min-min, min-max, max-max, max-min.
+/// Emitting corners rather than the center keeps corridor/lane membership edge-conservative:
+/// a cell counts as inside if any corner is.
+std::array<Point2d, 4> cell_corners(const grid_map::Position & center, double resolution);
+
+/// 2D distance from ego_polygon to the nearest qualifying cell. Cells are areas, so the distance
+/// is measured to the cell's footprint box rather than to its center. Returns +inf when nothing
+/// qualifies inside the ROI (the caller treats that as "clear within ROI").
+double nearest_distance(
+  const grid_map::GridMap & grid, const Polygon2d & ego_polygon, const Gate & gate);
+
+/// std::nullopt when nothing qualifies inside the ROI (the nullopt <-> +inf analog of
+/// nearest_distance; a consumer treats nullopt as "clear within ROI"). On a distance tie the
+/// first cell encountered by the grid iterator wins (either-of; callers must not rely on which).
+std::optional<NearestCell> nearest_cell(
+  const grid_map::GridMap & grid, const Polygon2d & ego_polygon, const Gate & gate);
+
 /// 8-connected labeling over the SUPPLIED qualifying cell indices. This function does NOT gate:
 /// the caller applies its per-cell Gate first and passes the surviving indices; here we only
 /// group them into components and sum point_count.
 ///
-/// Adjacency is computed in grid_map's UNWRAPPED index space (via getIndexFromBufferIndex), so it
-/// stays geometrically correct even when the grid's circular buffer has been move()d
-/// (getStartIndex() != (0,0)): geometrically adjacent cells that straddle the buffer wrap seam are
-/// still merged into one component, and cells that are merely neighbors in raw buffer-index space
-/// across the seam are not falsely merged. The reported CellComponent::cells are the caller's
-/// ORIGINAL buffer indices, so they remain usable directly with grid.at().
-///
-/// O(cells): membership and visited are hashed on an unwrapped linear key, so out-of-grid
-/// neighbors of border cells are simply absent from the member set and never probed. Components
-/// come out in first-seen order for stable, deterministic output.
+/// Adjacency is computed in grid_map's UNWRAPPED index space, so it stays geometrically correct
+/// even when the grid's circular buffer has been move()d: geometrically adjacent cells that
+/// straddle the buffer wrap seam are still merged into one component, and cells that are merely
+/// neighbors in raw buffer-index space across the seam are not falsely merged. The reported
+/// CellComponent::cells are the caller's ORIGINAL buffer indices, so they remain usable directly
+/// with grid.at(). Components come out in first-seen order, for deterministic output.
 ///
 /// Precondition: every supplied index is a valid in-grid cell. point_count is expected non-NaN
 /// (the caller's Gate already rejects NaN point_count); a NaN contribution is skipped rather than
 /// poisoning the whole component's point_sum to NaN and silently dropping a real cluster.
-inline std::vector<CellComponent> connected_components(
-  const grid_map::GridMap & grid, const std::vector<grid_map::Index> & qualifying)
-{
-  const grid_map::Size size = grid.getSize();
-  const grid_map::Index start = grid.getStartIndex();
-  const int rows = size(0);
-  const int cols = size(1);
-  const auto key = [cols](const grid_map::Index & unwrapped) {
-    return static_cast<std::int64_t>(unwrapped(0)) * cols + static_cast<std::int64_t>(unwrapped(1));
-  };
-  // Map an unwrapped-index key to the caller's ORIGINAL buffer index (for grid.at / reporting).
-  std::unordered_map<std::int64_t, grid_map::Index> members;
-  members.reserve(qualifying.size());
-  for (const auto & idx : qualifying) {
-    members.emplace(key(grid_map::getIndexFromBufferIndex(idx, size, start)), idx);
-  }
-  std::unordered_set<std::int64_t> visited;
-  visited.reserve(qualifying.size());
-  std::vector<CellComponent> out;
-  for (const auto & seed : qualifying) {
-    const grid_map::Index seed_unwrapped = grid_map::getIndexFromBufferIndex(seed, size, start);
-    const std::int64_t seed_key = key(seed_unwrapped);
-    if (visited.count(seed_key) != 0) {
-      continue;  // already absorbed into an earlier component (or a duplicate index)
-    }
-    CellComponent comp;
-    comp.point_sum = 0.0;
-    std::vector<grid_map::Index> stack{seed_unwrapped};  // unwrapped indices
-    visited.insert(seed_key);
-    while (!stack.empty()) {
-      const grid_map::Index cur = stack.back();  // unwrapped
-      stack.pop_back();
-      const grid_map::Index buf = grid_map::getBufferIndexFromIndex(cur, size, start);
-      comp.cells.push_back(buf);  // report the caller's buffer-index space
-      const float cnt = grid.at("point_count", buf);
-      if (!std::isnan(cnt)) {
-        comp.point_sum += static_cast<double>(cnt);  // skip NaN rather than poison the sum
-      }
-      for (int dr = -1; dr <= 1; ++dr) {
-        for (int dc = -1; dc <= 1; ++dc) {
-          if (dr == 0 && dc == 0) {
-            continue;
-          }
-          const grid_map::Index nb(cur(0) + dr, cur(1) + dc);  // unwrapped neighbor
-          if (nb(0) < 0 || nb(0) >= rows || nb(1) < 0 || nb(1) >= cols) {
-            continue;  // off-grid neighbor: skip before keying so the linear key cannot alias
-          }
-          const std::int64_t nb_key = key(nb);
-          const auto found = members.find(nb_key);
-          if (found == members.end() || visited.count(nb_key) != 0) {
-            continue;
-          }
-          visited.insert(nb_key);
-          stack.push_back(nb);  // nb is already the unwrapped index of found->second
-        }
-      }
-    }
-    out.push_back(std::move(comp));
-  }
-  return out;
-}
+std::vector<CellComponent> connected_components(
+  const grid_map::GridMap & grid, const std::vector<grid_map::Index> & qualifying);
 }  // namespace autoware::obstacle_grid_utils
 #endif  // AUTOWARE__OBSTACLE_GRID_UTILS__OBSTACLE_GRID_UTILS_HPP_

--- a/common/autoware_obstacle_grid_utils/include/autoware/obstacle_grid_utils/obstacle_grid_utils.hpp
+++ b/common/autoware_obstacle_grid_utils/include/autoware/obstacle_grid_utils/obstacle_grid_utils.hpp
@@ -20,9 +20,14 @@
 #include <boost/geometry.hpp>
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <cstdint>
 #include <limits>
+#include <optional>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
 #include <vector>
 
 namespace autoware::obstacle_grid_utils
@@ -61,6 +66,17 @@ inline Polygon2d cell_footprint(const grid_map::Position & c, double res)
   return box;
 }
 
+/// The 4 corner points of a cell footprint box, in the same winding as cell_footprint
+/// (min-min, min-max, max-max, max-min). Emitting corners rather than the center keeps
+/// corridor/lane membership edge-conservative: a cell counts as inside if any corner is.
+inline std::array<Point2d, 4> cell_corners(const grid_map::Position & center, double resolution)
+{
+  const double h = 0.5 * resolution;
+  return {
+    Point2d(center.x() - h, center.y() - h), Point2d(center.x() - h, center.y() + h),
+    Point2d(center.x() + h, center.y() + h), Point2d(center.x() + h, center.y() - h)};
+}
+
 /// 2D distance from ego_polygon to the nearest qualifying cell footprint. Returns
 /// +inf when nothing qualifies inside the ROI (caller treats that as "clear within ROI").
 inline double nearest_distance(
@@ -75,6 +91,38 @@ inline double nearest_distance(
     grid_map::Position c;
     grid.getPosition(*it, c);
     best = std::min(best, boost::geometry::distance(ego_polygon, cell_footprint(c, res)));
+  }
+  return best;
+}
+
+/// Nearest qualifying cell together with WHERE it is. distance is edge-aware (to the cell
+/// footprint box, identical semantics to nearest_distance); position is the cell center and
+/// index its grid index, for debug markers / SafetyFactor.points / StopObstacle.nearest_point.
+struct NearestCell
+{
+  double distance;
+  grid_map::Position position;  // cell center
+  grid_map::Index index;
+};
+
+/// std::nullopt when nothing qualifies inside the ROI (the nullopt <-> +inf analog of
+/// nearest_distance; a consumer treats nullopt as "clear within ROI"). On a distance tie the
+/// first cell encountered by the grid iterator wins (either-of; callers must not rely on which).
+inline std::optional<NearestCell> nearest_cell(
+  const grid_map::GridMap & grid, const Polygon2d & ego_polygon, const Gate & gate)
+{
+  std::optional<NearestCell> best;
+  const double res = grid.getResolution();
+  for (grid_map::GridMapIterator it(grid); !it.isPastEnd(); ++it) {
+    if (!cell_qualifies(grid, *it, gate)) {
+      continue;
+    }
+    grid_map::Position c;
+    grid.getPosition(*it, c);
+    const double d = boost::geometry::distance(ego_polygon, cell_footprint(c, res));
+    if (!best || d < best->distance) {
+      best = NearestCell{d, c, *it};
+    }
   }
   return best;
 }
@@ -96,6 +144,73 @@ inline std::vector<grid_map::Position> cells_in_polygon(
     grid_map::Position c;
     grid.getPosition(*it, c);
     out.push_back(c);
+  }
+  return out;
+}
+
+/// One 8-connected component of qualifying cells; point_sum is the sum of the point_count layer
+/// over its cells (the grid analog of a Euclidean cluster's point total, gated by the caller).
+struct CellComponent
+{
+  std::vector<grid_map::Index> cells;
+  double point_sum;
+};
+
+/// 8-connected labeling over the SUPPLIED qualifying cell indices. This function does NOT gate:
+/// the caller applies its per-cell Gate first and passes the surviving indices; here we only
+/// group them into components and sum point_count. O(cells): membership and visited are hashed on
+/// a linear key, so out-of-grid neighbors of border cells are simply absent from the member set
+/// and never probed. Components come out in first-seen order for stable, deterministic output.
+inline std::vector<CellComponent> connected_components(
+  const grid_map::GridMap & grid, const std::vector<grid_map::Index> & qualifying)
+{
+  const int rows = grid.getSize()(0);
+  const int cols = grid.getSize()(1);
+  const auto key = [cols](const grid_map::Index & idx) {
+    return static_cast<std::int64_t>(idx(0)) * cols + static_cast<std::int64_t>(idx(1));
+  };
+  std::unordered_map<std::int64_t, grid_map::Index> members;
+  members.reserve(qualifying.size());
+  for (const auto & idx : qualifying) {
+    members.emplace(key(idx), idx);
+  }
+  std::unordered_set<std::int64_t> visited;
+  visited.reserve(qualifying.size());
+  std::vector<CellComponent> out;
+  for (const auto & seed : qualifying) {
+    const std::int64_t seed_key = key(seed);
+    if (visited.count(seed_key) != 0) {
+      continue;  // already absorbed into an earlier component (or a duplicate index)
+    }
+    CellComponent comp;
+    comp.point_sum = 0.0;
+    std::vector<grid_map::Index> stack{seed};
+    visited.insert(seed_key);
+    while (!stack.empty()) {
+      const grid_map::Index cur = stack.back();
+      stack.pop_back();
+      comp.cells.push_back(cur);
+      comp.point_sum += static_cast<double>(grid.at("point_count", cur));
+      for (int dr = -1; dr <= 1; ++dr) {
+        for (int dc = -1; dc <= 1; ++dc) {
+          if (dr == 0 && dc == 0) {
+            continue;
+          }
+          const grid_map::Index nb(cur(0) + dr, cur(1) + dc);
+          if (nb(0) < 0 || nb(0) >= rows || nb(1) < 0 || nb(1) >= cols) {
+            continue;  // off-grid neighbor: skip before keying so the linear key cannot alias
+          }
+          const std::int64_t nb_key = key(nb);
+          const auto found = members.find(nb_key);
+          if (found == members.end() || visited.count(nb_key) != 0) {
+            continue;
+          }
+          visited.insert(nb_key);
+          stack.push_back(found->second);
+        }
+      }
+    }
+    out.push_back(std::move(comp));
   }
   return out;
 }

--- a/common/autoware_obstacle_grid_utils/include/autoware/obstacle_grid_utils/obstacle_grid_utils.hpp
+++ b/common/autoware_obstacle_grid_utils/include/autoware/obstacle_grid_utils/obstacle_grid_utils.hpp
@@ -158,45 +158,66 @@ struct CellComponent
 
 /// 8-connected labeling over the SUPPLIED qualifying cell indices. This function does NOT gate:
 /// the caller applies its per-cell Gate first and passes the surviving indices; here we only
-/// group them into components and sum point_count. O(cells): membership and visited are hashed on
-/// a linear key, so out-of-grid neighbors of border cells are simply absent from the member set
-/// and never probed. Components come out in first-seen order for stable, deterministic output.
+/// group them into components and sum point_count.
+///
+/// Adjacency is computed in grid_map's UNWRAPPED index space (via getIndexFromBufferIndex), so it
+/// stays geometrically correct even when the grid's circular buffer has been move()d
+/// (getStartIndex() != (0,0)): geometrically adjacent cells that straddle the buffer wrap seam are
+/// still merged into one component, and cells that are merely neighbors in raw buffer-index space
+/// across the seam are not falsely merged. The reported CellComponent::cells are the caller's
+/// ORIGINAL buffer indices, so they remain usable directly with grid.at().
+///
+/// O(cells): membership and visited are hashed on an unwrapped linear key, so out-of-grid
+/// neighbors of border cells are simply absent from the member set and never probed. Components
+/// come out in first-seen order for stable, deterministic output.
+///
+/// Precondition: every supplied index is a valid in-grid cell. point_count is expected non-NaN
+/// (the caller's Gate already rejects NaN point_count); a NaN contribution is skipped rather than
+/// poisoning the whole component's point_sum to NaN and silently dropping a real cluster.
 inline std::vector<CellComponent> connected_components(
   const grid_map::GridMap & grid, const std::vector<grid_map::Index> & qualifying)
 {
-  const int rows = grid.getSize()(0);
-  const int cols = grid.getSize()(1);
-  const auto key = [cols](const grid_map::Index & idx) {
-    return static_cast<std::int64_t>(idx(0)) * cols + static_cast<std::int64_t>(idx(1));
+  const grid_map::Size size = grid.getSize();
+  const grid_map::Index start = grid.getStartIndex();
+  const int rows = size(0);
+  const int cols = size(1);
+  const auto key = [cols](const grid_map::Index & unwrapped) {
+    return static_cast<std::int64_t>(unwrapped(0)) * cols + static_cast<std::int64_t>(unwrapped(1));
   };
+  // Map an unwrapped-index key to the caller's ORIGINAL buffer index (for grid.at / reporting).
   std::unordered_map<std::int64_t, grid_map::Index> members;
   members.reserve(qualifying.size());
   for (const auto & idx : qualifying) {
-    members.emplace(key(idx), idx);
+    members.emplace(key(grid_map::getIndexFromBufferIndex(idx, size, start)), idx);
   }
   std::unordered_set<std::int64_t> visited;
   visited.reserve(qualifying.size());
   std::vector<CellComponent> out;
   for (const auto & seed : qualifying) {
-    const std::int64_t seed_key = key(seed);
+    const grid_map::Index seed_unwrapped = grid_map::getIndexFromBufferIndex(seed, size, start);
+    const std::int64_t seed_key = key(seed_unwrapped);
     if (visited.count(seed_key) != 0) {
       continue;  // already absorbed into an earlier component (or a duplicate index)
     }
     CellComponent comp;
     comp.point_sum = 0.0;
-    std::vector<grid_map::Index> stack{seed};
+    std::vector<grid_map::Index> stack{seed_unwrapped};  // unwrapped indices
     visited.insert(seed_key);
     while (!stack.empty()) {
-      const grid_map::Index cur = stack.back();
+      const grid_map::Index cur = stack.back();  // unwrapped
       stack.pop_back();
-      comp.cells.push_back(cur);
-      comp.point_sum += static_cast<double>(grid.at("point_count", cur));
+      const grid_map::Index buf = grid_map::getBufferIndexFromIndex(cur, size, start);
+      comp.cells.push_back(buf);  // report the caller's buffer-index space
+      const float cnt = grid.at("point_count", buf);
+      if (!std::isnan(cnt)) {
+        comp.point_sum += static_cast<double>(cnt);  // skip NaN rather than poison the sum
+      }
       for (int dr = -1; dr <= 1; ++dr) {
         for (int dc = -1; dc <= 1; ++dc) {
           if (dr == 0 && dc == 0) {
             continue;
           }
-          const grid_map::Index nb(cur(0) + dr, cur(1) + dc);
+          const grid_map::Index nb(cur(0) + dr, cur(1) + dc);  // unwrapped neighbor
           if (nb(0) < 0 || nb(0) >= rows || nb(1) < 0 || nb(1) >= cols) {
             continue;  // off-grid neighbor: skip before keying so the linear key cannot alias
           }
@@ -206,7 +227,7 @@ inline std::vector<CellComponent> connected_components(
             continue;
           }
           visited.insert(nb_key);
-          stack.push_back(found->second);
+          stack.push_back(nb);  // nb is already the unwrapped index of found->second
         }
       }
     }

--- a/common/autoware_obstacle_grid_utils/package.xml
+++ b/common/autoware_obstacle_grid_utils/package.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>autoware_obstacle_grid_utils</name>
+  <version>0.51.0</version>
+  <description>
+    Header-only consumer helper for the obstacle grid: a per-cell qualification gate plus
+    nearest-distance and cells-in-polygon queries over a grid_map_msgs/GridMap, shared by all
+    last-resort safety consumers so they cannot each re-derive the query logic incorrectly.
+  </description>
+  <maintainer email="yutaka.kondo@youtalk.jp">Yutaka Kondo</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
+
+  <depend>autoware_utils_geometry</depend>
+  <depend>grid_map_core</depend>
+
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>autoware_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/common/autoware_obstacle_grid_utils/package.xml
+++ b/common/autoware_obstacle_grid_utils/package.xml
@@ -9,7 +9,7 @@
     queries over a grid_map_msgs/GridMap, shared by all last-resort safety consumers so they
     cannot each re-derive the query logic incorrectly.
   </description>
-  <maintainer email="yutaka.kondo@youtalk.jp">Yutaka Kondo</maintainer>
+  <maintainer email="yutaka.kondo@tier4.jp">Yutaka Kondo</maintainer>
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/common/autoware_obstacle_grid_utils/package.xml
+++ b/common/autoware_obstacle_grid_utils/package.xml
@@ -4,10 +4,10 @@
   <name>autoware_obstacle_grid_utils</name>
   <version>0.51.0</version>
   <description>
-    Header-only consumer helper for the obstacle grid: a per-cell qualification gate plus
-    nearest-distance/nearest-cell, cells-in-polygon, cell-corner, and 8-connected component
-    queries over a grid_map_msgs/GridMap, shared by all last-resort safety consumers so they
-    cannot each re-derive the query logic incorrectly.
+    Consumer helper for the obstacle grid: a per-cell qualification gate plus
+    nearest-distance/nearest-cell, cell-corner, and 8-connected component queries over a
+    grid_map_msgs/GridMap, shared by all last-resort safety consumers so they cannot each
+    re-derive the query logic incorrectly.
   </description>
   <maintainer email="yutaka.kondo@tier4.jp">Yutaka Kondo</maintainer>
   <license>Apache License 2.0</license>

--- a/common/autoware_obstacle_grid_utils/package.xml
+++ b/common/autoware_obstacle_grid_utils/package.xml
@@ -5,8 +5,9 @@
   <version>0.51.0</version>
   <description>
     Header-only consumer helper for the obstacle grid: a per-cell qualification gate plus
-    nearest-distance and cells-in-polygon queries over a grid_map_msgs/GridMap, shared by all
-    last-resort safety consumers so they cannot each re-derive the query logic incorrectly.
+    nearest-distance/nearest-cell, cells-in-polygon, cell-corner, and 8-connected component
+    queries over a grid_map_msgs/GridMap, shared by all last-resort safety consumers so they
+    cannot each re-derive the query logic incorrectly.
   </description>
   <maintainer email="yutaka.kondo@youtalk.jp">Yutaka Kondo</maintainer>
   <license>Apache License 2.0</license>

--- a/common/autoware_obstacle_grid_utils/src/obstacle_grid_utils.cpp
+++ b/common/autoware_obstacle_grid_utils/src/obstacle_grid_utils.cpp
@@ -1,0 +1,234 @@
+// Copyright 2026 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <autoware/obstacle_grid_utils/obstacle_grid_utils.hpp>
+
+#include <boost/geometry.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <optional>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace autoware::obstacle_grid_utils
+{
+namespace
+{
+/// Footprint box of one cell. Cells are areas, so measuring a distance to this box rather than
+/// to the cell center is what makes nearest_distance()/nearest_cell() edge-aware. Internal: the
+/// public edge-aware surface is nearest_distance(), nearest_cell() and cell_corners().
+Polygon2d cell_footprint(const grid_map::Position & center, double resolution)
+{
+  const double half = 0.5 * resolution;
+  Polygon2d box;
+  boost::geometry::append(box.outer(), Point2d(center.x() - half, center.y() - half));
+  boost::geometry::append(box.outer(), Point2d(center.x() - half, center.y() + half));
+  boost::geometry::append(box.outer(), Point2d(center.x() + half, center.y() + half));
+  boost::geometry::append(box.outer(), Point2d(center.x() + half, center.y() - half));
+  boost::geometry::correct(box);
+  return box;
+}
+
+/// The 8 neighbour offsets, in row-major order.
+constexpr std::array<std::pair<int, int>, 8> neighbor_offsets{
+  {{-1, -1}, {-1, 0}, {-1, 1}, {0, -1}, {0, 1}, {1, -1}, {1, 0}, {1, 1}}};
+
+/// Grows 8-connected components over a fixed set of qualifying cells.
+///
+/// Every index is handled in grid_map's UNWRAPPED space, so adjacency stays geometric even when
+/// the circular buffer has been move()d; cells are converted back to the caller's buffer-index
+/// space only when they are recorded into a component.
+class ComponentBuilder
+{
+public:
+  ComponentBuilder(const grid_map::GridMap & grid, const std::vector<grid_map::Index> & qualifying)
+  : grid_(grid),
+    size_(grid.getSize()),
+    start_(grid.getStartIndex()),
+    rows_(size_(0)),
+    columns_(size_(1))
+  {
+    members_.reserve(qualifying.size());
+    visited_.reserve(qualifying.size());
+    for (const auto & buffer_index : qualifying) {
+      members_.insert(key(unwrap(buffer_index)));
+    }
+  }
+
+  bool visited(const grid_map::Index & buffer_index) const
+  {
+    return visited_.count(key(unwrap(buffer_index))) != 0;
+  }
+
+  /// Flood-fill the component reachable from `seed`, marking every cell it reaches as visited.
+  CellComponent grow_from(const grid_map::Index & seed)
+  {
+    CellComponent component;
+    component.point_sum = 0.0;
+    std::vector<grid_map::Index> stack{unwrap(seed)};
+    visited_.insert(key(stack.back()));
+    while (!stack.empty()) {
+      const grid_map::Index current = stack.back();
+      stack.pop_back();
+      absorb(current, component);
+      for (const auto & neighbor : unvisited_members_around(current)) {
+        visited_.insert(key(neighbor));
+        stack.push_back(neighbor);
+      }
+    }
+    return component;
+  }
+
+private:
+  grid_map::Index unwrap(const grid_map::Index & buffer_index) const
+  {
+    return grid_map::getIndexFromBufferIndex(buffer_index, size_, start_);
+  }
+
+  std::int64_t key(const grid_map::Index & unwrapped) const
+  {
+    return static_cast<std::int64_t>(unwrapped(0)) * columns_ +
+           static_cast<std::int64_t>(unwrapped(1));
+  }
+
+  bool inside_grid(const grid_map::Index & unwrapped) const
+  {
+    const bool row_inside = unwrapped(0) >= 0 && unwrapped(0) < rows_;
+    const bool column_inside = unwrapped(1) >= 0 && unwrapped(1) < columns_;
+    return row_inside && column_inside;
+  }
+
+  /// Off-grid neighbours are rejected before keying, so the linear key can never alias one of
+  /// them onto a real cell in the next row.
+  bool is_unvisited_member(const grid_map::Index & unwrapped) const
+  {
+    if (!inside_grid(unwrapped)) {
+      return false;
+    }
+    const std::int64_t neighbor_key = key(unwrapped);
+    return members_.count(neighbor_key) != 0 && visited_.count(neighbor_key) == 0;
+  }
+
+  std::vector<grid_map::Index> unvisited_members_around(const grid_map::Index & unwrapped) const
+  {
+    std::vector<grid_map::Index> neighbors;
+    neighbors.reserve(neighbor_offsets.size());
+    for (const auto & offset : neighbor_offsets) {
+      const grid_map::Index neighbor(unwrapped(0) + offset.first, unwrapped(1) + offset.second);
+      if (is_unvisited_member(neighbor)) {
+        neighbors.push_back(neighbor);
+      }
+    }
+    return neighbors;
+  }
+
+  /// Record one cell into the component, in the caller's buffer-index space. A NaN point_count is
+  /// skipped rather than poisoning the whole sum and silently dropping a real cluster.
+  void absorb(const grid_map::Index & unwrapped, CellComponent & component) const
+  {
+    const grid_map::Index buffer_index =
+      grid_map::getBufferIndexFromIndex(unwrapped, size_, start_);
+    component.cells.push_back(buffer_index);
+    const float point_count = grid_.at("point_count", buffer_index);
+    if (!std::isnan(point_count)) {
+      component.point_sum += static_cast<double>(point_count);
+    }
+  }
+
+  const grid_map::GridMap & grid_;
+  grid_map::Size size_;
+  grid_map::Index start_;
+  int rows_;
+  int columns_;
+  std::unordered_set<std::int64_t> members_;
+  std::unordered_set<std::int64_t> visited_;
+};
+}  // namespace
+
+bool cell_qualifies(
+  const grid_map::GridMap & grid, const grid_map::Index & index, const Gate & gate)
+{
+  const float point_count = grid.at("point_count", index);
+  const bool count_passes = !std::isnan(point_count) &&
+                            static_cast<std::uint32_t>(point_count) >= gate.min_point_count_cell;
+  if (!count_passes) {
+    return false;
+  }
+  const float max_height = grid.at("max_height", index);
+  return !std::isnan(max_height) && static_cast<double>(max_height) >= gate.min_height;
+}
+
+std::array<Point2d, 4> cell_corners(const grid_map::Position & center, double resolution)
+{
+  const double half = 0.5 * resolution;
+  return {
+    Point2d(center.x() - half, center.y() - half), Point2d(center.x() - half, center.y() + half),
+    Point2d(center.x() + half, center.y() + half), Point2d(center.x() + half, center.y() - half)};
+}
+
+double nearest_distance(
+  const grid_map::GridMap & grid, const Polygon2d & ego_polygon, const Gate & gate)
+{
+  double nearest = std::numeric_limits<double>::infinity();
+  const double resolution = grid.getResolution();
+  for (grid_map::GridMapIterator it(grid); !it.isPastEnd(); ++it) {
+    if (!cell_qualifies(grid, *it, gate)) {
+      continue;
+    }
+    grid_map::Position center;
+    grid.getPosition(*it, center);
+    nearest =
+      std::min(nearest, boost::geometry::distance(ego_polygon, cell_footprint(center, resolution)));
+  }
+  return nearest;
+}
+
+std::optional<NearestCell> nearest_cell(
+  const grid_map::GridMap & grid, const Polygon2d & ego_polygon, const Gate & gate)
+{
+  std::optional<NearestCell> nearest;
+  const double resolution = grid.getResolution();
+  for (grid_map::GridMapIterator it(grid); !it.isPastEnd(); ++it) {
+    if (!cell_qualifies(grid, *it, gate)) {
+      continue;
+    }
+    grid_map::Position center;
+    grid.getPosition(*it, center);
+    const double distance =
+      boost::geometry::distance(ego_polygon, cell_footprint(center, resolution));
+    if (!nearest || distance < nearest->distance) {
+      nearest = NearestCell{distance, center, *it};
+    }
+  }
+  return nearest;
+}
+
+std::vector<CellComponent> connected_components(
+  const grid_map::GridMap & grid, const std::vector<grid_map::Index> & qualifying)
+{
+  ComponentBuilder builder(grid, qualifying);
+  std::vector<CellComponent> components;
+  for (const auto & seed : qualifying) {
+    if (builder.visited(seed)) {
+      continue;  // already absorbed into an earlier component (or a duplicate index)
+    }
+    components.push_back(builder.grow_from(seed));
+  }
+  return components;
+}
+}  // namespace autoware::obstacle_grid_utils

--- a/common/autoware_obstacle_grid_utils/test/test_obstacle_grid_utils.cpp
+++ b/common/autoware_obstacle_grid_utils/test/test_obstacle_grid_utils.cpp
@@ -19,333 +19,480 @@
 
 #include <array>
 #include <cmath>
+#include <cstddef>
 #include <limits>
-#include <optional>
+#include <string>
 #include <vector>
 
 namespace autoware::obstacle_grid_utils
 {
-namespace bg = boost::geometry;
-
-// A 0.2 m grid centered at (0,0). Mark one occupied cell containing position (cx, cy).
-// NOTE: with center (0,0) and resolution 0.2, cell centers fall on odd multiples of 0.1
-// (..., 1.9, 2.1, ...), so callers pass true cell-center coordinates (e.g. 2.1, 1.1) to
-// keep the independent oracle exact.
-grid_map::GridMap make_grid(double cx, double cy, float count, float zmin, float zmax)
+namespace
 {
-  grid_map::GridMap g({"max_height", "min_height", "point_count"});
-  g.setFrameId("base_link");
-  g.setGeometry(grid_map::Length(10.0, 10.0), 0.2, grid_map::Position(0.0, 0.0));
-  g["point_count"].setConstant(std::numeric_limits<float>::quiet_NaN());
-  g["max_height"].setConstant(std::numeric_limits<float>::quiet_NaN());
-  g["min_height"].setConstant(std::numeric_limits<float>::quiet_NaN());
-  grid_map::Index idx;
-  g.getIndex(grid_map::Position(cx, cy), idx);
-  g.at("point_count", idx) = count;
-  g.at("max_height", idx) = zmax;
-  g.at("min_height", idx) = zmin;
-  return g;
-}
+constexpr double grid_resolution = 0.2;  // metres per cell
+constexpr double grid_length = 10.0;     // metres per side, centred on the origin
+constexpr int expected_grid_columns = 50;
 
-Polygon2d ego_point()  // degenerate ego polygon at the origin
+/// What the extractor is assumed to have written into one cell. Only point_count and max_height
+/// are ever read by the helpers under test; min_height is populated for realism, never queried.
+struct CellContent
 {
-  Polygon2d p;
-  bg::append(p.outer(), Point2d(0.0, 0.0));
-  bg::correct(p);
-  return p;
-}
+  float point_count;
+  float max_height;
+};
 
-bool qualifies_at(const grid_map::GridMap & g, double x, double y, const Gate & gate)
-{
-  grid_map::Index idx;
-  g.getIndex(grid_map::Position(x, y), idx);
-  return cell_qualifies(g, idx, gate);
-}
+constexpr CellContent occupied{40.0f, 1.5f};
+constexpr float realistic_min_height = 0.5f;
 
-// An all-NaN (heartbeat) 0.2 m grid centered at (0,0); mark individual cells by grid index below.
+/// An all-NaN (heartbeat) grid: no cell qualifies until a test marks one.
 grid_map::GridMap make_empty_grid()
 {
-  grid_map::GridMap g({"max_height", "min_height", "point_count"});
-  g.setFrameId("base_link");
-  g.setGeometry(grid_map::Length(10.0, 10.0), 0.2, grid_map::Position(0.0, 0.0));
-  g["point_count"].setConstant(std::numeric_limits<float>::quiet_NaN());
-  g["max_height"].setConstant(std::numeric_limits<float>::quiet_NaN());
-  g["min_height"].setConstant(std::numeric_limits<float>::quiet_NaN());
-  return g;
+  grid_map::GridMap grid({"max_height", "min_height", "point_count"});
+  grid.setFrameId("base_link");
+  grid.setGeometry(
+    grid_map::Length(grid_length, grid_length), grid_resolution, grid_map::Position(0.0, 0.0));
+  grid["point_count"].setConstant(std::numeric_limits<float>::quiet_NaN());
+  grid["max_height"].setConstant(std::numeric_limits<float>::quiet_NaN());
+  grid["min_height"].setConstant(std::numeric_limits<float>::quiet_NaN());
+  return grid;
 }
 
-void set_cell(grid_map::GridMap & g, const grid_map::Index & idx, float count)
+void mark_cell(grid_map::GridMap & grid, const grid_map::Index & index, const CellContent & content)
 {
-  g.at("point_count", idx) = count;
-  g.at("max_height", idx) = 1.5f;
-  g.at("min_height", idx) = 0.5f;
+  grid.at("point_count", index) = content.point_count;
+  grid.at("max_height", index) = content.max_height;
+  grid.at("min_height", index) = realistic_min_height;
 }
 
-TEST(ObstacleGridUtils, EdgeAwareDistanceUsesCellFootprint)
+grid_map::Index index_at(const grid_map::GridMap & grid, const grid_map::Position & position)
 {
-  // Occupied cell centered at the true cell center (2.1, 1.1); its 0.2 m footprint box is
-  // [2.0,2.2] x [1.0,1.2], whose near corner (2.0, 1.0) is closer to ego than the center.
-  const auto g = make_grid(2.1, 1.1, 40, 0.5, 1.5);
-  const double d = nearest_distance(g, ego_point(), Gate{1u, 0.0});
-  // Independent oracle: distance to the near corner of the footprint, hand-computed.
-  EXPECT_LT(d, std::hypot(2.1, 1.1));          // edge-aware: strictly less than center distance
-  EXPECT_NEAR(d, std::hypot(2.0, 1.0), 1e-6);  // distance to the near footprint corner
+  grid_map::Index index;
+  grid.getIndex(position, index);
+  return index;
 }
 
-TEST(ObstacleGridUtils, NearestDistanceIsInfWhenNothingQualifies)
+/// A grid whose only marked cell is the one containing `center`.
+///
+/// NOTE: with the grid centred at (0,0) and a 0.2 m resolution, cell centres fall on odd
+/// multiples of 0.1 (..., 1.9, 2.1, ...), so the tests pass true cell-centre coordinates
+/// (e.g. 2.1, 1.1) to keep the hand-computed oracles exact.
+grid_map::GridMap make_grid_with_one_cell(
+  const grid_map::Position & center, const CellContent & content)
 {
-  const auto g = make_grid(2.1, 1.1, 5, 0.5, 1.5);  // count 5 < gate 10 -> nothing qualifies
-  const double d = nearest_distance(g, ego_point(), Gate{10u, 0.0});
-  EXPECT_TRUE(std::isinf(d));
+  auto grid = make_empty_grid();
+  mark_cell(grid, index_at(grid, center), content);
+  return grid;
 }
 
-TEST(ObstacleGridUtils, GateRejectsBelowCount)
+/// Degenerate single-point ego polygon at the origin, so the measured distance is purely the
+/// distance to the obstacle cell.
+Polygon2d ego_polygon_at_origin()
 {
-  EXPECT_FALSE(qualifies_at(make_grid(2.1, 1.1, 9, 0.5, 1.5), 2.1, 1.1, Gate{10u, 0.0}));
-  EXPECT_TRUE(qualifies_at(make_grid(2.1, 1.1, 10, 0.5, 1.5), 2.1, 1.1, Gate{10u, 0.0}));
+  Polygon2d polygon;
+  boost::geometry::append(polygon.outer(), Point2d(0.0, 0.0));
+  boost::geometry::correct(polygon);
+  return polygon;
 }
 
-TEST(ObstacleGridUtils, GateRejectsBelowHeight)
+bool cell_qualifies_at(
+  const grid_map::GridMap & grid, const grid_map::Position & position, const Gate & gate)
 {
-  // tall enough passes the height gate; a flat ground-height sliver fails it.
-  EXPECT_TRUE(qualifies_at(make_grid(2.1, 1.1, 50, 0.0, 1.2), 2.1, 1.1, Gate{10u, 0.3}));
-  EXPECT_FALSE(qualifies_at(make_grid(2.1, 1.1, 50, 0.0, 0.1), 2.1, 1.1, Gate{10u, 0.3}));
+  return cell_qualifies(grid, index_at(grid, position), gate);
+}
+}  // namespace
+
+// --- nearest_distance ---------------------------------------------------------------------------
+
+TEST(ObstacleGridUtils, NearestDistanceMeasuresToTheCellEdgeNotItsCenter)
+{
+  // Arrange: one occupied cell centred at (2.1, 1.1); its 0.2 m footprint box is
+  // [2.0, 2.2] x [1.0, 1.2], so its near corner (2.0, 1.0) is closer to ego than its centre.
+  const auto grid = make_grid_with_one_cell(grid_map::Position(2.1, 1.1), occupied);
+  const Gate accept_anything{1u, 0.0};
+
+  // Act
+  const double distance_to_nearest =
+    nearest_distance(grid, ego_polygon_at_origin(), accept_anything);
+
+  // Assert: the hand-computed distance to the near footprint corner, strictly closer than the
+  // distance to the cell centre would be.
+  EXPECT_NEAR(distance_to_nearest, std::hypot(2.0, 1.0), 1e-6);
+  EXPECT_LT(distance_to_nearest, std::hypot(2.1, 1.1));
 }
 
-TEST(ObstacleGridUtils, GateRejectsNanHeightEvenWhenCountPasses)
+TEST(ObstacleGridUtils, NearestDistanceIsInfiniteWhenNothingQualifies)
 {
-  // A cell whose point_count clears the count gate but whose max_height is NaN (a heartbeat cell
-  // that was never populated with a height) must fail the height guard rather than qualify.
-  auto g = make_empty_grid();
-  grid_map::Index idx;
-  g.getIndex(grid_map::Position(2.1, 1.1), idx);
-  g.at("point_count", idx) = 50.0f;  // count 50 >= gate 10 -> passes the count gate
-  // max_height(idx) is left NaN by make_empty_grid; the !isnan(max_height) guard must reject.
-  EXPECT_FALSE(cell_qualifies(g, idx, Gate{10u, 0.0}));
+  // Arrange: the only marked cell holds 5 points, below the gate's threshold of 10.
+  const auto grid = make_grid_with_one_cell(grid_map::Position(2.1, 1.1), CellContent{5.0f, 1.5f});
+  const Gate needs_ten_points{10u, 0.0};
+
+  // Act
+  const double distance_to_nearest =
+    nearest_distance(grid, ego_polygon_at_origin(), needs_ten_points);
+
+  // Assert
+  EXPECT_TRUE(std::isinf(distance_to_nearest));
 }
 
-TEST(ObstacleGridUtils, CellCornersAreLiteralFootprintCorners)
+// --- cell_qualifies -----------------------------------------------------------------------------
+
+TEST(ObstacleGridUtils, CellQualifiesWhenPointCountReachesTheThreshold)
 {
-  // center (2.1, 1.1), resolution 0.2 -> half 0.1 -> box [2.0,2.2] x [1.0,1.2].
-  const auto corners = cell_corners(grid_map::Position(2.1, 1.1), 0.2);
-  ASSERT_EQ(corners.size(), 4u);
-  EXPECT_NEAR(corners[0].x(), 2.0, 1e-9);  // min-min
-  EXPECT_NEAR(corners[0].y(), 1.0, 1e-9);
-  EXPECT_NEAR(corners[1].x(), 2.0, 1e-9);  // min-max
-  EXPECT_NEAR(corners[1].y(), 1.2, 1e-9);
-  EXPECT_NEAR(corners[2].x(), 2.2, 1e-9);  // max-max
-  EXPECT_NEAR(corners[2].y(), 1.2, 1e-9);
-  EXPECT_NEAR(corners[3].x(), 2.2, 1e-9);  // max-min
-  EXPECT_NEAR(corners[3].y(), 1.0, 1e-9);
+  // Arrange
+  const grid_map::Position center(2.1, 1.1);
+  const auto grid = make_grid_with_one_cell(center, CellContent{10.0f, 1.5f});
+
+  // Act & Assert
+  EXPECT_TRUE(cell_qualifies_at(grid, center, Gate{10u, 0.0}));
 }
 
-TEST(ObstacleGridUtils, NearestCellMatchesNearestDistanceAndReportsWhere)
+TEST(ObstacleGridUtils, CellDoesNotQualifyWhenPointCountIsBelowTheThreshold)
 {
-  // Same fixture as EdgeAwareDistanceUsesCellFootprint: one cell centered at (2.1, 1.1).
-  const auto g = make_grid(2.1, 1.1, 40, 0.5, 1.5);
-  const auto nc = nearest_cell(g, ego_point(), Gate{1u, 0.0});
-  ASSERT_TRUE(nc.has_value());
-  // Equivalence with the scalar helper (edge-aware distance to the near footprint corner).
-  EXPECT_NEAR(nc->distance, nearest_distance(g, ego_point(), Gate{1u, 0.0}), 1e-12);
-  EXPECT_NEAR(nc->distance, std::hypot(2.0, 1.0), 1e-6);  // independent oracle
-  // WHERE: cell center and grid index of the occupied cell.
-  EXPECT_NEAR(nc->position.x(), 2.1, 1e-6);
-  EXPECT_NEAR(nc->position.y(), 1.1, 1e-6);
-  grid_map::Index expected;
-  g.getIndex(grid_map::Position(2.1, 1.1), expected);
-  EXPECT_EQ(nc->index(0), expected(0));
-  EXPECT_EQ(nc->index(1), expected(1));
+  // Arrange
+  const grid_map::Position center(2.1, 1.1);
+  const auto grid = make_grid_with_one_cell(center, CellContent{9.0f, 1.5f});
+
+  // Act & Assert
+  EXPECT_FALSE(cell_qualifies_at(grid, center, Gate{10u, 0.0}));
+}
+
+TEST(ObstacleGridUtils, CellQualifiesWhenMaxHeightReachesTheThreshold)
+{
+  // Arrange: a cell tall enough to clear a 0.3 m height gate.
+  const grid_map::Position center(2.1, 1.1);
+  const auto grid = make_grid_with_one_cell(center, CellContent{50.0f, 1.2f});
+
+  // Act & Assert
+  EXPECT_TRUE(cell_qualifies_at(grid, center, Gate{10u, 0.3}));
+}
+
+TEST(ObstacleGridUtils, CellDoesNotQualifyWhenMaxHeightIsBelowTheThreshold)
+{
+  // Arrange: a flat ground-height sliver that must not trip a 0.3 m height gate.
+  const grid_map::Position center(2.1, 1.1);
+  const auto grid = make_grid_with_one_cell(center, CellContent{50.0f, 0.1f});
+
+  // Act & Assert
+  EXPECT_FALSE(cell_qualifies_at(grid, center, Gate{10u, 0.3}));
+}
+
+TEST(ObstacleGridUtils, CellDoesNotQualifyWhenMaxHeightIsNanEvenIfPointCountPasses)
+{
+  // Arrange: a heartbeat cell that got a point count but was never populated with a height. The
+  // count clears the gate, so only the NaN guard on max_height can reject it.
+  const grid_map::Position center(2.1, 1.1);
+  const auto nan_height = std::numeric_limits<float>::quiet_NaN();
+  const auto grid = make_grid_with_one_cell(center, CellContent{50.0f, nan_height});
+
+  // Act & Assert
+  EXPECT_FALSE(cell_qualifies_at(grid, center, Gate{10u, 0.0}));
+}
+
+// --- cell_corners -------------------------------------------------------------------------------
+
+TEST(ObstacleGridUtils, CellCornersAreTheLiteralFootprintCorners)
+{
+  // Arrange: centre (2.1, 1.1) at 0.2 m resolution -> box [2.0, 2.2] x [1.0, 1.2], wound
+  // min-min, min-max, max-max, max-min.
+  const grid_map::Position center(2.1, 1.1);
+  const std::array<Point2d, 4> expected_corners{
+    Point2d(2.0, 1.0), Point2d(2.0, 1.2), Point2d(2.2, 1.2), Point2d(2.2, 1.0)};
+
+  // Act
+  const std::array<Point2d, 4> corners = cell_corners(center, grid_resolution);
+
+  // Assert
+  for (std::size_t i = 0; i < expected_corners.size(); ++i) {
+    SCOPED_TRACE("corner " + std::to_string(i));
+    EXPECT_NEAR(corners[i].x(), expected_corners[i].x(), 1e-9);
+    EXPECT_NEAR(corners[i].y(), expected_corners[i].y(), 1e-9);
+  }
+}
+
+// --- nearest_cell -------------------------------------------------------------------------------
+
+TEST(ObstacleGridUtils, NearestCellReportsTheSameDistanceAsNearestDistance)
+{
+  // Arrange
+  const auto grid = make_grid_with_one_cell(grid_map::Position(2.1, 1.1), occupied);
+  const auto ego = ego_polygon_at_origin();
+  const Gate accept_anything{1u, 0.0};
+  const double expected_distance = nearest_distance(grid, ego, accept_anything);
+
+  // Act
+  const auto nearest = nearest_cell(grid, ego, accept_anything);
+
+  // Assert
+  ASSERT_TRUE(nearest.has_value());
+  EXPECT_NEAR(nearest->distance, expected_distance, 1e-12);
+}
+
+TEST(ObstacleGridUtils, NearestCellReportsWhereTheCellIs)
+{
+  // Arrange
+  const grid_map::Position center(2.1, 1.1);
+  const auto grid = make_grid_with_one_cell(center, occupied);
+  const grid_map::Index expected_index = index_at(grid, center);
+
+  // Act
+  const auto nearest = nearest_cell(grid, ego_polygon_at_origin(), Gate{1u, 0.0});
+
+  // Assert: the cell centre and the grid index, for debug markers / SafetyFactor.points.
+  ASSERT_TRUE(nearest.has_value());
+  EXPECT_NEAR(nearest->position.x(), center.x(), 1e-6);
+  EXPECT_NEAR(nearest->position.y(), center.y(), 1e-6);
+  EXPECT_TRUE((nearest->index == expected_index).all());
 }
 
 TEST(ObstacleGridUtils, NearestCellIsNulloptWhenNothingQualifies)
 {
-  // count 5 < gate 10: nothing qualifies -> nullopt (the nullopt <-> +inf analog).
-  const auto g = make_grid(2.1, 1.1, 5, 0.5, 1.5);
-  EXPECT_FALSE(nearest_cell(g, ego_point(), Gate{10u, 0.0}).has_value());
-  EXPECT_TRUE(std::isinf(nearest_distance(g, ego_point(), Gate{10u, 0.0})));
+  // Arrange: 5 points is below the gate's threshold of 10, so nothing qualifies.
+  const auto grid = make_grid_with_one_cell(grid_map::Position(2.1, 1.1), CellContent{5.0f, 1.5f});
+
+  // Act
+  const auto nearest = nearest_cell(grid, ego_polygon_at_origin(), Gate{10u, 0.0});
+
+  // Assert: the std::nullopt <-> +inf analog of nearest_distance.
+  EXPECT_FALSE(nearest.has_value());
 }
 
 TEST(ObstacleGridUtils, NearestCellPicksTheCloserOfTwoOccupiedCells)
 {
-  auto g = make_empty_grid();
-  grid_map::Index near_idx;
-  grid_map::Index far_idx;
-  g.getIndex(grid_map::Position(2.1, 1.1), near_idx);
-  g.getIndex(grid_map::Position(4.1, 3.1), far_idx);
-  set_cell(g, near_idx, 40);
-  set_cell(g, far_idx, 40);
-  const auto nc = nearest_cell(g, ego_point(), Gate{1u, 0.0});
-  ASSERT_TRUE(nc.has_value());
-  EXPECT_NEAR(nc->position.x(), 2.1, 1e-6);
-  EXPECT_NEAR(nc->position.y(), 1.1, 1e-6);
-  EXPECT_EQ(nc->index(0), near_idx(0));
-  EXPECT_EQ(nc->index(1), near_idx(1));
+  // Arrange
+  auto grid = make_empty_grid();
+  const grid_map::Position near_center(2.1, 1.1);
+  const grid_map::Index near_index = index_at(grid, near_center);
+  mark_cell(grid, near_index, occupied);
+  mark_cell(grid, index_at(grid, grid_map::Position(4.1, 3.1)), occupied);
+
+  // Act
+  const auto nearest = nearest_cell(grid, ego_polygon_at_origin(), Gate{1u, 0.0});
+
+  // Assert
+  ASSERT_TRUE(nearest.has_value());
+  EXPECT_TRUE((nearest->index == near_index).all());
 }
 
-// --- connected_components -------------------------------------------------------------------
-// Indices below are grid indices (row, col); connected_components does not gate, so the caller
-// supplies the qualifying list directly and we assert component structure and point_count sums.
+// --- connected_components -----------------------------------------------------------------------
+// connected_components does not gate, so these tests supply the qualifying index list directly
+// and assert the resulting component structure.
 
-TEST(ObstacleGridUtils, ConnectedComponentsEmptyInputEmptyOutput)
+TEST(ObstacleGridUtils, ConnectedComponentsOfNothingIsNoComponents)
 {
-  const auto g = make_empty_grid();
-  EXPECT_TRUE(connected_components(g, {}).empty());
+  // Arrange
+  const auto grid = make_empty_grid();
+
+  // Act
+  const auto components = connected_components(grid, {});
+
+  // Assert
+  EXPECT_TRUE(components.empty());
 }
 
-TEST(ObstacleGridUtils, ConnectedComponentsSingleCellSumsPointCount)
+TEST(ObstacleGridUtils, ConnectedComponentsOfOneCellIsOneComponent)
 {
-  auto g = make_empty_grid();
-  const grid_map::Index a(10, 10);
-  set_cell(g, a, 30);
-  const auto comps = connected_components(g, {a});
-  ASSERT_EQ(comps.size(), 1u);
-  EXPECT_EQ(comps[0].cells.size(), 1u);
-  EXPECT_NEAR(comps[0].point_sum, 30.0, 1e-6);
+  // Arrange
+  auto grid = make_empty_grid();
+  const grid_map::Index only_cell(10, 10);
+  mark_cell(grid, only_cell, occupied);
+
+  // Act
+  const auto components = connected_components(grid, {only_cell});
+
+  // Assert
+  ASSERT_EQ(components.size(), 1u);
+  EXPECT_EQ(components[0].cells.size(), 1u);
 }
 
-TEST(ObstacleGridUtils, ConnectedComponentsStraightLineIsOneComponent)
+TEST(ObstacleGridUtils, ConnectedComponentsSumsPointCountAcrossTheComponent)
 {
-  auto g = make_empty_grid();
-  const grid_map::Index a(10, 10);
-  const grid_map::Index b(10, 11);
-  const grid_map::Index c(10, 12);
-  set_cell(g, a, 10);
-  set_cell(g, b, 20);
-  set_cell(g, c, 30);
-  const auto comps = connected_components(g, {a, b, c});
-  ASSERT_EQ(comps.size(), 1u);
-  EXPECT_EQ(comps[0].cells.size(), 3u);
-  EXPECT_NEAR(comps[0].point_sum, 60.0, 1e-6);  // 10 + 20 + 30
+  // Arrange: three adjacent cells holding 10, 20 and 30 points.
+  auto grid = make_empty_grid();
+  const grid_map::Index left(10, 10);
+  const grid_map::Index middle(10, 11);
+  const grid_map::Index right(10, 12);
+  mark_cell(grid, left, CellContent{10.0f, 1.5f});
+  mark_cell(grid, middle, CellContent{20.0f, 1.5f});
+  mark_cell(grid, right, CellContent{30.0f, 1.5f});
+
+  // Act
+  const auto components = connected_components(grid, {left, middle, right});
+
+  // Assert
+  ASSERT_EQ(components.size(), 1u);
+  EXPECT_NEAR(components[0].point_sum, 60.0, 1e-6);
 }
 
-TEST(ObstacleGridUtils, ConnectedComponentsLShapeIsOneComponent)
+TEST(ObstacleGridUtils, ConnectedComponentsJoinAStraightLineOfCells)
 {
-  auto g = make_empty_grid();
-  const grid_map::Index a(10, 10);
-  const grid_map::Index b(11, 10);
-  const grid_map::Index c(11, 11);
-  set_cell(g, a, 5);
-  set_cell(g, b, 5);
-  set_cell(g, c, 5);
-  const auto comps = connected_components(g, {a, b, c});
-  ASSERT_EQ(comps.size(), 1u);
-  EXPECT_EQ(comps[0].cells.size(), 3u);
-  EXPECT_NEAR(comps[0].point_sum, 15.0, 1e-6);
+  // Arrange
+  auto grid = make_empty_grid();
+  const grid_map::Index left(10, 10);
+  const grid_map::Index middle(10, 11);
+  const grid_map::Index right(10, 12);
+  mark_cell(grid, left, occupied);
+  mark_cell(grid, middle, occupied);
+  mark_cell(grid, right, occupied);
+
+  // Act
+  const auto components = connected_components(grid, {left, middle, right});
+
+  // Assert
+  ASSERT_EQ(components.size(), 1u);
+  EXPECT_EQ(components[0].cells.size(), 3u);
 }
 
-TEST(ObstacleGridUtils, ConnectedComponentsDiagonalPairIsOneComponentUnder8Connectivity)
+TEST(ObstacleGridUtils, ConnectedComponentsJoinAnLShapeOfCells)
 {
-  auto g = make_empty_grid();
-  const grid_map::Index a(10, 10);
-  const grid_map::Index b(11, 11);  // diagonal neighbor
-  set_cell(g, a, 12);
-  set_cell(g, b, 8);
-  const auto comps = connected_components(g, {a, b});
-  ASSERT_EQ(comps.size(), 1u);  // 8-connected: diagonal touches
-  EXPECT_EQ(comps[0].cells.size(), 2u);
-  EXPECT_NEAR(comps[0].point_sum, 20.0, 1e-6);
+  // Arrange
+  auto grid = make_empty_grid();
+  const grid_map::Index corner(10, 10);
+  const grid_map::Index below(11, 10);
+  const grid_map::Index below_right(11, 11);
+  mark_cell(grid, corner, occupied);
+  mark_cell(grid, below, occupied);
+  mark_cell(grid, below_right, occupied);
+
+  // Act
+  const auto components = connected_components(grid, {corner, below, below_right});
+
+  // Assert
+  ASSERT_EQ(components.size(), 1u);
+  EXPECT_EQ(components[0].cells.size(), 3u);
 }
 
-TEST(ObstacleGridUtils, ConnectedComponentsGapSeparatesIntoTwoComponents)
+TEST(ObstacleGridUtils, ConnectedComponentsJoinADiagonalPairUnder8Connectivity)
 {
-  auto g = make_empty_grid();
-  const grid_map::Index a(10, 10);
-  const grid_map::Index c(10, 12);  // (10,11) deliberately not qualifying -> not adjacent to a
-  set_cell(g, a, 7);
-  set_cell(g, c, 9);
-  const auto comps = connected_components(g, {a, c});
-  ASSERT_EQ(comps.size(), 2u);
-  EXPECT_EQ(comps[0].cells.size(), 1u);
-  EXPECT_EQ(comps[1].cells.size(), 1u);
-  EXPECT_NEAR(comps[0].point_sum, 7.0, 1e-6);  // first-seen order
-  EXPECT_NEAR(comps[1].point_sum, 9.0, 1e-6);
+  // Arrange: the two cells touch only at a corner, which 4-connectivity would separate.
+  auto grid = make_empty_grid();
+  const grid_map::Index cell(10, 10);
+  const grid_map::Index diagonal_neighbor(11, 11);
+  mark_cell(grid, cell, occupied);
+  mark_cell(grid, diagonal_neighbor, occupied);
+
+  // Act
+  const auto components = connected_components(grid, {cell, diagonal_neighbor});
+
+  // Assert
+  ASSERT_EQ(components.size(), 1u);
+  EXPECT_EQ(components[0].cells.size(), 2u);
 }
 
-TEST(ObstacleGridUtils, ConnectedComponentsBorderCellsNoOutOfRangeProbe)
+TEST(ObstacleGridUtils, ConnectedComponentsSplitCellsSeparatedByAGap)
 {
-  // Cells on the (0,0) corner: neighbors like (-1,-1) are off-grid and must not be probed nor
-  // alias an in-grid cell via the linear key. a and b are adjacent -> one component.
-  auto g = make_empty_grid();
-  const grid_map::Index a(0, 0);
-  const grid_map::Index b(0, 1);
-  set_cell(g, a, 3);
-  set_cell(g, b, 4);
-  const auto comps = connected_components(g, {a, b});
-  ASSERT_EQ(comps.size(), 1u);
-  EXPECT_EQ(comps[0].cells.size(), 2u);
-  EXPECT_NEAR(comps[0].point_sum, 7.0, 1e-6);
+  // Arrange: (10, 11) is deliberately left out, so the two cells are not adjacent.
+  auto grid = make_empty_grid();
+  const grid_map::Index left(10, 10);
+  const grid_map::Index right(10, 12);
+  mark_cell(grid, left, occupied);
+  mark_cell(grid, right, occupied);
+
+  // Act
+  const auto components = connected_components(grid, {left, right});
+
+  // Assert
+  EXPECT_EQ(components.size(), 2u);
 }
 
-TEST(ObstacleGridUtils, ConnectedComponentsRowWrapDoesNotFalselyConnect)
+TEST(ObstacleGridUtils, ConnectedComponentsHandleBorderCellsWithoutProbingOffGrid)
 {
-  // 10 m / 0.2 m = 50 columns. The last cell of row r, (r, 49), and the first cell of row r+1,
-  // (r+1, 0), are NOT 8-adjacent but a naive row*cols+col key would alias (r,50) onto (r+1,0).
-  // The off-grid bounds guard must keep them as two separate components.
-  auto g = make_empty_grid();
-  ASSERT_EQ(g.getSize()(1), 50);
-  const grid_map::Index a(10, 49);
-  const grid_map::Index b(11, 0);
-  set_cell(g, a, 6);
-  set_cell(g, b, 6);
-  EXPECT_EQ(connected_components(g, {a, b}).size(), 2u);
+  // Arrange: cells on the (0, 0) corner, whose neighbours like (-1, -1) are off-grid and must
+  // neither be probed nor alias an in-grid cell through the linear key.
+  auto grid = make_empty_grid();
+  const grid_map::Index corner(0, 0);
+  const grid_map::Index beside_corner(0, 1);
+  mark_cell(grid, corner, occupied);
+  mark_cell(grid, beside_corner, occupied);
+
+  // Act
+  const auto components = connected_components(grid, {corner, beside_corner});
+
+  // Assert
+  ASSERT_EQ(components.size(), 1u);
+  EXPECT_EQ(components[0].cells.size(), 2u);
 }
 
-TEST(ObstacleGridUtils, ConnectedComponentsDuplicateIndexCountedOnce)
+TEST(ObstacleGridUtils, ConnectedComponentsDoNotJoinCellsAcrossARowWrap)
 {
-  // The code guards duplicates via the visited set: supplying the same index twice must yield a
-  // single one-cell component whose point_sum is NOT double-counted.
-  auto g = make_empty_grid();
-  const grid_map::Index a(10, 10);
-  set_cell(g, a, 25);
-  const auto comps = connected_components(g, {a, a});
-  ASSERT_EQ(comps.size(), 1u);
-  EXPECT_EQ(comps[0].cells.size(), 1u);
-  EXPECT_NEAR(comps[0].point_sum, 25.0, 1e-6);
+  // Arrange: 10 m / 0.2 m = 50 columns. The last cell of one row and the first cell of the next
+  // are NOT 8-adjacent, but a naive row * columns + column key would alias (row, 50) onto
+  // (row + 1, 0). The off-grid bounds guard has to keep them apart.
+  auto grid = make_empty_grid();
+  ASSERT_EQ(grid.getSize()(1), expected_grid_columns);
+  const grid_map::Index row_end(10, expected_grid_columns - 1);
+  const grid_map::Index next_row_start(11, 0);
+  mark_cell(grid, row_end, occupied);
+  mark_cell(grid, next_row_start, occupied);
+
+  // Act
+  const auto components = connected_components(grid, {row_end, next_row_start});
+
+  // Assert
+  EXPECT_EQ(components.size(), 2u);
 }
 
-TEST(ObstacleGridUtils, ConnectedComponentsSkipsNanPointCountInSum)
+TEST(ObstacleGridUtils, ConnectedComponentsCountADuplicateIndexOnce)
 {
-  // A supplied cell whose point_count is NaN must be skipped from point_sum rather than poisoning
-  // it: the component is still formed (both cells reported) but the sum stays finite. Without the
-  // isnan guard the sum would be NaN and the real cluster's point total would be lost.
-  auto g = make_empty_grid();
-  const grid_map::Index a(10, 10);
-  const grid_map::Index b(10, 11);  // 4-adjacent to a -> one component
-  set_cell(g, a, 20);
-  g.at("max_height", b) = 1.5f;  // populate heights but leave point_count(b) NaN
-  g.at("min_height", b) = 0.5f;
-  const auto comps = connected_components(g, {a, b});
-  ASSERT_EQ(comps.size(), 1u);
-  EXPECT_EQ(comps[0].cells.size(), 2u);          // both cells belong to the component
-  EXPECT_FALSE(std::isnan(comps[0].point_sum));  // NaN contribution did not poison the sum
-  EXPECT_NEAR(comps[0].point_sum, 20.0, 1e-6);   // only a's 20 counts; b's NaN skipped
+  // Arrange: the same index supplied twice must be absorbed by the visited set rather than
+  // forming a second component or double-counting its points.
+  auto grid = make_empty_grid();
+  const grid_map::Index only_cell(10, 10);
+  mark_cell(grid, only_cell, CellContent{25.0f, 1.5f});
+
+  // Act
+  const auto components = connected_components(grid, {only_cell, only_cell});
+
+  // Assert
+  ASSERT_EQ(components.size(), 1u);
+  EXPECT_NEAR(components[0].point_sum, 25.0, 1e-6);
 }
 
-TEST(ObstacleGridUtils, ConnectedComponentsMergeAcrossBufferWrapSeam)
+TEST(ObstacleGridUtils, ConnectedComponentsSkipANanPointCountInTheSum)
 {
-  // A move()d grid has a non-zero circular-buffer start index, so raw buffer-index adjacency no
-  // longer equals geometric adjacency at the wrap seam. Two geometrically adjacent cells whose
-  // buffer indices land on opposite ends of the buffer (rows size-1 and 0) must still merge into
-  // ONE component -- the regression guard for stepping in unwrapped index space.
-  auto g = make_empty_grid();
-  g.move(grid_map::Position(1.0, 0.0));  // shift the buffer origin along x (5 cells at 0.2 m)
-  ASSERT_FALSE(g.isDefaultStartIndex());
-  const grid_map::Size size = g.getSize();
-  const grid_map::Index start = g.getStartIndex();
-  ASSERT_NE(start(0), 0);  // x-move must have offset the row start index
-  // Unwrapped row u maps to buffer row (u + start(0)) % size(0); the seam is at u0 = size-1-start.
-  const int u0 = size(0) - 1 - start(0);
-  const int col = 5;
-  const auto buf_a = grid_map::getBufferIndexFromIndex(grid_map::Index(u0, col), size, start);
-  const auto buf_b = grid_map::getBufferIndexFromIndex(grid_map::Index(u0 + 1, col), size, start);
-  // Confirm the two geometric neighbours really straddle the buffer seam (buffer rows 49 and 0).
-  ASSERT_EQ(buf_a(0) - buf_b(0), size(0) - 1);
-  set_cell(g, buf_a, 6);
-  set_cell(g, buf_b, 6);
-  const auto comps = connected_components(g, {buf_a, buf_b});
-  ASSERT_EQ(comps.size(), 1u);  // geometrically adjacent across the seam -> one component
-  EXPECT_EQ(comps[0].cells.size(), 2u);
-  EXPECT_NEAR(comps[0].point_sum, 12.0, 1e-6);
+  // Arrange: two adjacent cells, one of which has a height but no point count. Without the NaN
+  // guard the whole component's sum would go NaN and the real cluster's point total be lost.
+  auto grid = make_empty_grid();
+  const grid_map::Index counted(10, 10);
+  const grid_map::Index uncounted(10, 11);
+  mark_cell(grid, counted, CellContent{20.0f, 1.5f});
+  mark_cell(grid, uncounted, CellContent{std::numeric_limits<float>::quiet_NaN(), 1.5f});
+
+  // Act
+  const auto components = connected_components(grid, {counted, uncounted});
+
+  // Assert: both cells belong to the component, but only the counted one contributes.
+  ASSERT_EQ(components.size(), 1u);
+  EXPECT_EQ(components[0].cells.size(), 2u);
+  EXPECT_NEAR(components[0].point_sum, 20.0, 1e-6);
+}
+
+TEST(ObstacleGridUtils, ConnectedComponentsMergeAcrossTheBufferWrapSeam)
+{
+  // Arrange: a move()d grid has a non-zero circular-buffer start index, so raw buffer-index
+  // adjacency no longer equals geometric adjacency at the seam. Pick two geometrically adjacent
+  // cells whose buffer indices land on opposite ends of the buffer.
+  auto grid = make_empty_grid();
+  grid.move(grid_map::Position(1.0, 0.0));  // shift the buffer origin by 5 cells along x
+  ASSERT_FALSE(grid.isDefaultStartIndex());
+  const grid_map::Size size = grid.getSize();
+  const grid_map::Index start = grid.getStartIndex();
+  ASSERT_NE(start(0), 0);
+  // Unwrapped row u maps to buffer row (u + start(0)) % size(0), so the seam sits at this row.
+  const int seam_row = size(0) - 1 - start(0);
+  const int column = 5;
+  const auto below_seam =
+    grid_map::getBufferIndexFromIndex(grid_map::Index(seam_row, column), size, start);
+  const auto above_seam =
+    grid_map::getBufferIndexFromIndex(grid_map::Index(seam_row + 1, column), size, start);
+  ASSERT_EQ(below_seam(0) - above_seam(0), size(0) - 1);  // they really do straddle the seam
+  mark_cell(grid, below_seam, occupied);
+  mark_cell(grid, above_seam, occupied);
+
+  // Act
+  const auto components = connected_components(grid, {below_seam, above_seam});
+
+  // Assert: geometric adjacency wins over buffer-index distance.
+  ASSERT_EQ(components.size(), 1u);
+  EXPECT_EQ(components[0].cells.size(), 2u);
 }
 
 }  // namespace autoware::obstacle_grid_utils

--- a/common/autoware_obstacle_grid_utils/test/test_obstacle_grid_utils.cpp
+++ b/common/autoware_obstacle_grid_utils/test/test_obstacle_grid_utils.cpp
@@ -1,0 +1,112 @@
+// Copyright 2026 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <autoware/obstacle_grid_utils/obstacle_grid_utils.hpp>
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <limits>
+#include <utility>
+
+namespace autoware::obstacle_grid_utils
+{
+namespace bg = boost::geometry;
+
+// A 0.2 m grid centered at (0,0). Mark one occupied cell containing position (cx, cy).
+// NOTE: with center (0,0) and resolution 0.2, cell centers fall on odd multiples of 0.1
+// (..., 1.9, 2.1, ...), so callers pass true cell-center coordinates (e.g. 2.1, 1.1) to
+// keep the independent oracle exact.
+grid_map::GridMap make_grid(double cx, double cy, float count, float zmin, float zmax)
+{
+  grid_map::GridMap g({"max_height", "min_height", "point_count"});
+  g.setFrameId("base_link");
+  g.setGeometry(grid_map::Length(10.0, 10.0), 0.2, grid_map::Position(0.0, 0.0));
+  g["point_count"].setConstant(std::numeric_limits<float>::quiet_NaN());
+  g["max_height"].setConstant(std::numeric_limits<float>::quiet_NaN());
+  g["min_height"].setConstant(std::numeric_limits<float>::quiet_NaN());
+  grid_map::Index idx;
+  g.getIndex(grid_map::Position(cx, cy), idx);
+  g.at("point_count", idx) = count;
+  g.at("max_height", idx) = zmax;
+  g.at("min_height", idx) = zmin;
+  return g;
+}
+
+Polygon2d ego_point()  // degenerate ego polygon at the origin
+{
+  Polygon2d p;
+  bg::append(p.outer(), Point2d(0.0, 0.0));
+  bg::correct(p);
+  return p;
+}
+
+bool qualifies_at(const grid_map::GridMap & g, double x, double y, const Gate & gate)
+{
+  grid_map::Index idx;
+  g.getIndex(grid_map::Position(x, y), idx);
+  return cell_qualifies(g, idx, gate);
+}
+
+TEST(ObstacleGridUtils, EdgeAwareDistanceUsesCellFootprint)
+{
+  // Occupied cell centered at the true cell center (2.1, 1.1); its 0.2 m footprint box is
+  // [2.0,2.2] x [1.0,1.2], whose near corner (2.0, 1.0) is closer to ego than the center.
+  const auto g = make_grid(2.1, 1.1, 40, 0.5, 1.5);
+  const double d = nearest_distance(g, ego_point(), Gate{1u, 0.0});
+  // Independent oracle: distance to the near corner of the footprint, hand-computed.
+  EXPECT_LT(d, std::hypot(2.1, 1.1));          // edge-aware: strictly less than center distance
+  EXPECT_NEAR(d, std::hypot(2.0, 1.0), 1e-6);  // distance to the near footprint corner
+}
+
+TEST(ObstacleGridUtils, NearestDistanceIsInfWhenNothingQualifies)
+{
+  const auto g = make_grid(2.1, 1.1, 5, 0.5, 1.5);  // count 5 < gate 10 -> nothing qualifies
+  const double d = nearest_distance(g, ego_point(), Gate{10u, 0.0});
+  EXPECT_TRUE(std::isinf(d));
+}
+
+TEST(ObstacleGridUtils, GateRejectsBelowCount)
+{
+  EXPECT_FALSE(qualifies_at(make_grid(2.1, 1.1, 9, 0.5, 1.5), 2.1, 1.1, Gate{10u, 0.0}));
+  EXPECT_TRUE(qualifies_at(make_grid(2.1, 1.1, 10, 0.5, 1.5), 2.1, 1.1, Gate{10u, 0.0}));
+}
+
+TEST(ObstacleGridUtils, GateRejectsBelowHeight)
+{
+  // tall enough passes the height gate; a flat ground-height sliver fails it.
+  EXPECT_TRUE(qualifies_at(make_grid(2.1, 1.1, 50, 0.0, 1.2), 2.1, 1.1, Gate{10u, 0.3}));
+  EXPECT_FALSE(qualifies_at(make_grid(2.1, 1.1, 50, 0.0, 0.1), 2.1, 1.1, Gate{10u, 0.3}));
+}
+
+TEST(ObstacleGridUtils, CellsInPolygonCollectsQualifyingCells)
+{
+  const auto g = make_grid(2.1, 0.1, 40, 0.5, 1.5);
+  Polygon2d lane;  // a box [1,3] x [-1,1] around the occupied cell
+  for (auto xy :
+       {std::pair{1.0, -1.0}, std::pair{1.0, 1.0}, std::pair{3.0, 1.0}, std::pair{3.0, -1.0}}) {
+    bg::append(lane.outer(), Point2d(xy.first, xy.second));
+  }
+  bg::correct(lane);
+  EXPECT_EQ(cells_in_polygon(g, lane, Gate{1u, 0.0}).size(), 1u);
+  // an empty (no-detection) lane crop yields no cells
+  const auto empty = make_grid(2.1, 0.1, std::numeric_limits<float>::quiet_NaN(), 0.0f, 0.0f);
+  EXPECT_EQ(cells_in_polygon(empty, lane, Gate{1u, 0.0}).size(), 0u);
+}
+}  // namespace autoware::obstacle_grid_utils
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/common/autoware_obstacle_grid_utils/test/test_obstacle_grid_utils.cpp
+++ b/common/autoware_obstacle_grid_utils/test/test_obstacle_grid_utils.cpp
@@ -111,6 +111,18 @@ TEST(ObstacleGridUtils, GateRejectsBelowHeight)
   EXPECT_FALSE(qualifies_at(make_grid(2.1, 1.1, 50, 0.0, 0.1), 2.1, 1.1, Gate{10u, 0.3}));
 }
 
+TEST(ObstacleGridUtils, GateRejectsNanHeightEvenWhenCountPasses)
+{
+  // A cell whose point_count clears the count gate but whose max_height is NaN (a heartbeat cell
+  // that was never populated with a height) must fail the height guard rather than qualify.
+  auto g = make_empty_grid();
+  grid_map::Index idx;
+  g.getIndex(grid_map::Position(2.1, 1.1), idx);
+  g.at("point_count", idx) = 50.0f;  // count 50 >= gate 10 -> passes the count gate
+  // max_height(idx) is left NaN by make_empty_grid; the !isnan(max_height) guard must reject.
+  EXPECT_FALSE(cell_qualifies(g, idx, Gate{10u, 0.0}));
+}
+
 TEST(ObstacleGridUtils, CellsInPolygonCollectsQualifyingCells)
 {
   const auto g = make_grid(2.1, 0.1, 40, 0.5, 1.5);
@@ -302,6 +314,24 @@ TEST(ObstacleGridUtils, ConnectedComponentsDuplicateIndexCountedOnce)
   ASSERT_EQ(comps.size(), 1u);
   EXPECT_EQ(comps[0].cells.size(), 1u);
   EXPECT_NEAR(comps[0].point_sum, 25.0, 1e-6);
+}
+
+TEST(ObstacleGridUtils, ConnectedComponentsSkipsNanPointCountInSum)
+{
+  // A supplied cell whose point_count is NaN must be skipped from point_sum rather than poisoning
+  // it: the component is still formed (both cells reported) but the sum stays finite. Without the
+  // isnan guard the sum would be NaN and the real cluster's point total would be lost.
+  auto g = make_empty_grid();
+  const grid_map::Index a(10, 10);
+  const grid_map::Index b(10, 11);  // 4-adjacent to a -> one component
+  set_cell(g, a, 20);
+  g.at("max_height", b) = 1.5f;  // populate heights but leave point_count(b) NaN
+  g.at("min_height", b) = 0.5f;
+  const auto comps = connected_components(g, {a, b});
+  ASSERT_EQ(comps.size(), 1u);
+  EXPECT_EQ(comps[0].cells.size(), 2u);          // both cells belong to the component
+  EXPECT_FALSE(std::isnan(comps[0].point_sum));  // NaN contribution did not poison the sum
+  EXPECT_NEAR(comps[0].point_sum, 20.0, 1e-6);   // only a's 20 counts; b's NaN skipped
 }
 
 TEST(ObstacleGridUtils, ConnectedComponentsMergeAcrossBufferWrapSeam)

--- a/common/autoware_obstacle_grid_utils/test/test_obstacle_grid_utils.cpp
+++ b/common/autoware_obstacle_grid_utils/test/test_obstacle_grid_utils.cpp
@@ -291,6 +291,46 @@ TEST(ObstacleGridUtils, ConnectedComponentsRowWrapDoesNotFalselyConnect)
   EXPECT_EQ(connected_components(g, {a, b}).size(), 2u);
 }
 
+TEST(ObstacleGridUtils, ConnectedComponentsDuplicateIndexCountedOnce)
+{
+  // The code guards duplicates via the visited set: supplying the same index twice must yield a
+  // single one-cell component whose point_sum is NOT double-counted.
+  auto g = make_empty_grid();
+  const grid_map::Index a(10, 10);
+  set_cell(g, a, 25);
+  const auto comps = connected_components(g, {a, a});
+  ASSERT_EQ(comps.size(), 1u);
+  EXPECT_EQ(comps[0].cells.size(), 1u);
+  EXPECT_NEAR(comps[0].point_sum, 25.0, 1e-6);
+}
+
+TEST(ObstacleGridUtils, ConnectedComponentsMergeAcrossBufferWrapSeam)
+{
+  // A move()d grid has a non-zero circular-buffer start index, so raw buffer-index adjacency no
+  // longer equals geometric adjacency at the wrap seam. Two geometrically adjacent cells whose
+  // buffer indices land on opposite ends of the buffer (rows size-1 and 0) must still merge into
+  // ONE component -- the regression guard for stepping in unwrapped index space.
+  auto g = make_empty_grid();
+  g.move(grid_map::Position(1.0, 0.0));  // shift the buffer origin along x (5 cells at 0.2 m)
+  ASSERT_FALSE(g.isDefaultStartIndex());
+  const grid_map::Size size = g.getSize();
+  const grid_map::Index start = g.getStartIndex();
+  ASSERT_NE(start(0), 0);  // x-move must have offset the row start index
+  // Unwrapped row u maps to buffer row (u + start(0)) % size(0); the seam is at u0 = size-1-start.
+  const int u0 = size(0) - 1 - start(0);
+  const int col = 5;
+  const auto buf_a = grid_map::getBufferIndexFromIndex(grid_map::Index(u0, col), size, start);
+  const auto buf_b = grid_map::getBufferIndexFromIndex(grid_map::Index(u0 + 1, col), size, start);
+  // Confirm the two geometric neighbours really straddle the buffer seam (buffer rows 49 and 0).
+  ASSERT_EQ(buf_a(0) - buf_b(0), size(0) - 1);
+  set_cell(g, buf_a, 6);
+  set_cell(g, buf_b, 6);
+  const auto comps = connected_components(g, {buf_a, buf_b});
+  ASSERT_EQ(comps.size(), 1u);  // geometrically adjacent across the seam -> one component
+  EXPECT_EQ(comps[0].cells.size(), 2u);
+  EXPECT_NEAR(comps[0].point_sum, 12.0, 1e-6);
+}
+
 }  // namespace autoware::obstacle_grid_utils
 
 int main(int argc, char ** argv)

--- a/common/autoware_obstacle_grid_utils/test/test_obstacle_grid_utils.cpp
+++ b/common/autoware_obstacle_grid_utils/test/test_obstacle_grid_utils.cpp
@@ -15,9 +15,12 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
 #include <cmath>
 #include <limits>
+#include <optional>
 #include <utility>
+#include <vector>
 
 namespace autoware::obstacle_grid_utils
 {
@@ -56,6 +59,25 @@ bool qualifies_at(const grid_map::GridMap & g, double x, double y, const Gate & 
   grid_map::Index idx;
   g.getIndex(grid_map::Position(x, y), idx);
   return cell_qualifies(g, idx, gate);
+}
+
+// An all-NaN (heartbeat) 0.2 m grid centered at (0,0); mark individual cells by grid index below.
+grid_map::GridMap make_empty_grid()
+{
+  grid_map::GridMap g({"max_height", "min_height", "point_count"});
+  g.setFrameId("base_link");
+  g.setGeometry(grid_map::Length(10.0, 10.0), 0.2, grid_map::Position(0.0, 0.0));
+  g["point_count"].setConstant(std::numeric_limits<float>::quiet_NaN());
+  g["max_height"].setConstant(std::numeric_limits<float>::quiet_NaN());
+  g["min_height"].setConstant(std::numeric_limits<float>::quiet_NaN());
+  return g;
+}
+
+void set_cell(grid_map::GridMap & g, const grid_map::Index & idx, float count)
+{
+  g.at("point_count", idx) = count;
+  g.at("max_height", idx) = 1.5f;
+  g.at("min_height", idx) = 0.5f;
 }
 
 TEST(ObstacleGridUtils, EdgeAwareDistanceUsesCellFootprint)
@@ -103,6 +125,172 @@ TEST(ObstacleGridUtils, CellsInPolygonCollectsQualifyingCells)
   const auto empty = make_grid(2.1, 0.1, std::numeric_limits<float>::quiet_NaN(), 0.0f, 0.0f);
   EXPECT_EQ(cells_in_polygon(empty, lane, Gate{1u, 0.0}).size(), 0u);
 }
+TEST(ObstacleGridUtils, CellCornersAreLiteralFootprintCorners)
+{
+  // center (2.1, 1.1), resolution 0.2 -> half 0.1 -> box [2.0,2.2] x [1.0,1.2].
+  const auto corners = cell_corners(grid_map::Position(2.1, 1.1), 0.2);
+  ASSERT_EQ(corners.size(), 4u);
+  EXPECT_NEAR(corners[0].x(), 2.0, 1e-9);  // min-min
+  EXPECT_NEAR(corners[0].y(), 1.0, 1e-9);
+  EXPECT_NEAR(corners[1].x(), 2.0, 1e-9);  // min-max
+  EXPECT_NEAR(corners[1].y(), 1.2, 1e-9);
+  EXPECT_NEAR(corners[2].x(), 2.2, 1e-9);  // max-max
+  EXPECT_NEAR(corners[2].y(), 1.2, 1e-9);
+  EXPECT_NEAR(corners[3].x(), 2.2, 1e-9);  // max-min
+  EXPECT_NEAR(corners[3].y(), 1.0, 1e-9);
+}
+
+TEST(ObstacleGridUtils, NearestCellMatchesNearestDistanceAndReportsWhere)
+{
+  // Same fixture as EdgeAwareDistanceUsesCellFootprint: one cell centered at (2.1, 1.1).
+  const auto g = make_grid(2.1, 1.1, 40, 0.5, 1.5);
+  const auto nc = nearest_cell(g, ego_point(), Gate{1u, 0.0});
+  ASSERT_TRUE(nc.has_value());
+  // Equivalence with the scalar helper (edge-aware distance to the near footprint corner).
+  EXPECT_NEAR(nc->distance, nearest_distance(g, ego_point(), Gate{1u, 0.0}), 1e-12);
+  EXPECT_NEAR(nc->distance, std::hypot(2.0, 1.0), 1e-6);  // independent oracle
+  // WHERE: cell center and grid index of the occupied cell.
+  EXPECT_NEAR(nc->position.x(), 2.1, 1e-6);
+  EXPECT_NEAR(nc->position.y(), 1.1, 1e-6);
+  grid_map::Index expected;
+  g.getIndex(grid_map::Position(2.1, 1.1), expected);
+  EXPECT_EQ(nc->index(0), expected(0));
+  EXPECT_EQ(nc->index(1), expected(1));
+}
+
+TEST(ObstacleGridUtils, NearestCellIsNulloptWhenNothingQualifies)
+{
+  // count 5 < gate 10: nothing qualifies -> nullopt (the nullopt <-> +inf analog).
+  const auto g = make_grid(2.1, 1.1, 5, 0.5, 1.5);
+  EXPECT_FALSE(nearest_cell(g, ego_point(), Gate{10u, 0.0}).has_value());
+  EXPECT_TRUE(std::isinf(nearest_distance(g, ego_point(), Gate{10u, 0.0})));
+}
+
+TEST(ObstacleGridUtils, NearestCellPicksTheCloserOfTwoOccupiedCells)
+{
+  auto g = make_empty_grid();
+  grid_map::Index near_idx;
+  grid_map::Index far_idx;
+  g.getIndex(grid_map::Position(2.1, 1.1), near_idx);
+  g.getIndex(grid_map::Position(4.1, 3.1), far_idx);
+  set_cell(g, near_idx, 40);
+  set_cell(g, far_idx, 40);
+  const auto nc = nearest_cell(g, ego_point(), Gate{1u, 0.0});
+  ASSERT_TRUE(nc.has_value());
+  EXPECT_NEAR(nc->position.x(), 2.1, 1e-6);
+  EXPECT_NEAR(nc->position.y(), 1.1, 1e-6);
+  EXPECT_EQ(nc->index(0), near_idx(0));
+  EXPECT_EQ(nc->index(1), near_idx(1));
+}
+
+// --- connected_components -------------------------------------------------------------------
+// Indices below are grid indices (row, col); connected_components does not gate, so the caller
+// supplies the qualifying list directly and we assert component structure and point_count sums.
+
+TEST(ObstacleGridUtils, ConnectedComponentsEmptyInputEmptyOutput)
+{
+  const auto g = make_empty_grid();
+  EXPECT_TRUE(connected_components(g, {}).empty());
+}
+
+TEST(ObstacleGridUtils, ConnectedComponentsSingleCellSumsPointCount)
+{
+  auto g = make_empty_grid();
+  const grid_map::Index a(10, 10);
+  set_cell(g, a, 30);
+  const auto comps = connected_components(g, {a});
+  ASSERT_EQ(comps.size(), 1u);
+  EXPECT_EQ(comps[0].cells.size(), 1u);
+  EXPECT_NEAR(comps[0].point_sum, 30.0, 1e-6);
+}
+
+TEST(ObstacleGridUtils, ConnectedComponentsStraightLineIsOneComponent)
+{
+  auto g = make_empty_grid();
+  const grid_map::Index a(10, 10);
+  const grid_map::Index b(10, 11);
+  const grid_map::Index c(10, 12);
+  set_cell(g, a, 10);
+  set_cell(g, b, 20);
+  set_cell(g, c, 30);
+  const auto comps = connected_components(g, {a, b, c});
+  ASSERT_EQ(comps.size(), 1u);
+  EXPECT_EQ(comps[0].cells.size(), 3u);
+  EXPECT_NEAR(comps[0].point_sum, 60.0, 1e-6);  // 10 + 20 + 30
+}
+
+TEST(ObstacleGridUtils, ConnectedComponentsLShapeIsOneComponent)
+{
+  auto g = make_empty_grid();
+  const grid_map::Index a(10, 10);
+  const grid_map::Index b(11, 10);
+  const grid_map::Index c(11, 11);
+  set_cell(g, a, 5);
+  set_cell(g, b, 5);
+  set_cell(g, c, 5);
+  const auto comps = connected_components(g, {a, b, c});
+  ASSERT_EQ(comps.size(), 1u);
+  EXPECT_EQ(comps[0].cells.size(), 3u);
+  EXPECT_NEAR(comps[0].point_sum, 15.0, 1e-6);
+}
+
+TEST(ObstacleGridUtils, ConnectedComponentsDiagonalPairIsOneComponentUnder8Connectivity)
+{
+  auto g = make_empty_grid();
+  const grid_map::Index a(10, 10);
+  const grid_map::Index b(11, 11);  // diagonal neighbor
+  set_cell(g, a, 12);
+  set_cell(g, b, 8);
+  const auto comps = connected_components(g, {a, b});
+  ASSERT_EQ(comps.size(), 1u);  // 8-connected: diagonal touches
+  EXPECT_EQ(comps[0].cells.size(), 2u);
+  EXPECT_NEAR(comps[0].point_sum, 20.0, 1e-6);
+}
+
+TEST(ObstacleGridUtils, ConnectedComponentsGapSeparatesIntoTwoComponents)
+{
+  auto g = make_empty_grid();
+  const grid_map::Index a(10, 10);
+  const grid_map::Index c(10, 12);  // (10,11) deliberately not qualifying -> not adjacent to a
+  set_cell(g, a, 7);
+  set_cell(g, c, 9);
+  const auto comps = connected_components(g, {a, c});
+  ASSERT_EQ(comps.size(), 2u);
+  EXPECT_EQ(comps[0].cells.size(), 1u);
+  EXPECT_EQ(comps[1].cells.size(), 1u);
+  EXPECT_NEAR(comps[0].point_sum, 7.0, 1e-6);  // first-seen order
+  EXPECT_NEAR(comps[1].point_sum, 9.0, 1e-6);
+}
+
+TEST(ObstacleGridUtils, ConnectedComponentsBorderCellsNoOutOfRangeProbe)
+{
+  // Cells on the (0,0) corner: neighbors like (-1,-1) are off-grid and must not be probed nor
+  // alias an in-grid cell via the linear key. a and b are adjacent -> one component.
+  auto g = make_empty_grid();
+  const grid_map::Index a(0, 0);
+  const grid_map::Index b(0, 1);
+  set_cell(g, a, 3);
+  set_cell(g, b, 4);
+  const auto comps = connected_components(g, {a, b});
+  ASSERT_EQ(comps.size(), 1u);
+  EXPECT_EQ(comps[0].cells.size(), 2u);
+  EXPECT_NEAR(comps[0].point_sum, 7.0, 1e-6);
+}
+
+TEST(ObstacleGridUtils, ConnectedComponentsRowWrapDoesNotFalselyConnect)
+{
+  // 10 m / 0.2 m = 50 columns. The last cell of row r, (r, 49), and the first cell of row r+1,
+  // (r+1, 0), are NOT 8-adjacent but a naive row*cols+col key would alias (r,50) onto (r+1,0).
+  // The off-grid bounds guard must keep them as two separate components.
+  auto g = make_empty_grid();
+  ASSERT_EQ(g.getSize()(1), 50);
+  const grid_map::Index a(10, 49);
+  const grid_map::Index b(11, 0);
+  set_cell(g, a, 6);
+  set_cell(g, b, 6);
+  EXPECT_EQ(connected_components(g, {a, b}).size(), 2u);
+}
+
 }  // namespace autoware::obstacle_grid_utils
 
 int main(int argc, char ** argv)

--- a/common/autoware_obstacle_grid_utils/test/test_obstacle_grid_utils.cpp
+++ b/common/autoware_obstacle_grid_utils/test/test_obstacle_grid_utils.cpp
@@ -13,13 +13,14 @@
 // limitations under the License.
 #include <autoware/obstacle_grid_utils/obstacle_grid_utils.hpp>
 
+#include <boost/geometry.hpp>
+
 #include <gtest/gtest.h>
 
 #include <array>
 #include <cmath>
 #include <limits>
 #include <optional>
-#include <utility>
 #include <vector>
 
 namespace autoware::obstacle_grid_utils
@@ -123,20 +124,6 @@ TEST(ObstacleGridUtils, GateRejectsNanHeightEvenWhenCountPasses)
   EXPECT_FALSE(cell_qualifies(g, idx, Gate{10u, 0.0}));
 }
 
-TEST(ObstacleGridUtils, CellsInPolygonCollectsQualifyingCells)
-{
-  const auto g = make_grid(2.1, 0.1, 40, 0.5, 1.5);
-  Polygon2d lane;  // a box [1,3] x [-1,1] around the occupied cell
-  for (auto xy :
-       {std::pair{1.0, -1.0}, std::pair{1.0, 1.0}, std::pair{3.0, 1.0}, std::pair{3.0, -1.0}}) {
-    bg::append(lane.outer(), Point2d(xy.first, xy.second));
-  }
-  bg::correct(lane);
-  EXPECT_EQ(cells_in_polygon(g, lane, Gate{1u, 0.0}).size(), 1u);
-  // an empty (no-detection) lane crop yields no cells
-  const auto empty = make_grid(2.1, 0.1, std::numeric_limits<float>::quiet_NaN(), 0.0f, 0.0f);
-  EXPECT_EQ(cells_in_polygon(empty, lane, Gate{1u, 0.0}).size(), 0u);
-}
 TEST(ObstacleGridUtils, CellCornersAreLiteralFootprintCorners)
 {
   // center (2.1, 1.1), resolution 0.2 -> half 0.1 -> box [2.0,2.2] x [1.0,1.2].


### PR DESCRIPTION
## Description

Adds `autoware_obstacle_grid_utils`, a small header-only library that the last-resort safety consumers share to query the sensing-side obstacle grid (`grid_map_msgs/GridMap`, layers `max_height`/`min_height`/`point_count`). Factoring the query logic once prevents each consumer from re-deriving it inconsistently.

It provides: a per-cell `Gate {min_point_count_cell, min_height}` (a cell qualifies iff `point_count >= min_point_count_cell && max_height >= min_height`, `NaN`-safe); `cell_qualifies()`; `cell_footprint()` and `cell_corners()` (the cell's footprint box and its four literal corners, so distance and membership queries are edge-aware rather than center-based, because cells are areas); `nearest_distance(grid, ego_polygon, gate)` (2D distance from an ego polygon to the nearest qualifying cell footprint, `+inf` when nothing qualifies inside the ROI); `nearest_cell(grid, ego_polygon, gate)` (the same edge-aware distance plus where the nearest qualifying cell is, as `std::optional<NearestCell{distance, position, index}>`, `std::nullopt` when nothing qualifies; on a distance tie the first cell reached by the grid iterator wins); `cells_in_polygon(grid, polygon, gate)` (centers of qualifying cells inside a lanelet/trajectory polygon); and `connected_components(grid, qualifying)` (8-connected labeling of the caller-supplied qualifying cell indices, returning `std::vector<CellComponent{cells, point_sum}>` in first-seen order, where `point_sum` is the sum of `point_count` over each component — it does not gate, the caller applies its own `Gate` first).

This is the first piece of the sensing-side safety path; no behavior changes in any existing node.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware_universe/issues/12972

## How was this PR tested?

`colcon test --packages-select autoware_obstacle_grid_utils` — 21 gtest cases pass with 0 failures in `autoware:universe-devel-jazzy`. The tests pin the edge-aware distance against a hand-computed independent oracle (distance to the near footprint corner, strictly less than the cell-center distance); the count and height gates (pass/reject), including rejection of a `NaN` `max_height` even when the count passes; the empty-ROI `+inf` return; `cells_in_polygon` collection on a known cell; `cell_corners` being the literal footprint corners; and `nearest_cell` agreeing with `nearest_distance`, returning `std::nullopt` when nothing qualifies, and picking the closer of two occupied cells. Eleven further cases cover `connected_components`: empty input, single-cell `point_sum`, straight-line and L-shaped components, a diagonal pair joining under 8-connectivity, a gap separating two components, border cells probing no out-of-range neighbour, a row wrap not falsely connecting, a duplicate index counted once, a `NaN` `point_count` skipped in the sum, and a merge across the circular-buffer wrap seam.

## Notes for reviewers

Header-only (`INTERFACE`-style, installed via `ament_auto_package`). Depends only on `grid_map_core` and `autoware_utils_geometry`. The grid contract (topic, layers, QoS) is produced by `autoware_obstacle_grid_extractor` (separate PR); this package only consumes a decoded `grid_map::GridMap`.

`connected_components` is circular-buffer aware: `grid_map` stores cells in a wrapping buffer, so neighbour probing resolves through the wrapped index rather than raw row/column arithmetic — hence the explicit wrap-seam and row-wrap tests.

This branch is cut on upstream `main` at `789bded9` and is purely additive: it adds one new package and depends on nothing that is not already upstream.

## Interface changes

New package; no topic/service/parameter changes to existing nodes.

## Effects on system behavior

None (new, unused-by-default helper library).
