### PR TITLE
refactor(autoware_mission_planner_universe): templatize planner plugin on node type

### DIFF
--- a/planning/autoware_mission_planner_universe/include/autoware/mission_planner_universe/mission_planner_plugin.hpp
+++ b/planning/autoware_mission_planner_universe/include/autoware/mission_planner_universe/mission_planner_plugin.hpp
@@ -28,7 +28,12 @@
 namespace autoware::mission_planner_universe
 {
 
-class PlannerPlugin
+/// @brief Interface of the mission planner plugins.
+/// @tparam NodeT type of the node the plugin is initialized with. Each instantiation is an
+/// independent pluginlib base class, so the same plugin implementation can be exported for several
+/// node types.
+template <typename NodeT>
+class PlannerPluginT
 {
 public:
   using RoutePoints = std::vector<geometry_msgs::msg::Pose>;
@@ -36,9 +41,9 @@ public:
   using LaneletMapBin = autoware_map_msgs::msg::LaneletMapBin;
   using MarkerArray = visualization_msgs::msg::MarkerArray;
 
-  virtual ~PlannerPlugin() = default;
-  virtual void initialize(rclcpp::Node * node) = 0;
-  virtual void initialize(rclcpp::Node * node, const LaneletMapBin::ConstSharedPtr msg) = 0;
+  virtual ~PlannerPluginT() = default;
+  virtual void initialize(NodeT * node) = 0;
+  virtual void initialize(NodeT * node, const LaneletMapBin::ConstSharedPtr msg) = 0;
   virtual bool ready() const = 0;
   virtual LaneletRoute plan(const RoutePoints & points) = 0;
   virtual MarkerArray visualize(
@@ -47,6 +52,8 @@ public:
   virtual void clearRoute() = 0;
   virtual const autoware::route_handler::RouteHandler & getRouteHandler() const = 0;
 };
+
+using PlannerPlugin = PlannerPluginT<rclcpp::Node>;
 
 }  // namespace autoware::mission_planner_universe
 

--- a/planning/autoware_mission_planner_universe/src/lanelet2_plugins/default_planner.cpp
+++ b/planning/autoware_mission_planner_universe/src/lanelet2_plugins/default_planner.cpp
@@ -88,51 +88,60 @@ bool hasDirectionChangeTag(const lanelet::ConstLanelet & lanelet)
 }
 }  // namespace
 
-void DefaultPlanner::initialize_common(rclcpp::Node * node)
+template <typename NodeT>
+void DefaultPlannerT<NodeT>::initialize_common(NodeT * node)
 {
   is_graph_ready_ = false;
   node_ = node;
 
   const auto durable_qos = rclcpp::QoS(1).transient_local();
   pub_goal_footprint_marker_ =
-    node_->create_publisher<MarkerArray>("~/debug/goal_footprint", durable_qos);
+    node_->template create_publisher<MarkerArray>("~/debug/goal_footprint", durable_qos);
 
   vehicle_info_ = autoware::vehicle_info_utils::VehicleInfoUtils(*node_).getVehicleInfo();
-  param_.goal_angle_threshold_deg = node_->declare_parameter<double>("goal_angle_threshold_deg");
-  param_.enable_correct_goal_pose = node_->declare_parameter<bool>("enable_correct_goal_pose");
-  param_.consider_no_drivable_lanes = node_->declare_parameter<bool>("consider_no_drivable_lanes");
+  param_.goal_angle_threshold_deg =
+    node_->template declare_parameter<double>("goal_angle_threshold_deg");
+  param_.enable_correct_goal_pose =
+    node_->template declare_parameter<bool>("enable_correct_goal_pose");
+  param_.consider_no_drivable_lanes =
+    node_->template declare_parameter<bool>("consider_no_drivable_lanes");
   param_.check_footprint_inside_lanes =
-    node_->declare_parameter<bool>("check_footprint_inside_lanes");
-  param_.allow_area = node_->declare_parameter<bool>("allow_area", false);
+    node_->template declare_parameter<bool>("check_footprint_inside_lanes");
+  param_.allow_area = node_->template declare_parameter<bool>("allow_area", false);
   route_handler_.setAllowArea(param_.allow_area);
 }
 
