### PR TITLE
test(autoware_behavior_path_planner_common): assert calcLaneAroundPose sequence

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_utils.cpp
@@ -533,7 +533,11 @@ TEST_F(BehaviorPathPlanningUtilTest, calcLaneAroundPose)
   {
     const auto lane = calcLaneAroundPose(
       planner_data_->route_handler, planner_data_->self_odometry->pose.pose, 10.0, 0.0);
-    EXPECT_EQ(lane.size(), 1);
+    // TODO(Koichi98): assert the whole sequence ({1001, 1011}) instead. The number of lanelets
+    // returned here currently depends on whether route_handler's rclcpp::ok() guard lets the
+    // forward traversal run at all, which it does not in this test binary. Tighten this once
+    // autowarefoundation/autoware_core#1289 has removed that guard.
+    ASSERT_FALSE(lane.empty());
     EXPECT_EQ(lane.front().id(), 1001);
   }
 }

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_utils.cpp
@@ -533,12 +533,10 @@ TEST_F(BehaviorPathPlanningUtilTest, calcLaneAroundPose)
   {
     const auto lane = calcLaneAroundPose(
       planner_data_->route_handler, planner_data_->self_odometry->pose.pose, 10.0, 0.0);
-    // TODO(Koichi98): assert the whole sequence ({1001, 1011}) instead. The number of lanelets
-    // returned here currently depends on whether route_handler's rclcpp::ok() guard lets the
-    // forward traversal run at all, which it does not in this test binary. Tighten this once
-    // autowarefoundation/autoware_core#1289 has removed that guard.
-    ASSERT_FALSE(lane.empty());
+    // The forward traversal covers the requested 10 m with the next lanelet in the route.
+    ASSERT_EQ(lane.size(), 2);
     EXPECT_EQ(lane.front().id(), 1001);
+    EXPECT_EQ(lane.back().id(), 1011);
   }
 }
 


### PR DESCRIPTION
## Description

Asserts the sequence `calcLaneAroundPose` actually returns, `{1001, 1011}`, including the lanelet the forward traversal appends — the original expectation checked only the count and the first id.

#13109 had to drop the count because it held only while `route_handler` skipped the traversal on `rclcpp::ok() == false`. autowarefoundation/autoware_core#1289 removes that guard, so the real result can be pinned. Test only.

## Related links

Step 3 of 3, blocked on #13109 and autowarefoundation/autoware_core#1289. Until both are merged `lane.size()` is 1 here, so **CI on this PR is expected to be red for now**. Stacked on #13109; will be rebased onto `main` once that merges.

## How was this PR tested?

`test_autoware_behavior_path_planner_common_utilities`: 36/36 against core#1289; 35/36 against core `main` (expected, see above).

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
