### PR TITLE
refactor(autoware_component_interface_specs_universe): re-export the core interface specs as the single version authority

### DIFF
--- a/common/autoware_component_interface_specs_universe/CMakeLists.txt
+++ b/common/autoware_component_interface_specs_universe/CMakeLists.txt
@@ -13,6 +13,7 @@ if(BUILD_TESTING)
     test/test_system.cpp
     test/test_map.cpp
     test/test_perception.cpp
+    test/test_sensing.cpp
     test/test_vehicle.cpp
   )
 endif()

--- a/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/control.hpp
+++ b/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/control.hpp
@@ -15,6 +15,7 @@
 #ifndef AUTOWARE__COMPONENT_INTERFACE_SPECS_UNIVERSE__CONTROL_HPP_
 #define AUTOWARE__COMPONENT_INTERFACE_SPECS_UNIVERSE__CONTROL_HPP_
 
+#include <autoware/component_interface_specs/control.hpp>
 #include <rclcpp/qos.hpp>
 
 #include <tier4_control_msgs/msg/is_paused.hpp>
@@ -27,6 +28,17 @@
 namespace autoware::component_interface_specs_universe::control
 {
 
+// Re-export the core specs so universe consumers keep resolving the canonical
+// (single-version-authority) type. See R-IF-12: core is the sole definition.
+using autoware::component_interface_specs::control::ControlCommand;
+using autoware::component_interface_specs::control::GearCommand;
+using autoware::component_interface_specs::control::HazardLightsCommand;
+using autoware::component_interface_specs::control::Specs;
+using autoware::component_interface_specs::control::TurnIndicatorsCommand;
+using autoware::component_interface_specs::control::version;
+
+// tier4-only specs kept here: they are typed on tier4_* messages and stay
+// unversioned until the vendor partition (parent doc P3). Not part of core Specs.
 struct ActuationCommand
 {
   using Message = tier4_vehicle_msgs::msg::ActuationCommandStamped;

--- a/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/control.hpp
+++ b/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/control.hpp
@@ -29,7 +29,7 @@ namespace autoware::component_interface_specs_universe::control
 {
 
 // Re-export the core specs so universe consumers keep resolving the canonical
-// (single-version-authority) type. See R-IF-12: core is the sole definition.
+// (single-version-authority) type; core is the sole definition and version authority.
 using autoware::component_interface_specs::control::ControlCommand;
 using autoware::component_interface_specs::control::GearCommand;
 using autoware::component_interface_specs::control::HazardLightsCommand;
@@ -38,7 +38,8 @@ using autoware::component_interface_specs::control::TurnIndicatorsCommand;
 using autoware::component_interface_specs::control::version;
 
 // tier4-only specs kept here: they are typed on tier4_* messages and stay
-// unversioned until the vendor partition (parent doc P3). Not part of core Specs.
+// unversioned until vendor-specific specs get their own versioned registry
+// separate from core's OSS-facing Specs tuple; they are not part of it yet.
 struct ActuationCommand
 {
   using Message = tier4_vehicle_msgs::msg::ActuationCommandStamped;

--- a/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/control.hpp
+++ b/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/control.hpp
@@ -31,8 +31,10 @@ namespace autoware::component_interface_specs_universe::control
 // Re-export the core specs so universe consumers keep resolving the canonical
 // (single-version-authority) type; core is the sole definition and version authority.
 using autoware::component_interface_specs::control::ControlCommand;
+using autoware::component_interface_specs::control::ControlModeRequest;
 using autoware::component_interface_specs::control::GearCommand;
 using autoware::component_interface_specs::control::HazardLightsCommand;
+using autoware::component_interface_specs::control::PredictedTrajectory;
 using autoware::component_interface_specs::control::Specs;
 using autoware::component_interface_specs::control::TurnIndicatorsCommand;
 using autoware::component_interface_specs::control::version;

--- a/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/localization.hpp
+++ b/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/localization.hpp
@@ -15,49 +15,18 @@
 #ifndef AUTOWARE__COMPONENT_INTERFACE_SPECS_UNIVERSE__LOCALIZATION_HPP_
 #define AUTOWARE__COMPONENT_INTERFACE_SPECS_UNIVERSE__LOCALIZATION_HPP_
 
-#include <rclcpp/qos.hpp>
+#include <autoware/component_interface_specs/localization.hpp>
 
-#include <autoware_adapi_v1_msgs/msg/localization_initialization_state.hpp>
-#include <autoware_localization_msgs/srv/initialize_localization.hpp>
-#include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
-#include <nav_msgs/msg/odometry.hpp>
-
+// Re-export the core specs so universe consumers keep resolving the canonical
+// (single-version-authority) type. See R-IF-12: core is the sole definition.
 namespace autoware::component_interface_specs_universe::localization
 {
-
-struct Initialize
-{
-  using Service = autoware_localization_msgs::srv::InitializeLocalization;
-  static constexpr char name[] = "/localization/initialize";
-};
-
-struct InitializationState
-{
-  using Message = autoware_adapi_v1_msgs::msg::LocalizationInitializationState;
-  static constexpr char name[] = "/localization/initialization_state";
-  static constexpr size_t depth = 1;
-  static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
-  static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
-};
-
-struct KinematicState
-{
-  using Message = nav_msgs::msg::Odometry;
-  static constexpr char name[] = "/localization/kinematic_state";
-  static constexpr size_t depth = 1;
-  static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
-  static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
-};
-
-struct Acceleration
-{
-  using Message = geometry_msgs::msg::AccelWithCovarianceStamped;
-  static constexpr char name[] = "/localization/acceleration";
-  static constexpr size_t depth = 1;
-  static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
-  static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
-};
-
+using autoware::component_interface_specs::localization::Acceleration;
+using autoware::component_interface_specs::localization::InitializationState;
+using autoware::component_interface_specs::localization::Initialize;
+using autoware::component_interface_specs::localization::KinematicState;
+using autoware::component_interface_specs::localization::Specs;
+using autoware::component_interface_specs::localization::version;
 }  // namespace autoware::component_interface_specs_universe::localization
 
 #endif  // AUTOWARE__COMPONENT_INTERFACE_SPECS_UNIVERSE__LOCALIZATION_HPP_

--- a/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/localization.hpp
+++ b/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/localization.hpp
@@ -18,7 +18,7 @@
 #include <autoware/component_interface_specs/localization.hpp>
 
 // Re-export the core specs so universe consumers keep resolving the canonical
-// (single-version-authority) type. See R-IF-12: core is the sole definition.
+// (single-version-authority) type; core is the sole definition and version authority.
 namespace autoware::component_interface_specs_universe::localization
 {
 using autoware::component_interface_specs::localization::Acceleration;

--- a/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/map.hpp
+++ b/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/map.hpp
@@ -18,10 +18,11 @@
 #include <autoware/component_interface_specs/map.hpp>
 
 // Re-export the core specs so universe consumers keep resolving the canonical
-// (single-version-authority) type. See R-IF-12: core is the sole definition.
+// (single-version-authority) type; core is the sole definition and version authority.
 // PointCloudMap is intentionally NOT re-exported: its spec (/map/point_cloud_map)
 // is a never-published topic with no universe consumer, and it is excluded from the
-// versioned Specs tuple anyway (heavy-raw confinement, design section 5).
+// versioned Specs tuple anyway, since it is a raw, high-bandwidth topic that
+// core deliberately keeps out of the versioned spec set.
 namespace autoware::component_interface_specs_universe::map
 {
 using autoware::component_interface_specs::map::GetDifferentialPointCloudMap;

--- a/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/map.hpp
+++ b/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/map.hpp
@@ -19,13 +19,13 @@
 
 // Re-export the core specs so universe consumers keep resolving the canonical
 // (single-version-authority) type. See R-IF-12: core is the sole definition.
-// PointCloudMap is re-exported for consumer convenience but stays excluded from
-// the versioned Specs tuple (heavy-raw confinement, design section 5).
+// PointCloudMap is intentionally NOT re-exported: its spec (/map/point_cloud_map)
+// is a never-published topic with no universe consumer, and it is excluded from the
+// versioned Specs tuple anyway (heavy-raw confinement, design section 5).
 namespace autoware::component_interface_specs_universe::map
 {
 using autoware::component_interface_specs::map::GetDifferentialPointCloudMap;
 using autoware::component_interface_specs::map::MapProjectorInfo;
-using autoware::component_interface_specs::map::PointCloudMap;
 using autoware::component_interface_specs::map::Specs;
 using autoware::component_interface_specs::map::VectorMap;
 using autoware::component_interface_specs::map::version;

--- a/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/map.hpp
+++ b/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/map.hpp
@@ -15,22 +15,20 @@
 #ifndef AUTOWARE__COMPONENT_INTERFACE_SPECS_UNIVERSE__MAP_HPP_
 #define AUTOWARE__COMPONENT_INTERFACE_SPECS_UNIVERSE__MAP_HPP_
 
-#include <rclcpp/qos.hpp>
+#include <autoware/component_interface_specs/map.hpp>
 
-#include <autoware_map_msgs/msg/map_projector_info.hpp>
-
+// Re-export the core specs so universe consumers keep resolving the canonical
+// (single-version-authority) type. See R-IF-12: core is the sole definition.
+// PointCloudMap is re-exported for consumer convenience but stays excluded from
+// the versioned Specs tuple (heavy-raw confinement, design section 5).
 namespace autoware::component_interface_specs_universe::map
 {
-
-struct MapProjectorInfo
-{
-  using Message = autoware_map_msgs::msg::MapProjectorInfo;
-  static constexpr char name[] = "/map/map_projector_info";
-  static constexpr size_t depth = 1;
-  static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
-  static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
-};
-
+using autoware::component_interface_specs::map::GetDifferentialPointCloudMap;
+using autoware::component_interface_specs::map::MapProjectorInfo;
+using autoware::component_interface_specs::map::PointCloudMap;
+using autoware::component_interface_specs::map::Specs;
+using autoware::component_interface_specs::map::VectorMap;
+using autoware::component_interface_specs::map::version;
 }  // namespace autoware::component_interface_specs_universe::map
 
 #endif  // AUTOWARE__COMPONENT_INTERFACE_SPECS_UNIVERSE__MAP_HPP_

--- a/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/map.hpp
+++ b/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/map.hpp
@@ -26,6 +26,7 @@
 namespace autoware::component_interface_specs_universe::map
 {
 using autoware::component_interface_specs::map::GetDifferentialPointCloudMap;
+using autoware::component_interface_specs::map::GetPartialPointCloudMap;
 using autoware::component_interface_specs::map::MapProjectorInfo;
 using autoware::component_interface_specs::map::Specs;
 using autoware::component_interface_specs::map::VectorMap;

--- a/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/perception.hpp
+++ b/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/perception.hpp
@@ -18,7 +18,7 @@
 #include <autoware/component_interface_specs/perception.hpp>
 
 // Re-export the core specs so universe consumers keep resolving the canonical
-// (single-version-authority) type. See R-IF-12: core is the sole definition.
+// (single-version-authority) type; core is the sole definition and version authority.
 namespace autoware::component_interface_specs_universe::perception
 {
 using autoware::component_interface_specs::perception::DetectedObjects;

--- a/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/perception.hpp
+++ b/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/perception.hpp
@@ -15,22 +15,17 @@
 #ifndef AUTOWARE__COMPONENT_INTERFACE_SPECS_UNIVERSE__PERCEPTION_HPP_
 #define AUTOWARE__COMPONENT_INTERFACE_SPECS_UNIVERSE__PERCEPTION_HPP_
 
-#include <rclcpp/qos.hpp>
+#include <autoware/component_interface_specs/perception.hpp>
 
-#include <autoware_perception_msgs/msg/predicted_objects.hpp>
-
+// Re-export the core specs so universe consumers keep resolving the canonical
+// (single-version-authority) type. See R-IF-12: core is the sole definition.
 namespace autoware::component_interface_specs_universe::perception
 {
-
-struct ObjectRecognition
-{
-  using Message = autoware_perception_msgs::msg::PredictedObjects;
-  static constexpr char name[] = "/perception/object_recognition/objects";
-  static constexpr size_t depth = 1;
-  static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
-  static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
-};
-
+using autoware::component_interface_specs::perception::DetectedObjects;
+using autoware::component_interface_specs::perception::ObjectRecognition;
+using autoware::component_interface_specs::perception::Specs;
+using autoware::component_interface_specs::perception::TrafficSignals;
+using autoware::component_interface_specs::perception::version;
 }  // namespace autoware::component_interface_specs_universe::perception
 
 #endif  // AUTOWARE__COMPONENT_INTERFACE_SPECS_UNIVERSE__PERCEPTION_HPP_

--- a/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/perception.hpp
+++ b/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/perception.hpp
@@ -21,7 +21,6 @@
 // (single-version-authority) type; core is the sole definition and version authority.
 namespace autoware::component_interface_specs_universe::perception
 {
-using autoware::component_interface_specs::perception::DetectedObjects;
 using autoware::component_interface_specs::perception::ObjectRecognition;
 using autoware::component_interface_specs::perception::Specs;
 using autoware::component_interface_specs::perception::TrafficSignals;

--- a/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/perception.hpp
+++ b/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/perception.hpp
@@ -23,6 +23,7 @@ namespace autoware::component_interface_specs_universe::perception
 {
 using autoware::component_interface_specs::perception::ObjectRecognition;
 using autoware::component_interface_specs::perception::Specs;
+using autoware::component_interface_specs::perception::TrackedObjects;
 using autoware::component_interface_specs::perception::TrafficSignals;
 using autoware::component_interface_specs::perception::version;
 }  // namespace autoware::component_interface_specs_universe::perception

--- a/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/planning.hpp
+++ b/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/planning.hpp
@@ -18,7 +18,7 @@
 #include <autoware/component_interface_specs/planning.hpp>
 
 // Re-export the core specs so universe consumers keep resolving the canonical
-// (single-version-authority) type. See R-IF-12: core is the sole definition.
+// (single-version-authority) type; core is the sole definition and version authority.
 namespace autoware::component_interface_specs_universe::planning
 {
 using autoware::component_interface_specs::planning::ClearRoute;

--- a/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/planning.hpp
+++ b/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/planning.hpp
@@ -15,63 +15,20 @@
 #ifndef AUTOWARE__COMPONENT_INTERFACE_SPECS_UNIVERSE__PLANNING_HPP_
 #define AUTOWARE__COMPONENT_INTERFACE_SPECS_UNIVERSE__PLANNING_HPP_
 
-#include <rclcpp/qos.hpp>
+#include <autoware/component_interface_specs/planning.hpp>
 
-#include <autoware_planning_msgs/msg/lanelet_route.hpp>
-#include <autoware_planning_msgs/msg/route_state.hpp>
-#include <autoware_planning_msgs/msg/trajectory.hpp>
-#include <autoware_planning_msgs/srv/clear_route.hpp>
-#include <autoware_planning_msgs/srv/set_lanelet_route.hpp>
-#include <autoware_planning_msgs/srv/set_waypoint_route.hpp>
-
+// Re-export the core specs so universe consumers keep resolving the canonical
+// (single-version-authority) type. See R-IF-12: core is the sole definition.
 namespace autoware::component_interface_specs_universe::planning
 {
-
-struct SetLaneletRoute
-{
-  using Service = autoware_planning_msgs::srv::SetLaneletRoute;
-  static constexpr char name[] = "/planning/set_lanelet_route";
-};
-
-struct SetWaypointRoute
-{
-  using Service = autoware_planning_msgs::srv::SetWaypointRoute;
-  static constexpr char name[] = "/planning/set_waypoint_route";
-};
-
-struct ClearRoute
-{
-  using Service = autoware_planning_msgs::srv::ClearRoute;
-  static constexpr char name[] = "/planning/clear_route";
-};
-
-struct RouteState
-{
-  using Message = autoware_planning_msgs::msg::RouteState;
-  static constexpr char name[] = "/planning/route_state";
-  static constexpr size_t depth = 1;
-  static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
-  static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
-};
-
-struct LaneletRoute
-{
-  using Message = autoware_planning_msgs::msg::LaneletRoute;
-  static constexpr char name[] = "/planning/route";
-  static constexpr size_t depth = 1;
-  static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
-  static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
-};
-
-struct Trajectory
-{
-  using Message = autoware_planning_msgs::msg::Trajectory;
-  static constexpr char name[] = "/planning/trajectory";
-  static constexpr size_t depth = 1;
-  static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
-  static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
-};
-
+using autoware::component_interface_specs::planning::ClearRoute;
+using autoware::component_interface_specs::planning::LaneletRoute;
+using autoware::component_interface_specs::planning::RouteState;
+using autoware::component_interface_specs::planning::SetLaneletRoute;
+using autoware::component_interface_specs::planning::SetWaypointRoute;
+using autoware::component_interface_specs::planning::Specs;
+using autoware::component_interface_specs::planning::Trajectory;
+using autoware::component_interface_specs::planning::version;
 }  // namespace autoware::component_interface_specs_universe::planning
 
 #endif  // AUTOWARE__COMPONENT_INTERFACE_SPECS_UNIVERSE__PLANNING_HPP_

--- a/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/sensing.hpp
+++ b/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/sensing.hpp
@@ -1,0 +1,29 @@
+// Copyright 2026 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__COMPONENT_INTERFACE_SPECS_UNIVERSE__SENSING_HPP_
+#define AUTOWARE__COMPONENT_INTERFACE_SPECS_UNIVERSE__SENSING_HPP_
+
+#include <autoware/component_interface_specs/sensing.hpp>
+
+// Re-export the core specs so universe consumers keep resolving the canonical
+// (single-version-authority) type. See R-IF-12: core is the sole definition.
+namespace autoware::component_interface_specs_universe::sensing
+{
+using autoware::component_interface_specs::sensing::Specs;
+using autoware::component_interface_specs::sensing::VehicleVelocityConverterTwist;
+using autoware::component_interface_specs::sensing::version;
+}  // namespace autoware::component_interface_specs_universe::sensing
+
+#endif  // AUTOWARE__COMPONENT_INTERFACE_SPECS_UNIVERSE__SENSING_HPP_

--- a/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/sensing.hpp
+++ b/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/sensing.hpp
@@ -18,7 +18,7 @@
 #include <autoware/component_interface_specs/sensing.hpp>
 
 // Re-export the core specs so universe consumers keep resolving the canonical
-// (single-version-authority) type. See R-IF-12: core is the sole definition.
+// (single-version-authority) type; core is the sole definition and version authority.
 namespace autoware::component_interface_specs_universe::sensing
 {
 using autoware::component_interface_specs::sensing::Specs;

--- a/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/system.hpp
+++ b/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/system.hpp
@@ -25,7 +25,6 @@ namespace autoware::component_interface_specs_universe::system
 {
 using autoware::component_interface_specs::system::ChangeAutowareControl;
 using autoware::component_interface_specs::system::ChangeOperationMode;
-using autoware::component_interface_specs::system::HazardStatus;
 using autoware::component_interface_specs::system::MrmState;
 using autoware::component_interface_specs::system::OperationModeState;
 using autoware::component_interface_specs::system::Specs;

--- a/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/system.hpp
+++ b/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/system.hpp
@@ -18,9 +18,9 @@
 #include <autoware/component_interface_specs/system.hpp>
 
 // Re-export the core specs so universe consumers keep resolving the canonical
-// (single-version-authority) type. See R-IF-12: core is the sole definition.
-// MrmState was promoted universe -> core; existing consumers keep compiling via
-// this re-export (design section 4, promote-on-port).
+// (single-version-authority) type; core is the sole definition and version authority.
+// MrmState was promoted from universe to core; existing consumers keep
+// compiling unchanged via this re-export, since the type identity is preserved.
 namespace autoware::component_interface_specs_universe::system
 {
 using autoware::component_interface_specs::system::ChangeAutowareControl;

--- a/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/system.hpp
+++ b/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/system.hpp
@@ -15,46 +15,21 @@
 #ifndef AUTOWARE__COMPONENT_INTERFACE_SPECS_UNIVERSE__SYSTEM_HPP_
 #define AUTOWARE__COMPONENT_INTERFACE_SPECS_UNIVERSE__SYSTEM_HPP_
 
-#include <rclcpp/qos.hpp>
+#include <autoware/component_interface_specs/system.hpp>
 
-#include <autoware_adapi_v1_msgs/msg/mrm_state.hpp>
-#include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
-#include <autoware_system_msgs/srv/change_autoware_control.hpp>
-#include <autoware_system_msgs/srv/change_operation_mode.hpp>
-
+// Re-export the core specs so universe consumers keep resolving the canonical
+// (single-version-authority) type. See R-IF-12: core is the sole definition.
+// MrmState was promoted universe -> core; existing consumers keep compiling via
+// this re-export (design section 4, promote-on-port).
 namespace autoware::component_interface_specs_universe::system
 {
-
-struct MrmState
-{
-  using Message = autoware_adapi_v1_msgs::msg::MrmState;
-  static constexpr char name[] = "/system/fail_safe/mrm_state";
-  static constexpr size_t depth = 1;
-  static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
-  static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
-};
-
-struct ChangeAutowareControl
-{
-  using Service = autoware_system_msgs::srv::ChangeAutowareControl;
-  static constexpr char name[] = "/system/operation_mode/change_autoware_control";
-};
-
-struct ChangeOperationMode
-{
-  using Service = autoware_system_msgs::srv::ChangeOperationMode;
-  static constexpr char name[] = "/system/operation_mode/change_operation_mode";
-};
-
-struct OperationModeState
-{
-  using Message = autoware_adapi_v1_msgs::msg::OperationModeState;
-  static constexpr char name[] = "/system/operation_mode/state";
-  static constexpr size_t depth = 1;
-  static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
-  static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
-};
-
+using autoware::component_interface_specs::system::ChangeAutowareControl;
+using autoware::component_interface_specs::system::ChangeOperationMode;
+using autoware::component_interface_specs::system::HazardStatus;
+using autoware::component_interface_specs::system::MrmState;
+using autoware::component_interface_specs::system::OperationModeState;
+using autoware::component_interface_specs::system::Specs;
+using autoware::component_interface_specs::system::version;
 }  // namespace autoware::component_interface_specs_universe::system
 
 #endif  // AUTOWARE__COMPONENT_INTERFACE_SPECS_UNIVERSE__SYSTEM_HPP_

--- a/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/vehicle.hpp
+++ b/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/vehicle.hpp
@@ -15,56 +15,29 @@
 #ifndef AUTOWARE__COMPONENT_INTERFACE_SPECS_UNIVERSE__VEHICLE_HPP_
 #define AUTOWARE__COMPONENT_INTERFACE_SPECS_UNIVERSE__VEHICLE_HPP_
 
+#include <autoware/component_interface_specs/vehicle.hpp>
 #include <rclcpp/qos.hpp>
 
 #include <autoware_adapi_v1_msgs/msg/door_status_array.hpp>
 #include <autoware_adapi_v1_msgs/srv/get_door_layout.hpp>
 #include <autoware_adapi_v1_msgs/srv/set_door_command.hpp>
-#include <autoware_vehicle_msgs/msg/gear_report.hpp>
-#include <autoware_vehicle_msgs/msg/hazard_lights_report.hpp>
-#include <autoware_vehicle_msgs/msg/steering_report.hpp>
-#include <autoware_vehicle_msgs/msg/turn_indicators_report.hpp>
 #include <tier4_vehicle_msgs/msg/battery_status.hpp>
 
 namespace autoware::component_interface_specs_universe::vehicle
 {
 
-struct SteeringStatus
-{
-  using Message = autoware_vehicle_msgs::msg::SteeringReport;
-  static constexpr char name[] = "/vehicle/status/steering_status";
-  static constexpr size_t depth = 1;
-  static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
-  static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
-};
+// Re-export the core specs so universe consumers keep resolving the canonical
+// (single-version-authority) type. See R-IF-12: core is the sole definition.
+using autoware::component_interface_specs::vehicle::GearStatus;
+using autoware::component_interface_specs::vehicle::HazardLightStatus;
+using autoware::component_interface_specs::vehicle::Specs;
+using autoware::component_interface_specs::vehicle::SteeringStatus;
+using autoware::component_interface_specs::vehicle::TurnIndicatorStatus;
+using autoware::component_interface_specs::vehicle::VelocityStatus;
+using autoware::component_interface_specs::vehicle::version;
 
-struct GearStatus
-{
-  using Message = autoware_vehicle_msgs::msg::GearReport;
-  static constexpr char name[] = "/vehicle/status/gear_status";
-  static constexpr size_t depth = 1;
-  static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
-  static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
-};
-
-struct TurnIndicatorStatus
-{
-  using Message = autoware_vehicle_msgs::msg::TurnIndicatorsReport;
-  static constexpr char name[] = "/vehicle/status/turn_indicators_status";
-  static constexpr size_t depth = 1;
-  static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
-  static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
-};
-
-struct HazardLightStatus
-{
-  using Message = autoware_vehicle_msgs::msg::HazardLightsReport;
-  static constexpr char name[] = "/vehicle/status/hazard_lights_status";
-  static constexpr size_t depth = 1;
-  static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
-  static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
-};
-
+// tier4/adapi-only specs kept here: they are typed on tier4_* / door messages
+// and stay unversioned until the vendor partition (parent doc P3). Not core Specs.
 struct EnergyStatus
 {
   using Message = tier4_vehicle_msgs::msg::BatteryStatus;

--- a/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/vehicle.hpp
+++ b/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/vehicle.hpp
@@ -27,7 +27,7 @@ namespace autoware::component_interface_specs_universe::vehicle
 {
 
 // Re-export the core specs so universe consumers keep resolving the canonical
-// (single-version-authority) type. See R-IF-12: core is the sole definition.
+// (single-version-authority) type; core is the sole definition and version authority.
 using autoware::component_interface_specs::vehicle::GearStatus;
 using autoware::component_interface_specs::vehicle::HazardLightStatus;
 using autoware::component_interface_specs::vehicle::Specs;
@@ -37,7 +37,8 @@ using autoware::component_interface_specs::vehicle::VelocityStatus;
 using autoware::component_interface_specs::vehicle::version;
 
 // tier4/adapi-only specs kept here: they are typed on tier4_* / door messages
-// and stay unversioned until the vendor partition (parent doc P3). Not core Specs.
+// and stay unversioned until vendor-specific specs get their own versioned
+// registry separate from core's OSS-facing Specs tuple; they are not part of it yet.
 struct EnergyStatus
 {
   using Message = tier4_vehicle_msgs::msg::BatteryStatus;

--- a/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/vehicle.hpp
+++ b/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/vehicle.hpp
@@ -28,6 +28,7 @@ namespace autoware::component_interface_specs_universe::vehicle
 
 // Re-export the core specs so universe consumers keep resolving the canonical
 // (single-version-authority) type; core is the sole definition and version authority.
+using autoware::component_interface_specs::vehicle::ControlModeStatus;
 using autoware::component_interface_specs::vehicle::GearStatus;
 using autoware::component_interface_specs::vehicle::HazardLightStatus;
 using autoware::component_interface_specs::vehicle::Specs;

--- a/common/autoware_component_interface_specs_universe/package.xml
+++ b/common/autoware_component_interface_specs_universe/package.xml
@@ -12,13 +12,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>
-  <depend>autoware_localization_msgs</depend>
-  <depend>autoware_map_msgs</depend>
-  <depend>autoware_perception_msgs</depend>
-  <depend>autoware_planning_msgs</depend>
-  <depend>autoware_system_msgs</depend>
-  <depend>autoware_vehicle_msgs</depend>
-  <depend>nav_msgs</depend>
+  <depend>autoware_component_interface_specs</depend>
   <depend>rcl</depend>
   <depend>rclcpp</depend>
   <depend>rosidl_runtime_cpp</depend>

--- a/common/autoware_component_interface_specs_universe/test/test_control.cpp
+++ b/common/autoware_component_interface_specs_universe/test/test_control.cpp
@@ -19,7 +19,7 @@
 #include <type_traits>
 
 // Proves the universe symbols are re-exports of the canonical core types, not
-// redefinitions: consumers see one definition, one version authority (R-IF-12).
+// redefinitions: consumers see one definition, one version authority.
 TEST(control_universe, reexports_core)
 {
   namespace core = autoware::component_interface_specs::control;

--- a/common/autoware_component_interface_specs_universe/test/test_control.cpp
+++ b/common/autoware_component_interface_specs_universe/test/test_control.cpp
@@ -12,8 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "autoware/component_interface_specs/control.hpp"
 #include "autoware/component_interface_specs_universe/control.hpp"
 #include "gtest/gtest.h"
+
+#include <type_traits>
+
+// Proves the universe symbols are re-exports of the canonical core types, not
+// redefinitions: consumers see one definition, one version authority (R-IF-12).
+TEST(control_universe, reexports_core)
+{
+  namespace core = autoware::component_interface_specs::control;
+  namespace universe = autoware::component_interface_specs_universe::control;
+  static_assert(std::is_same_v<universe::ControlCommand, core::ControlCommand>);
+  static_assert(std::is_same_v<universe::GearCommand, core::GearCommand>);
+  SUCCEED();
+}
 
 TEST(control, interface)
 {

--- a/common/autoware_component_interface_specs_universe/test/test_localization.cpp
+++ b/common/autoware_component_interface_specs_universe/test/test_localization.cpp
@@ -12,8 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "autoware/component_interface_specs/localization.hpp"
 #include "autoware/component_interface_specs_universe/localization.hpp"
 #include "gtest/gtest.h"
+
+#include <type_traits>
+
+// Proves the universe symbols are re-exports of the canonical core types, not
+// redefinitions: consumers see one definition, one version authority (R-IF-12).
+TEST(localization_universe, reexports_core)
+{
+  namespace core = autoware::component_interface_specs::localization;
+  namespace universe = autoware::component_interface_specs_universe::localization;
+  static_assert(std::is_same_v<universe::KinematicState, core::KinematicState>);
+  static_assert(std::is_same_v<universe::Initialize, core::Initialize>);
+  SUCCEED();
+}
 
 TEST(localization, interface)
 {

--- a/common/autoware_component_interface_specs_universe/test/test_localization.cpp
+++ b/common/autoware_component_interface_specs_universe/test/test_localization.cpp
@@ -19,7 +19,7 @@
 #include <type_traits>
 
 // Proves the universe symbols are re-exports of the canonical core types, not
-// redefinitions: consumers see one definition, one version authority (R-IF-12).
+// redefinitions: consumers see one definition, one version authority.
 TEST(localization_universe, reexports_core)
 {
   namespace core = autoware::component_interface_specs::localization;

--- a/common/autoware_component_interface_specs_universe/test/test_map.cpp
+++ b/common/autoware_component_interface_specs_universe/test/test_map.cpp
@@ -19,7 +19,7 @@
 #include <type_traits>
 
 // Proves the universe symbols are re-exports of the canonical core types, not
-// redefinitions: consumers see one definition, one version authority (R-IF-12).
+// redefinitions: consumers see one definition, one version authority.
 TEST(map_universe, reexports_core)
 {
   namespace core = autoware::component_interface_specs::map;

--- a/common/autoware_component_interface_specs_universe/test/test_map.cpp
+++ b/common/autoware_component_interface_specs_universe/test/test_map.cpp
@@ -12,8 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "autoware/component_interface_specs/map.hpp"
 #include "autoware/component_interface_specs_universe/map.hpp"
 #include "gtest/gtest.h"
+
+#include <type_traits>
+
+// Proves the universe symbols are re-exports of the canonical core types, not
+// redefinitions: consumers see one definition, one version authority (R-IF-12).
+TEST(map_universe, reexports_core)
+{
+  namespace core = autoware::component_interface_specs::map;
+  namespace universe = autoware::component_interface_specs_universe::map;
+  static_assert(std::is_same_v<universe::VectorMap, core::VectorMap>);
+  static_assert(
+    std::is_same_v<universe::GetDifferentialPointCloudMap, core::GetDifferentialPointCloudMap>);
+  SUCCEED();
+}
 
 TEST(map, interface)
 {

--- a/common/autoware_component_interface_specs_universe/test/test_perception.cpp
+++ b/common/autoware_component_interface_specs_universe/test/test_perception.cpp
@@ -12,8 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "autoware/component_interface_specs/perception.hpp"
 #include "autoware/component_interface_specs_universe/perception.hpp"
 #include "gtest/gtest.h"
+
+#include <type_traits>
+
+// Proves the universe symbols are re-exports of the canonical core types, not
+// redefinitions: consumers see one definition, one version authority (R-IF-12).
+TEST(perception_universe, reexports_core)
+{
+  namespace core = autoware::component_interface_specs::perception;
+  namespace universe = autoware::component_interface_specs_universe::perception;
+  static_assert(std::is_same_v<universe::ObjectRecognition, core::ObjectRecognition>);
+  static_assert(std::is_same_v<universe::TrafficSignals, core::TrafficSignals>);
+  static_assert(std::is_same_v<universe::DetectedObjects, core::DetectedObjects>);
+  SUCCEED();
+}
 
 TEST(perception, interface)
 {

--- a/common/autoware_component_interface_specs_universe/test/test_perception.cpp
+++ b/common/autoware_component_interface_specs_universe/test/test_perception.cpp
@@ -19,7 +19,7 @@
 #include <type_traits>
 
 // Proves the universe symbols are re-exports of the canonical core types, not
-// redefinitions: consumers see one definition, one version authority (R-IF-12).
+// redefinitions: consumers see one definition, one version authority.
 TEST(perception_universe, reexports_core)
 {
   namespace core = autoware::component_interface_specs::perception;

--- a/common/autoware_component_interface_specs_universe/test/test_perception.cpp
+++ b/common/autoware_component_interface_specs_universe/test/test_perception.cpp
@@ -26,7 +26,6 @@ TEST(perception_universe, reexports_core)
   namespace universe = autoware::component_interface_specs_universe::perception;
   static_assert(std::is_same_v<universe::ObjectRecognition, core::ObjectRecognition>);
   static_assert(std::is_same_v<universe::TrafficSignals, core::TrafficSignals>);
-  static_assert(std::is_same_v<universe::DetectedObjects, core::DetectedObjects>);
   SUCCEED();
 }
 

--- a/common/autoware_component_interface_specs_universe/test/test_planning.cpp
+++ b/common/autoware_component_interface_specs_universe/test/test_planning.cpp
@@ -19,7 +19,7 @@
 #include <type_traits>
 
 // Proves the universe symbols are re-exports of the canonical core types, not
-// redefinitions: consumers see one definition, one version authority (R-IF-12).
+// redefinitions: consumers see one definition, one version authority.
 TEST(planning_universe, reexports_core)
 {
   namespace core = autoware::component_interface_specs::planning;

--- a/common/autoware_component_interface_specs_universe/test/test_planning.cpp
+++ b/common/autoware_component_interface_specs_universe/test/test_planning.cpp
@@ -12,8 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "autoware/component_interface_specs/planning.hpp"
 #include "autoware/component_interface_specs_universe/planning.hpp"
 #include "gtest/gtest.h"
+
+#include <type_traits>
+
+// Proves the universe symbols are re-exports of the canonical core types, not
+// redefinitions: consumers see one definition, one version authority (R-IF-12).
+TEST(planning_universe, reexports_core)
+{
+  namespace core = autoware::component_interface_specs::planning;
+  namespace universe = autoware::component_interface_specs_universe::planning;
+  static_assert(std::is_same_v<universe::Trajectory, core::Trajectory>);
+  static_assert(std::is_same_v<universe::SetLaneletRoute, core::SetLaneletRoute>);
+  SUCCEED();
+}
 
 TEST(planning, interface)
 {

--- a/common/autoware_component_interface_specs_universe/test/test_sensing.cpp
+++ b/common/autoware_component_interface_specs_universe/test/test_sensing.cpp
@@ -1,0 +1,42 @@
+// Copyright 2026 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/component_interface_specs/sensing.hpp"
+#include "autoware/component_interface_specs_universe/sensing.hpp"
+#include "gtest/gtest.h"
+
+#include <type_traits>
+
+// Proves the universe symbols are re-exports of the canonical core types, not
+// redefinitions: consumers see one definition, one version authority (R-IF-12).
+TEST(sensing_universe, reexports_core)
+{
+  namespace core = autoware::component_interface_specs::sensing;
+  namespace universe = autoware::component_interface_specs_universe::sensing;
+  static_assert(
+    std::is_same_v<universe::VehicleVelocityConverterTwist, core::VehicleVelocityConverterTwist>);
+  SUCCEED();
+}
+
+TEST(sensing, interface)
+{
+  {
+    using autoware::component_interface_specs_universe::sensing::VehicleVelocityConverterTwist;
+    VehicleVelocityConverterTwist twist;
+    size_t depth = 1;
+    EXPECT_EQ(twist.depth, depth);
+    EXPECT_EQ(twist.reliability, RMW_QOS_POLICY_RELIABILITY_RELIABLE);
+    EXPECT_EQ(twist.durability, RMW_QOS_POLICY_DURABILITY_VOLATILE);
+  }
+}

--- a/common/autoware_component_interface_specs_universe/test/test_sensing.cpp
+++ b/common/autoware_component_interface_specs_universe/test/test_sensing.cpp
@@ -19,7 +19,7 @@
 #include <type_traits>
 
 // Proves the universe symbols are re-exports of the canonical core types, not
-// redefinitions: consumers see one definition, one version authority (R-IF-12).
+// redefinitions: consumers see one definition, one version authority.
 TEST(sensing_universe, reexports_core)
 {
   namespace core = autoware::component_interface_specs::sensing;

--- a/common/autoware_component_interface_specs_universe/test/test_sensing.cpp
+++ b/common/autoware_component_interface_specs_universe/test/test_sensing.cpp
@@ -34,7 +34,7 @@ TEST(sensing, interface)
   {
     using autoware::component_interface_specs_universe::sensing::VehicleVelocityConverterTwist;
     VehicleVelocityConverterTwist twist;
-    size_t depth = 1;
+    size_t depth = 10;
     EXPECT_EQ(twist.depth, depth);
     EXPECT_EQ(twist.reliability, RMW_QOS_POLICY_RELIABILITY_RELIABLE);
     EXPECT_EQ(twist.durability, RMW_QOS_POLICY_DURABILITY_VOLATILE);

--- a/common/autoware_component_interface_specs_universe/test/test_system.cpp
+++ b/common/autoware_component_interface_specs_universe/test/test_system.cpp
@@ -19,7 +19,7 @@
 #include <type_traits>
 
 // Proves the universe symbols are re-exports of the canonical core types, not
-// redefinitions: consumers see one definition, one version authority (R-IF-12).
+// redefinitions: consumers see one definition, one version authority.
 // MrmState was promoted universe -> core; this asserts the identity survives.
 TEST(system_universe, reexports_core)
 {

--- a/common/autoware_component_interface_specs_universe/test/test_system.cpp
+++ b/common/autoware_component_interface_specs_universe/test/test_system.cpp
@@ -12,8 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "autoware/component_interface_specs/system.hpp"
 #include "autoware/component_interface_specs_universe/system.hpp"
 #include "gtest/gtest.h"
+
+#include <type_traits>
+
+// Proves the universe symbols are re-exports of the canonical core types, not
+// redefinitions: consumers see one definition, one version authority (R-IF-12).
+// MrmState was promoted universe -> core; this asserts the identity survives.
+TEST(system_universe, reexports_core)
+{
+  namespace core = autoware::component_interface_specs::system;
+  namespace universe = autoware::component_interface_specs_universe::system;
+  static_assert(std::is_same_v<universe::MrmState, core::MrmState>);
+  static_assert(std::is_same_v<universe::ChangeOperationMode, core::ChangeOperationMode>);
+  SUCCEED();
+}
 
 TEST(system, interface)
 {

--- a/common/autoware_component_interface_specs_universe/test/test_vehicle.cpp
+++ b/common/autoware_component_interface_specs_universe/test/test_vehicle.cpp
@@ -19,7 +19,7 @@
 #include <type_traits>
 
 // Proves the universe symbols are re-exports of the canonical core types, not
-// redefinitions: consumers see one definition, one version authority (R-IF-12).
+// redefinitions: consumers see one definition, one version authority.
 TEST(vehicle_universe, reexports_core)
 {
   namespace core = autoware::component_interface_specs::vehicle;

--- a/common/autoware_component_interface_specs_universe/test/test_vehicle.cpp
+++ b/common/autoware_component_interface_specs_universe/test/test_vehicle.cpp
@@ -12,8 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "autoware/component_interface_specs/vehicle.hpp"
 #include "autoware/component_interface_specs_universe/vehicle.hpp"
 #include "gtest/gtest.h"
+
+#include <type_traits>
+
+// Proves the universe symbols are re-exports of the canonical core types, not
+// redefinitions: consumers see one definition, one version authority (R-IF-12).
+TEST(vehicle_universe, reexports_core)
+{
+  namespace core = autoware::component_interface_specs::vehicle;
+  namespace universe = autoware::component_interface_specs_universe::vehicle;
+  static_assert(std::is_same_v<universe::VelocityStatus, core::VelocityStatus>);
+  static_assert(std::is_same_v<universe::SteeringStatus, core::SteeringStatus>);
+  SUCCEED();
+}
 
 TEST(vehicle, interface)
 {


### PR DESCRIPTION
## Description

This PR makes `autoware_component_interface_specs` (core) the single definition and version authority for the shared component interface specs, and converts `autoware_component_interface_specs_universe` into a set of re-export shims (`using`-declarations) of the core symbols; before this change the two packages held duplicate struct definitions of the same cross-container boundaries, and this collapses that duplication down to one source of truth (core) while keeping universe as a thin compatibility surface.

Every core-authoritative struct that this package previously duplicated is deleted and replaced with a `using`-declaration aliasing the core type, so the type identity is preserved: existing universe consumers keep compiling unchanged and now resolve the canonical core type; this change is transparent to existing consumers, no call sites, includes, or namespaces need to change.

This branch builds and its tests pass in full against core `main` (tip `1d0af16c`, which now carries all eight registered per-domain specs, including `sensing.hpp`): **57 tests, 0 errors, 0 failures, 17 skipped**, covering every domain's alias-identity assertions and every domain's QoS-field assertions.

The `control`, `map`, `perception`, and `vehicle` shims alias every spec core registers in those domains, including the four core added most recently (`control::ControlModeRequest`, `control::PredictedTrajectory`, `map::GetPartialPointCloudMap`, `vehicle::ControlModeStatus`) and `perception::TrackedObjects`, which core has had for longer; earlier revisions of this branch missed all five. Neither `HazardStatus` nor `PointCloudMap` gets a re-export alias, and those two are now the only omissions: core's system domain no longer defines `HazardStatus` — `/system/emergency/hazard_status` was removed from the spec set because it has no OSS consumers — and no universe code consumed the old alias either. `PointCloudMap`'s spec (`/map/point_cloud_map`) is a never-published topic with no in-tree universe consumer, and core already excludes it from the versioned `Specs` tuple as a raw, high-bandwidth interface. Both omissions are recorded directly in the header comments.

The tier4-vendor-typed structs are unchanged and stay in this package exactly as before, unversioned: `control` keeps `ActuationCommand`, `SetPause`, `IsPaused`, `IsStartRequested`, `SetStop`, `IsStopped`; `vehicle` keeps `EnergyStatus`, `DoorCommand`, `DoorLayout`, `DoorStatus`. None of these are registered in the core `Specs` tuples.

`package.xml` gains a single `<depend>autoware_component_interface_specs</depend>` so the shims can see the core package; the seven message-package dependencies whose last direct includes this change removed (`autoware_localization_msgs`, `autoware_map_msgs`, `autoware_perception_msgs`, `autoware_planning_msgs`, `autoware_system_msgs`, `autoware_vehicle_msgs`, `nav_msgs`) are dropped from `package.xml` too, since core already depends on them and re-exports that dependency to this package's consumers; no other dependency was added or is otherwise affected.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware/issues/7210

## How was this PR tested?

Built and tested in the `autoware:universe-devel-jazzy` container with this package's `common/autoware_component_interface_specs_universe` and core's `common/autoware_component_interface_specs` (from core `main`, tip `1d0af16c`) both mounted into a fresh `colcon` workspace, so the build resolves the branch's own headers instead of the devel image's pre-installed `/opt/autoware` copy of the specs package -- an artifact of when that image was built, not of any repository pin, and old enough (`package.xml` version `1.8.0`) to predate `version.hpp`/`concepts.hpp`/`sensing.hpp` entirely (confirmed by three independent checks: the underlay has no `sensing.hpp`/`version.hpp`/`concepts.hpp` at all; those files were installed into `install/` from the mounted sources; and `$AMENT_PREFIX_PATH` resolves the workspace install ahead of `/opt/autoware`): `colcon build --packages-up-to autoware_component_interface_specs_universe --cmake-args -DBUILD_TESTING=ON` succeeds (exit 0), then `colcon test --packages-select autoware_component_interface_specs_universe --event-handlers console_cohesion+` and `colcon test-result --verbose` report **100% tests passed, 0 tests failed out of 5, and 57 tests, 0 errors, 0 failures, 17 skipped overall** — the gtest binary (16 sub-tests across all eight domains' alias-identity and QoS-field assertions), copyright, cppcheck, lint_cmake, and xmllint all pass. `pre-commit run --files ...` is clean on every changed file.

The two `fix(...)` commits on this branch come from that same build: it caught an alias to a `DetectedObjects` symbol that core's perception spec has never defined, and a `test_sensing.cpp` assertion pinned to this package's old local QoS depth (1) rather than core's `VehicleVelocityConverterTwist::depth` (10). The result above is from the branch tip, with both corrected.

## Notes for reviewers

`core/autoware_core` is not pinned to a release anywhere in this repository's CI. `build_depends_stable.repos` carries no `core/*` entries at all; its own header says core packages are provided pre-built by the CI Docker image and that adding a repository pin here would cause redundant rebuilds. The only place `core/autoware_core` is pinned is `build_depends_nightly.repos`, at `main`, and every workflow that builds a `main`-based PR (`build-and-test-differential`, `build-and-test-packages-above-differential`, and the reusable `main`-branch build) combines that overlay in before building; the plain `build_depends_stable.repos` copy is used only for PRs based on the `humble`/`jazzy` release branches, which this PR's base (`main`) is not.

So this PR's CI already source-builds `core/autoware_core` at `main` -- the same core commit this branch was tested against above -- and at head `870e84d3`, `build-and-test-differential` is green on both `humble` and `jazzy`. There is no remaining core-side dependency blocking this PR.

## Interface changes

None. Type identities are preserved via using-declarations.

## Effects on system behavior

None: there is no QoS, topic-name, or service-name change to any live wire, and existing consumers resolve the same canonical types they did before.