-void DefaultPlanner::initialize(rclcpp::Node * node)
+template <typename NodeT>
+void DefaultPlannerT<NodeT>::initialize(NodeT * node)
 {
   initialize_common(node);
-  map_subscriber_ = node_->create_subscription<LaneletMapBin>(
+  map_subscriber_ = node_->template create_subscription<LaneletMapBin>(
     "~/input/vector_map", rclcpp::QoS{10}.transient_local(),
-    std::bind(&DefaultPlanner::map_callback, this, std::placeholders::_1));
+    [this](const LaneletMapBin & msg) { map_callback(msg); });
 }
 
-void DefaultPlanner::initialize(rclcpp::Node * node, const LaneletMapBin::ConstSharedPtr msg)
+template <typename NodeT>
+void DefaultPlannerT<NodeT>::initialize(NodeT * node, const LaneletMapBin::ConstSharedPtr msg)
 {
   initialize_common(node);
-  map_callback(msg);
+  map_callback(*msg);
 }
 
-bool DefaultPlanner::ready() const
+template <typename NodeT>
+bool DefaultPlannerT<NodeT>::ready() const
 {
   return is_graph_ready_;
 }
 
-void DefaultPlanner::map_callback(const LaneletMapBin::ConstSharedPtr msg)
+template <typename NodeT>
+void DefaultPlannerT<NodeT>::map_callback(const LaneletMapBin & msg)
 {
-  route_handler_.setMap(*msg);
+  route_handler_.setMap(msg);
   is_graph_ready_ = true;
 }
 
