### PR TITLE
ci: purge stale released Debian packages in the -above job

### DIFF
--- a/.github/workflows/build-and-test-packages-above-differential.yaml
+++ b/.github/workflows/build-and-test-packages-above-differential.yaml
@@ -99,6 +99,30 @@ jobs:
         run: cp build_depends_stable.repos build_depends.repos
         shell: bash
 
+      - name: Remove released Debian packages of the source-built dependencies
+        if: ${{ steps.get-modified-packages.outputs.modified-packages != '' }}
+        run: |
+          ros_distro="${ROS_DISTRO:-${{ inputs.rosdistro }}}"
+          # colcon-build imports these into dependency_ws and builds them from source.
+          # Importing here as well makes the package list known before the build starts;
+          # the import inside the action then finds the repositories already in place.
+          mkdir -p dependency_ws
+          vcs import --recursive dependency_ws < build_depends.repos
+          vcs import --recursive dependency_ws < packages_above.repos
+          for pkg_xml in $(find . -name package.xml); do
+            pkg_name=$(xmllint --xpath 'string(//package/name)' "$pkg_xml")
+            # The released Debian package installs the same headers under
+            # /opt/ros/$ROS_DISTRO/include, which is searched before the workspace include
+            # directory when packages above it are compiled. Leaving it in place lets a
+            # stale released header shadow the one just built from source.
+            deb_name="ros-${ros_distro}-${pkg_name//_/-}"
+            if dpkg-query -W -f='${Status}' "$deb_name" 2>/dev/null | grep -q '^install ok installed$'; then
+              echo "Removing $deb_name"
+              sudo dpkg --remove --force-depends "$deb_name"
+            fi
+          done
+        shell: bash
+
       - name: Build
         if: ${{ steps.get-modified-packages.outputs.modified-packages != '' }}
         uses: autowarefoundation/autoware-github-actions/colcon-build@v1


### PR DESCRIPTION
## Description

Every `build-and-test-packages-above-differential (humble|jazzy)` job has been failing since core's `feat(point_types, object_recognition_utils): segmentation pointcloud` ([autoware_core#1288](https://github.com/autowarefoundation/autoware_core/pull/1288)) landed, on PRs from several different authors and regardless of what those PRs change. The failure is always the same, in a header the PR under test never touches — e.g. [autowarefoundation/autoware_universe#13090](https://github.com/autowarefoundation/autoware_universe/pull/13090), whose only subject is `autoware_mpc_lateral_controller`, dies compiling `autoware_cluster_merger`:

```
install/autoware_object_recognition_utils/include/autoware_object_recognition_utils/autoware/object_recognition_utils/pointcloud_classification.hpp:29:30:
error: 'PointCloudClassification' has not been declared in 'autoware::point_types'
   29 | using autoware::point_types::PointCloudClassification;
```

### Root cause

`build_depends_nightly.repos` pins `core/autoware_core` to `main` so unreleased core changes are tested against Universe, and `colcon-build` imports it into `dependency_ws` and builds it from source. The **released Debian packages** of those same core packages stay installed in the CI image, and they ship their headers into `/opt/ros/$ROS_DISTRO/include`:

```
$ dpkg -S /opt/ros/humble/include/autoware/point_types/types.hpp
ros-humble-autoware-point-types: /opt/ros/humble/include/autoware/point_types/types.hpp
$ dpkg -l | grep autoware-point-types
ii  ros-humble-autoware-point-types  1.8.0-3jammy.20260623.232751
```

`/opt/ros/$ROS_DISTRO/include` is searched **before** the workspace include directory when a package above the source build is compiled. In `autoware_cluster_merger` the include flags come out as `-isystem /opt/ros/humble/include` at **position 1** and `-isystem <ws>/install/autoware_point_types/include` at **position 7**, so `#include <autoware/point_types/types.hpp>` resolves to the released 1.8.0 header, which predates `PointCloudClassification`.

