### PR TITLE
ci: remove stale debian packages in build-and-test

### DIFF
--- a/.github/workflows/build-and-test-differential.yaml
+++ b/.github/workflows/build-and-test-differential.yaml
@@ -108,6 +108,29 @@ jobs:
         run: cp build_depends_stable.repos build_depends.repos
         shell: bash
 
+      - name: Remove released Debian packages of the source-built dependencies
+        if: ${{ steps.get-modified-packages.outputs.modified-packages != '' }}
+        run: |
+          ros_distro="${ROS_DISTRO:-${{ inputs.rosdistro }}}"
+          # colcon-build imports these into dependency_ws and builds them from source.
+          # Importing here as well makes the package list known before the build starts;
+          # the import inside the action then finds the repositories already in place.
+          mkdir -p dependency_ws
+          vcs import --recursive dependency_ws < build_depends.repos
+          for pkg_xml in $(find . -name package.xml); do
+            pkg_name=$(xmllint --xpath 'string(//package/name)' "$pkg_xml")
+            # The released Debian package installs the same headers under
+            # /opt/ros/$ROS_DISTRO/include, which is searched before the workspace include
+            # directory when packages above it are compiled. Leaving it in place lets a
+            # stale released header shadow the one just built from source.
+            deb_name="ros-${ros_distro}-${pkg_name//_/-}"
+            if dpkg-query -W -f='${Status}' "$deb_name" 2>/dev/null | grep -q '^install ok installed$'; then
+              echo "Removing $deb_name"
+              sudo dpkg --remove --force-depends "$deb_name"
+            fi
+          done
+        shell: bash
+
       - name: Build
         if: ${{ steps.get-modified-packages.outputs.modified-packages != '' }}
         uses: autowarefoundation/autoware-github-actions/colcon-build@v1

--- a/.github/workflows/build-and-test-reusable.yaml
+++ b/.github/workflows/build-and-test-reusable.yaml
@@ -129,6 +129,29 @@ jobs:
           overlay_file: build_depends_nightly.repos
           output_file: build_depends.repos
 
+      - name: Remove released Debian packages of the source-built dependencies
+        if: ${{ steps.get-modified-packages.outputs.modified-packages != '' }}
+        run: |
+          ros_distro="${ROS_DISTRO:-${{ inputs.rosdistro }}}"
+          # colcon-build imports these into dependency_ws and builds them from source.
+          # Importing here as well makes the package list known before the build starts;
+          # the import inside the action then finds the repositories already in place.
+          mkdir -p dependency_ws
+          vcs import --recursive dependency_ws < build_depends.repos
+          for pkg_xml in $(find . -name package.xml); do
+            pkg_name=$(xmllint --xpath 'string(//package/name)' "$pkg_xml")
+            # The released Debian package installs the same headers under
+            # /opt/ros/$ROS_DISTRO/include, which is searched before the workspace include
+            # directory when packages above it are compiled. Leaving it in place lets a
+            # stale released header shadow the one just built from source.
+            deb_name="ros-${ros_distro}-${pkg_name//_/-}"
+            if dpkg-query -W -f='${Status}' "$deb_name" 2>/dev/null | grep -q '^install ok installed$'; then
+              echo "Removing $deb_name"
+              sudo dpkg --remove --force-depends "$deb_name"
+            fi
+          done
+        shell: bash
+
       - name: Build
         if: ${{ steps.get-self-packages.outputs.self-packages != '' }}
         uses: autowarefoundation/autoware-github-actions/colcon-build@v1


### PR DESCRIPTION
## Description

As reported in https://github.com/autowarefoundation/autoware_universe/pull/13114, `build-and-test` and `build-and-test-differential` also fails.
This pull request adds a task to remove the matching Debian package for every package that is about to be built from source.

## Related links

- https://github.com/autowarefoundation/autoware_core/pull/1311
- https://github.com/autowarefoundation/autoware_core/pull/1311

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