-PlannerPlugin::MarkerArray DefaultPlanner::visualize(
+template <typename NodeT>
+typename DefaultPlannerT<NodeT>::MarkerArray DefaultPlannerT<NodeT>::visualize(
   const LaneletRoute & route, float goal_lanelet_transparency) const
 {
   lanelet::ConstLanelets route_lanelets;
@@ -209,7 +218,8 @@ PlannerPlugin::MarkerArray DefaultPlanner::visualize(
   return route_marker_array;
 }
 
-visualization_msgs::msg::MarkerArray DefaultPlanner::visualize_debug_footprint(
+template <typename NodeT>
+visualization_msgs::msg::MarkerArray DefaultPlannerT<NodeT>::visualize_debug_footprint(
   autoware_utils::LinearRing2d goal_footprint)
 {
   visualization_msgs::msg::MarkerArray msg;
@@ -238,7 +248,8 @@ visualization_msgs::msg::MarkerArray DefaultPlanner::visualize_debug_footprint(
   return msg;
 }
 
-bool DefaultPlanner::check_goal_footprint_inside_lanes(
+template <typename NodeT>
+bool DefaultPlannerT<NodeT>::check_goal_footprint_inside_lanes(
   const lanelet::ConstLanelets & lanelets_near_goal,
   const autoware_utils::Polygon2d & goal_footprint) const
 {
@@ -278,7 +289,8 @@ bool DefaultPlanner::check_goal_footprint_inside_lanes(
   return boost::geometry::covered_by(goal_footprint, lane_polygon);
 }
 
-bool DefaultPlanner::is_goal_valid(const geometry_msgs::msg::Pose & goal)
+template <typename NodeT>
+bool DefaultPlannerT<NodeT>::is_goal_valid(const geometry_msgs::msg::Pose & goal)
 {
   const auto logger = node_->get_logger();
 
@@ -394,7 +406,9 @@ bool DefaultPlanner::is_goal_valid(const geometry_msgs::msg::Pose & goal)
   return is_in_parking_lot(parking_lots, goal_lanelet_pt);
 }
 
-PlannerPlugin::LaneletRoute DefaultPlanner::plan(const RoutePoints & points)
+template <typename NodeT>
+typename DefaultPlannerT<NodeT>::LaneletRoute DefaultPlannerT<NodeT>::plan(
+  const RoutePoints & points)
 {
   const auto logger = node_->get_logger();
 
@@ -502,7 +516,8 @@ PlannerPlugin::LaneletRoute DefaultPlanner::plan(const RoutePoints & points)
   return route_msg;
 }
 
-geometry_msgs::msg::Pose DefaultPlanner::refine_goal_height(
+template <typename NodeT>
+geometry_msgs::msg::Pose DefaultPlannerT<NodeT>::refine_goal_height(
   const Pose & goal, const RouteSections & route_sections)
 {
   const auto & pref = route_sections.back().preferred_primitive;
@@ -528,15 +543,19 @@ geometry_msgs::msg::Pose DefaultPlanner::refine_goal_height(
   return refined_goal;
 }
 
-void DefaultPlanner::updateRoute(const PlannerPlugin::LaneletRoute & route)
+template <typename NodeT>
+void DefaultPlannerT<NodeT>::updateRoute(const LaneletRoute & route)
 {
   route_handler_.setRoute(route);
 }
 
-void DefaultPlanner::clearRoute()
+template <typename NodeT>
+void DefaultPlannerT<NodeT>::clearRoute()
 {
   route_handler_.clearRoute();
 }
+
+template class DefaultPlannerT<rclcpp::Node>;
 
 }  // namespace autoware::mission_planner_universe::lanelet2
 

--- a/planning/autoware_mission_planner_universe/src/lanelet2_plugins/default_planner.hpp
+++ b/planning/autoware_mission_planner_universe/src/lanelet2_plugins/default_planner.hpp
@@ -28,6 +28,9 @@
 #include <lanelet2_routing/RoutingGraph.h>
 #include <lanelet2_traffic_rules/TrafficRulesFactory.h>
 
+#include <functional>
+#include <string>
+#include <utility>
 #include <vector>
 
 namespace autoware::mission_planner_universe::lanelet2
@@ -42,16 +45,26 @@ struct DefaultPlannerParameters
   bool allow_area;
 };
 
-class DefaultPlanner : public mission_planner_universe::PlannerPlugin
+/// @brief Lanelet2 based implementation of the mission planner plugin.
+/// @tparam NodeT type of the node the planner is initialized with. The publisher and subscription
+/// handle types are derived from NodeT, so the implementation is independent of the node type.
+template <typename NodeT>
+class DefaultPlannerT : public mission_planner_universe::PlannerPluginT<NodeT>
 {
 public:
-  DefaultPlanner() : vehicle_info_(), is_graph_ready_(false), param_(), node_(nullptr) {}
+  // Redeclared as non-dependent types so that they can be used without `typename`.
+  using RoutePoints = std::vector<geometry_msgs::msg::Pose>;
+  using LaneletRoute = autoware_planning_msgs::msg::LaneletRoute;
+  using LaneletMapBin = autoware_map_msgs::msg::LaneletMapBin;
+  using MarkerArray = visualization_msgs::msg::MarkerArray;
 
-  void initialize(rclcpp::Node * node) override;
-  void initialize(rclcpp::Node * node, const LaneletMapBin::ConstSharedPtr msg) override;
+  DefaultPlannerT() : vehicle_info_(), is_graph_ready_(false), param_(), node_(nullptr) {}
+
+  void initialize(NodeT * node) override;
+  void initialize(NodeT * node, const LaneletMapBin::ConstSharedPtr msg) override;
   [[nodiscard]] bool ready() const override;
   LaneletRoute plan(const RoutePoints & points) override;
-  void updateRoute(const PlannerPlugin::LaneletRoute & route) override;
+  void updateRoute(const LaneletRoute & route) override;
   void clearRoute() override;
   [[nodiscard]] MarkerArray visualize(
     const LaneletRoute & route, float goal_lanelet_transparency = 0.05) const override;
@@ -66,17 +79,25 @@ public:
 protected:
   using RouteSections = std::vector<autoware_planning_msgs::msg::LaneletSegment>;
   using Pose = geometry_msgs::msg::Pose;
+  using MapSubscriptionPtr =
+    decltype(std::declval<NodeT &>().template create_subscription<LaneletMapBin>(
+      std::declval<const std::string &>(), std::declval<const rclcpp::QoS &>(),
+      std::declval<std::function<void(const LaneletMapBin &)>>()));
+  using MarkerArrayPublisherPtr =
+    decltype(std::declval<NodeT &>().template create_publisher<MarkerArray>(
+      std::declval<const std::string &>(), std::declval<const rclcpp::QoS &>()));
+
   bool is_graph_ready_;
   autoware::route_handler::RouteHandler route_handler_;
 
   DefaultPlannerParameters param_;
 
-  rclcpp::Node * node_;
-  rclcpp::Subscription<LaneletMapBin>::SharedPtr map_subscriber_;
-  rclcpp::Publisher<MarkerArray>::SharedPtr pub_goal_footprint_marker_;
+  NodeT * node_;
+  MapSubscriptionPtr map_subscriber_;
+  MarkerArrayPublisherPtr pub_goal_footprint_marker_;
 
-  void initialize_common(rclcpp::Node * node);
-  void map_callback(const LaneletMapBin::ConstSharedPtr msg);
+  void initialize_common(NodeT * node);
+  void map_callback(const LaneletMapBin & msg);
 
   /**
    * @brief check if the goal_footprint is within the lanelets closest to the goal plus the
@@ -104,6 +125,8 @@ protected:
    */
   Pose refine_goal_height(const Pose & goal, const RouteSections & route_sections);
 };
+
+using DefaultPlanner = DefaultPlannerT<rclcpp::Node>;
 
 }  // namespace autoware::mission_planner_universe::lanelet2
 


### PR DESCRIPTION
## Description

Templatize the mission planner plugin interface on the node type it is initialized with, so that the same plugin implementation can be exported for more than one node type.

- `PlannerPlugin` -> `PlannerPluginT<NodeT>`, `DefaultPlanner` -> `DefaultPlannerT<NodeT>`. The publisher and subscription handle types are now derived from `NodeT` via `decltype`, and the map callback takes `const LaneletMapBin &` (accepted by any node type that supports const-ref subscription callbacks) instead of a node-type-specific smart pointer.
- `using PlannerPlugin = PlannerPluginT<rclcpp::Node>` and `using DefaultPlanner = DefaultPlannerT<rclcpp::Node>` keep the existing names, the pluginlib base class name, and the plugin lookup name unchanged, so users of the interface (`MissionPlanner`, and `autoware_static_centerline_generator` in `autoware_tools`) are unaffected.
- `DefaultPlannerT` is explicitly instantiated for `rclcpp::Node` in `default_planner.cpp`, so the implementation stays in the `.cpp` and only one instantiation is compiled.

Pure refactor, no behavior change.

Motivation: https://github.com/autowarefoundation/autoware_universe/pull/13057 migrates `MissionPlanner` to `autoware::agnocast_wrapper::Node`, which requires the plugin to be initialized with that node type. Changing the node type of the interface instead of templating it breaks `autoware_static_centerline_generator`, which loads this plugin with a plain `rclcpp::Node`. With this refactor, that PR can add a second instantiation (`PlannerPluginT<autoware::agnocast_wrapper::Node>`) and export it as an additional pluginlib base class, leaving the `rclcpp::Node` interface intact.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware/issues/7007

## How was this PR tested?

- `colcon build` + `colcon test` for `autoware_mission_planner_universe`: 82 tests, 0 failures (including `DefaultPlannerTest`, which initializes the planner with an `rclcpp::Node` and plans a route).
- Verified that the templated implementation is really node-type-agnostic by instantiating `DefaultPlannerT<autoware::agnocast_wrapper::Node>` in a scratch translation unit with `USE_AGNOCAST_ENABLED`; it compiles without changes to the implementation.

## Notes for reviewers

None.

## Interface changes

None. `PlannerPlugin`, `DefaultPlanner`, the pluginlib base class name and the plugin lookup name are unchanged.

## Effects on system behavior

None.