core#1288 added `PointCloudClassification` to `autoware_point_types` and wired the new `pointcloud_classification.hpp` into the aggregate `object_recognition_utils.hpp`, so every Universe consumer of that aggregate header now compiles `autoware/point_types/types.hpp` and hits the stale copy. The `build-and-test-differential` jobs are unaffected because nothing is compiled *above* the source build there.

### Fix

Remove the matching Debian package for every package that is about to be built from source, so the source build is the only version visible to the packages built above it. `dpkg --remove --force-depends` is used deliberately: `apt-get remove` would cascade into the dependency packages the job still needs.

The repositories are imported in this step as well, because `dependency_ws` is created *inside* `colcon-build` and the package list has to be known before the build starts. `vcs import` is idempotent, so the import inside the action then finds the repositories already in place — measured at 0.5 s for a repository already present, against 1.2 s for a fresh clone.

This is the Universe counterpart of [autoware_core#1311](https://github.com/autowarefoundation/autoware_core/pull/1311), which fixed the identical defect in core's `-above` jobs. The patch is **not** identical, because the asymmetry matters: core's step iterates `find .` over its own checkout, which is exactly where its shadowing packages live. In Universe every installed Autoware Debian package is a *core* package, so a step scanning only Universe's own checkout would remove nothing and fix nothing — the scan has to reach `dependency_ws`.

## Related links

**Parent Issue:**

- None. Filed as a CI fix for the currently red `-above` gate.

Related: [autoware_core#1311](https://github.com/autowarefoundation/autoware_core/pull/1311), [autoware_core#1288](https://github.com/autowarefoundation/autoware_core/pull/1288), [autowarefoundation/autoware_universe#13090](https://github.com/autowarefoundation/autoware_universe/pull/13090) (a PR blocked by this failure).

## How was this PR tested?

Reproduced and fixed in the exact CI container (`ghcr.io/autowarefoundation/autoware:universe-dependencies-humble`), with `autoware_point_types` + `autoware_object_recognition_utils` from `autoware_core@main` in `dependency_ws`, `tier4_perception_msgs` at the pinned `v0.58.0`, and the real `autoware_cluster_merger` from this repository, sourcing `/opt/ros/humble` then `/opt/autoware` exactly as `colcon-build` does:

- **Before this change** — `Failed <<< autoware_cluster_merger [22.1s, exited with code 2]`, with the identical `'PointCloudClassification' has not been declared` error and nothing else.
- **After this change** — `Removing ros-humble-autoware-point-types`, then `Finished <<< autoware_cluster_merger [33.2s]`, `Summary: 4 packages finished`, zero shadowing errors.

The include ordering was confirmed directly from the failing translation unit's `compile_commands.json`:

| `-isystem` position | Path |
| --- | --- |
| 1 | `/opt/ros/humble/include` ← released Debian headers |
| 7 | `<ws>/install/autoware_point_types/include` ← fresh source build |

The new step's shell body was then run **verbatim** in the same container against a real checkout of this repository with the CI-combined `build_depends.repos`: 470 `package.xml` files scanned, 37 s total including the `vcs import`, installed `ros-humble-autoware-*` packages 18 → 12, and `/opt/ros/humble/include/autoware/point_types/types.hpp` gone afterwards. The six removed packages are exactly the six core#1311 reported:

```
Removing ros-humble-autoware-lanelet2-utils
Removing ros-humble-autoware-vehicle-info-utils
Removing ros-humble-autoware-trajectory
Removing ros-humble-autoware-motion-utils
Removing ros-humble-autoware-interpolation
Removing ros-humble-autoware-point-types
```

All six are built from source in this job, so the workspace overlay always provides a replacement. The other 12 remain installed because nothing rebuilds them.

`pre-commit run` passes on the changed file.

## Notes for reviewers

The `/opt/autoware` prebuilt underlay is deliberately left intact, unlike core#1311 which also removes `/opt/autoware/$pkg_name`. It is an *isolated* colcon install (per-package prefixes, no shared `include/`), so `find_package` resolves to the workspace overlay and the underlay copy is never added to the include path — verified from `compile_commands.json`, where `/opt/autoware/autoware_point_types/include` does not appear at all while 22 other `/opt/autoware/*/include` entries do. Universe also depends on `/opt/autoware` for the ~280 core packages it does *not* rebuild, so removing entries there would be a larger and unnecessary change.

Worth considering as a follow-up: the same defect exists in principle for any repository whose `-above` job builds a Debian-released package from source, and `dependency_ws` is created inside `autowarefoundation/autoware-github-actions`'s `colcon-build`. Consolidating this step into that action would fix every consumer at once and make core#1311's copy redundant. I kept the change repo-local here so the red gate is unblocked without a cross-repo change on a floating `@v1` tag; happy to move it if you prefer that shape.

## Interface changes

None.

## Effects on system behavior

None. CI-only change.

## CI evidence

Fork CI on `youtalk/autoware_universe`, run [30550015741](https://github.com/youtalk/autoware_universe/actions/runs/30550015741), commit `d7b070e1` — this branch's change plus one throwaway commit touching `autoware_mpc_lateral_controller`, so that `get-modified-packages` returned a non-empty list and the gated `Build` step actually ran (a workflow-only diff skips it). That gives `modified-packages: autoware_mpc_lateral_controller` — the same trigger package as the failing upstream run [30504913880](https://github.com/autowarefoundation/autoware_universe/actions/runs/30504913880).

| Job | Result |
| --- | --- |
| [build-and-test-packages-above-differential (humble)](https://github.com/youtalk/autoware_universe/actions/runs/30550015741/job/90895970386) | success |
| [build-and-test-packages-above-differential (jazzy)](https://github.com/youtalk/autoware_universe/actions/runs/30550015741/job/90895970820) | success |
| build-and-test-differential (humble) | success |
| build-and-test-differential (jazzy) | success |
| clang-tidy-differential | success |

Both `-above` jobs completed a full **233-package** build with **zero** failures — `Summary: 233 packages finished [21min 20s]` on humble and `[23min 51s]` on jazzy. The upstream run aborted after 83 packages. `autoware_cluster_merger`, the package that was failing, now reports `Finished <<< autoware_cluster_merger [55.9s]` (humble) and `[1min 2s]` (jazzy), and neither log contains a single `has not been declared in` error.

The new step reports what it removed, with the distro-correct package names on each:

```
Removing ros-humble-autoware-interpolation (1.8.0-3jammy.20260624.090149) ...
Removing ros-humble-autoware-lanelet2-utils (1.8.0-3jammy.20260624.091844) ...
Removing ros-humble-autoware-motion-utils (1.8.0-3jammy.20260624.090645) ...
Removing ros-humble-autoware-point-types (1.8.0-3jammy.20260623.232751) ...
Removing ros-humble-autoware-trajectory (1.8.0-3jammy.20260624.095929) ...
Removing ros-humble-autoware-vehicle-info-utils (1.8.0-3jammy.20260624.090156) ...
```

So six released packages were shadowing the source build, not just `autoware_point_types`; the others simply had not yet gained a symbol that a workspace header needed. The `Test` step also passes afterwards (`9 packages finished`), which confirms that removing the *library* packages among those six — `autoware_interpolation`, `autoware_motion_utils`, `autoware_trajectory`, `autoware_vehicle_info_utils` — does not break the run-time link, because the workspace overlay supplies them.

> [!IMPORTANT]
> The `-above` checks **on this PR itself prove nothing**. The diff is workflow-only, so `get-modified-packages` returns an empty list and steps 16–19 (`Remove released Debian packages`, `Build`, `Test`) are all reported `skipped` on both distros — the same blind spot that let core#1288 merge with its `-above` checks skipped in the first place. Their green marks confirm only that the workflow still parses and that the new step's `if:` guard evaluates correctly. The actual proof that the fix works is the fork run linked above, where a throwaway commit made `modified-packages` non-empty and the full 233-package build ran.
