### PR TITLE
feat(MPC): add option to get feed-forward steering from input trajectory

### DIFF
--- a/control/autoware_mpc_lateral_controller/README.md
+++ b/control/autoware_mpc_lateral_controller/README.md
@@ -63,6 +63,37 @@ enough.
 The moving average filter for example is not suited and can yield worse results than without any
 filtering.
 
+### Trajectory steering feed-forward
+
+In temporal trajectory-reference mode, the controller can use the trajectory point's
+`front_wheel_angle_rad` as the steering feed-forward reference. This avoids reconstructing
+feed-forward steering from spatial derivatives of a time-sampled trajectory when the trajectory
+generator already provides a dynamically consistent steering state.
+
+Enable this behavior with:
+
+```yaml
+use_trajectory_steering_for_feedforward: true
+```
+
+The parameter enables an availability check for each complete received trajectory:
+
+- If at least one `front_wheel_angle_rad` has an absolute value greater than `1.0e-6 rad`, the
+  controller treats the steering field as populated. It temporally interpolates the field at the
+  MPC prediction timestamps and uses it to construct the feed-forward input.
+- If all steering values are effectively zero, the controller uses the smoothed geometric
+  curvature to calculate feed-forward steering.
+- The source is selected once for the complete received trajectory. It does not switch between
+  trajectory steering and geometric curvature at individual zero-steering points.
+
+This feature affects only temporal trajectory-reference mode. Spatial mode continues to use
+geometric curvature. Geometric curvature also remains in use for vehicle-model linearization,
+curvature-dependent weights, steering-rate limits, and diagnostics.
+
+The trajectory producer must ensure that `front_wheel_angle_rad` represents the front tire steering
+state at the corresponding `time_from_start`. Supplying default zeros on a curved trajectory causes
+the controller to fall back to geometric feed-forward.
+
 ## Assumptions / Known limits
 
 <!-- Required -->

--- a/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/mpc.hpp
+++ b/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/mpc.hpp
@@ -238,6 +238,8 @@ private:
   double m_yaw_error_prev = 0.0;       // Previous heading error for derivative calculation.
 
   bool m_is_forward_shift = true;  // Flag indicating if the shift is in the forward direction.
+  bool m_reference_trajectory_has_steering =
+    false;  // True when the complete received trajectory contains a nonzero steering state.
   std::optional<double> m_prev_nearest_time{};  // Stabilized nearest trajectory time.
 
   rclcpp::Publisher<Trajectory>::SharedPtr m_debug_frenet_predicted_trajectory_pub;
@@ -464,6 +466,9 @@ public:
 
   bool m_use_temporal_trajectory =
     false;  // Flag to use temporal trajectory mode (true: use timestamps, false: spatial)
+
+  bool m_use_trajectory_steering_for_feedforward =
+    false;  // Prefer temporal trajectory steering when the received field is populated.
 
   bool m_publish_debug_trajectories = false;  // Flag to publish predicted trajectory and
                                               // resampled reference trajectory for debug purpose

--- a/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/mpc_trajectory.hpp
+++ b/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/mpc_trajectory.hpp
@@ -41,6 +41,7 @@ public:
   double vx;
   double k;
   double smooth_k;
+  double steer;
   double relative_time;
 };
 
@@ -58,6 +59,7 @@ public:
   std::vector<double> vx;             //!< @brief vx velocity vx vector
   std::vector<double> k;              //!< @brief k curvature k vector
   std::vector<double> smooth_k;       //!< @brief k smoothed-curvature k vector
+  std::vector<double> steer;          //!< @brief trajectory steering state vector
   std::vector<double> relative_time;  //!< @brief relative_time duration time from start point
 
   /**
@@ -66,6 +68,14 @@ public:
   void push_back(
     const double & xp, const double & yp, const double & zp, const double & yawp,
     const double & vxp, const double & kp, const double & smooth_kp, const double & tp);
+
+  /**
+   * @brief push_back for all values, including the trajectory steering state
+   */
+  void push_back(
+    const double & xp, const double & yp, const double & zp, const double & yawp,
+    const double & vxp, const double & kp, const double & smooth_kp, const double & steerp,
+    const double & tp);
 
   /**
    * @brief push_back for all values
@@ -122,6 +132,7 @@ public:
       point.pose.position.z = z.at(i);
       point.pose.orientation = autoware_utils::create_quaternion_from_yaw(yaw.at(i));
       point.longitudinal_velocity_mps = vx.at(i);
+      point.front_wheel_angle_rad = steer.at(i);
       points.push_back(point);
     }
     return points;

--- a/control/autoware_mpc_lateral_controller/param/lateral_controller_defaults.param.yaml
+++ b/control/autoware_mpc_lateral_controller/param/lateral_controller_defaults.param.yaml
@@ -4,6 +4,9 @@
     traj_resample_dist: 0.1         # path resampling interval [m]
     use_steer_prediction: false     # flag for using steer prediction (do not use steer measurement)
     use_delayed_initial_state: true # flag to use x0_delayed as initial state for predicted trajectory
+    # Use temporal trajectory steering for Uref when at least one input steering value is nonzero.
+    use_trajectory_steering_for_feedforward: true
+    # NOTE: trajectory_reference_mode is now set at trajectory_follower_node level
     # This default file is for MPC-specific parameters only
 
     # -- path smoothing --

--- a/control/autoware_mpc_lateral_controller/schema/sub/system.json
+++ b/control/autoware_mpc_lateral_controller/schema/sub/system.json
@@ -26,6 +26,11 @@
           "description": "trajectory tracking mode: \"spatial\" (indexes the trajectory by distance) or \"temporal\" (uses the trajectory's time_from_start directly). Normally set once at the `autoware_trajectory_follower_node` level; declared here as well only as a fallback default for standalone use of this node.",
           "enum": ["spatial", "temporal"],
           "default": "spatial"
+        },
+        "use_trajectory_steering_for_feedforward": {
+          "type": "boolean",
+          "description": "in temporal mode, use trajectory steering for feed-forward when at least one input steering value is nonzero; otherwise use geometric curvature",
+          "default": true
         }
       },
       "required": [

--- a/control/autoware_mpc_lateral_controller/src/mpc.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc.cpp
@@ -246,8 +246,8 @@ Float32MultiArrayStamped MPC::generateDiagData(
   append_diag(wz_command);                           // [11] angular velocity from steer command
   append_diag(wz_measured);                          // [12] angular velocity from measured steer
   append_diag(current_velocity * nearest_smooth_k);  // [13] angular velocity from path curvature
-  append_diag(nearest_smooth_k);          // [14] nearest path curvature (used for feed-forward)
-  append_diag(nearest_k);                 // [15] nearest path curvature (not smoothed)
+  append_diag(nearest_smooth_k);  // [14] nearest smoothed path curvature (geometric feed-forward)
+  append_diag(nearest_k);         // [15] nearest path curvature (not smoothed)
   append_diag(mpc_data.predicted_steer);  // [16] predicted steer
   append_diag(wz_predicted);              // [17] angular velocity from predicted steer
   append_diag(iteration_num);             // [18] iteration number
@@ -361,6 +361,13 @@ void MPC::setReferenceTrajectory(
   mpc_traj_smoothed.stamp = trajectory_msg.header.stamp;
 
   m_reference_trajectory = mpc_traj_smoothed;
+  constexpr double steering_availability_threshold = 1.0e-6;
+  m_reference_trajectory_has_steering = std::any_of(
+    trajectory_msg.points.begin(), trajectory_msg.points.end(),
+    [steering_availability_threshold](const auto & point) {
+      return std::abs(static_cast<double>(point.front_wheel_angle_rad)) >
+             steering_availability_threshold;
+    });
 }
 
 void MPC::resetPrevResult(const SteeringReport & current_steer)
@@ -733,9 +740,19 @@ MPCMatrix MPC::generateMPCMatrix(
     m.Qex.block(idx_y_i, idx_y_i, DIM_Y, DIM_Y) = Q_adaptive;
     m.R1ex.block(idx_u_i, idx_u_i, DIM_U, DIM_U) = R_adaptive;
 
-    // get reference input (feed-forward)
-    m_vehicle_model_ptr->setCurvature(ref_smooth_k);
-    m_vehicle_model_ptr->calculateReferenceInput(Uref);
+    // Get reference input (feed-forward). Temporal trajectories may provide a steering state
+    // directly, avoiding numerical spatial derivatives of a time-sampled path. Geometric
+    // curvature remains in use for model linearization, weights, and the default fallback.
+    const double trajectory_steer = reference_trajectory.steer.at(i);
+    if (
+      m_use_temporal_trajectory && m_use_trajectory_steering_for_feedforward &&
+      m_reference_trajectory_has_steering && std::isfinite(trajectory_steer)) {
+      Uref.setZero();
+      Uref(0, 0) = std::clamp(trajectory_steer, -m_steer_lim, m_steer_lim);
+    } else {
+      m_vehicle_model_ptr->setCurvature(ref_smooth_k);
+      m_vehicle_model_ptr->calculateReferenceInput(Uref);
+    }
     if (std::fabs(Uref(0, 0)) < autoware_utils::deg2rad(m_param.zero_ff_steer_deg)) {
       Uref(0, 0) = 0.0;  // ignore curvature noise
     }

--- a/control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp
@@ -162,6 +162,8 @@ MpcLateralController::MpcLateralController(
     throw std::invalid_argument(
       "Invalid trajectory_reference_mode. Expected \"spatial\" or \"temporal\".");
   }
+  m_mpc->m_use_trajectory_steering_for_feedforward =
+    dp_bool("use_trajectory_steering_for_feedforward");
 
   m_mpc->m_publish_debug_trajectories = dp_bool("publish_debug_trajectories");
 

--- a/control/autoware_mpc_lateral_controller/src/mpc_trajectory.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc_trajectory.cpp
@@ -22,6 +22,13 @@ void MPCTrajectory::push_back(
   const double & xp, const double & yp, const double & zp, const double & yawp, const double & vxp,
   const double & kp, const double & smooth_kp, const double & tp)
 {
+  push_back(xp, yp, zp, yawp, vxp, kp, smooth_kp, 0.0, tp);
+}
+
+void MPCTrajectory::push_back(
+  const double & xp, const double & yp, const double & zp, const double & yawp, const double & vxp,
+  const double & kp, const double & smooth_kp, const double & steerp, const double & tp)
+{
   x.push_back(xp);
   y.push_back(yp);
   z.push_back(zp);
@@ -29,6 +36,7 @@ void MPCTrajectory::push_back(
   vx.push_back(vxp);
   k.push_back(kp);
   smooth_k.push_back(smooth_kp);
+  steer.push_back(steerp);
   relative_time.push_back(tp);
 }
 
@@ -41,6 +49,7 @@ void MPCTrajectory::push_back(const MPCTrajectoryPoint & p)
   vx.push_back(p.vx);
   k.push_back(p.k);
   smooth_k.push_back(p.smooth_k);
+  steer.push_back(p.steer);
   relative_time.push_back(p.relative_time);
 }
 
@@ -55,6 +64,7 @@ MPCTrajectoryPoint MPCTrajectory::back()
   p.vx = vx.back();
   p.k = k.back();
   p.smooth_k = smooth_k.back();
+  p.steer = steer.back();
   p.relative_time = relative_time.back();
 
   return p;
@@ -71,6 +81,7 @@ MPCTrajectoryPoint MPCTrajectory::at(const size_t i) const
   p.vx = vx.at(i);
   p.k = k.at(i);
   p.smooth_k = smooth_k.at(i);
+  p.steer = steer.at(i);
   p.relative_time = relative_time.at(i);
 
   return p;
@@ -85,6 +96,7 @@ void MPCTrajectory::clear()
   vx.clear();
   k.clear();
   smooth_k.clear();
+  steer.clear();
   relative_time.clear();
 }
 
@@ -93,7 +105,7 @@ size_t MPCTrajectory::size() const
   if (
     x.size() == y.size() && x.size() == z.size() && x.size() == yaw.size() &&
     x.size() == vx.size() && x.size() == k.size() && x.size() == smooth_k.size() &&
-    x.size() == relative_time.size()) {
+    x.size() == steer.size() && x.size() == relative_time.size()) {
     return x.size();
   } else {
     std::cerr << "[MPC trajectory] trajectory size is inappropriate" << std::endl;

--- a/control/autoware_mpc_lateral_controller/src/mpc_utils.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc_utils.cpp
@@ -21,6 +21,7 @@
 #include "autoware_utils/math/normalization.hpp"
 
 #include <algorithm>
+#include <cmath>
 #include <iostream>
 #include <limits>
 #include <string>
@@ -170,6 +171,7 @@ std::pair<bool, MPCTrajectory> resampleMPCTrajectoryByDistance(
   output.yaw = spline_arc_length(input_yaw);
   output.vx = lerp_arc_length(input.vx);  // must be linear
   output.k = spline_arc_length(input.k);
+  output.steer = lerp_arc_length(input.steer);
   output.smooth_k = spline_arc_length(input.smooth_k);
   output.relative_time = lerp_arc_length(input.relative_time);  // must be linear
 
@@ -200,6 +202,7 @@ bool linearInterpMPCTrajectory(
     out_traj.vx = lerp_arc_length(in_traj.vx);
     out_traj.k = lerp_arc_length(in_traj.k);
     out_traj.smooth_k = lerp_arc_length(in_traj.smooth_k);
+    out_traj.steer = lerp_arc_length(in_traj.steer);
     out_traj.relative_time = lerp_arc_length(in_traj.relative_time);
   } catch (const std::exception & e) {
     std::cerr << "linearInterpMPCTrajectory error!: " << e.what() << std::endl;
@@ -345,6 +348,7 @@ void calcTrajectoryCurvatureBySpatialResample(
   spatial_traj.vx.resize(n, 0.0);
   spatial_traj.k.resize(n, 0.0);
   spatial_traj.smooth_k.resize(n, 0.0);
+  spatial_traj.steer.resize(n, 0.0);
   spatial_traj.relative_time.resize(n, 0.0);
 
   // 5. Calculate curvature on the spatially uniform trajectory
@@ -444,13 +448,14 @@ MPCTrajectory convertToMPCTrajectory(const Trajectory & input, const bool use_te
     const double z = p.pose.position.z;
     const double yaw = tf2::getYaw(p.pose.orientation);
     const double vx = p.longitudinal_velocity_mps;
+    const double steer = p.front_wheel_angle_rad;
     const double k = 0.0;
 
     // Time handling: temporal (use timestamps) vs spatial (calculate from distance/velocity)
     const double t = use_temporal_trajectory
                        ? rclcpp::Duration(p.time_from_start).seconds()
                        : 0.0;  // Will be recalculated by calcMPCTrajectoryTime()
-    output.push_back(x, y, z, yaw, vx, k, k, t);
+    output.push_back(x, y, z, yaw, vx, k, k, steer, t);
   }
 
   if (!use_temporal_trajectory) {
@@ -475,6 +480,8 @@ Trajectory convertToAutowareTrajectory(const MPCTrajectory & input, const double
       rclcpp::Duration::from_seconds(input.relative_time.at(i) - input.relative_time.front());
     if (wheelbase != 0.0) {
       p.front_wheel_angle_rad = static_cast<float>(std::atan(input.smooth_k.at(i) * wheelbase));
+    } else if (std::isfinite(input.steer.at(i))) {
+      p.front_wheel_angle_rad = static_cast<float>(input.steer.at(i));
     }
     output.points.push_back(p);
     if (output.points.size() == output.points.max_size()) {
@@ -707,7 +714,8 @@ void extendTrajectoryInYawDirection(
     extended_pose = autoware_utils::calc_offset_pose(extended_pose, x_offset, 0.0, 0.0);
     traj.push_back(
       extended_pose.position.x, extended_pose.position.y, extended_pose.position.z, traj.yaw.back(),
-      extend_vel, traj.k.back(), traj.smooth_k.back(), traj.relative_time.back() + dt);
+      extend_vel, traj.k.back(), traj.smooth_k.back(), traj.steer.back(),
+      traj.relative_time.back() + dt);
   }
 }
 

--- a/control/autoware_mpc_lateral_controller/test/test_mpc_utils.cpp
+++ b/control/autoware_mpc_lateral_controller/test/test_mpc_utils.cpp
@@ -74,13 +74,36 @@ TEST(TestMPC, ConvertToMPCTrajectoryTemporalUsesTimeFromStart)
   p0.time_from_start = rclcpp::Duration::from_seconds(0.0);
   p1.time_from_start = rclcpp::Duration::from_seconds(0.3);
   p2.time_from_start = rclcpp::Duration::from_seconds(0.8);
+  p0.front_wheel_angle_rad = 0.1F;
+  p1.front_wheel_angle_rad = 0.2F;
+  p2.front_wheel_angle_rad = 0.4F;
   trajectory_msg.points = {p0, p1, p2};
 
   const auto mpc_traj = MPCUtils::convertToMPCTrajectory(trajectory_msg, true);
   ASSERT_EQ(mpc_traj.relative_time.size(), 3UL);
+  ASSERT_EQ(mpc_traj.steer.size(), 3UL);
   EXPECT_DOUBLE_EQ(mpc_traj.relative_time.at(0), 0.0);
   EXPECT_DOUBLE_EQ(mpc_traj.relative_time.at(1), 0.3);
   EXPECT_DOUBLE_EQ(mpc_traj.relative_time.at(2), 0.8);
+  EXPECT_FLOAT_EQ(static_cast<float>(mpc_traj.steer.at(0)), 0.1F);
+  EXPECT_FLOAT_EQ(static_cast<float>(mpc_traj.steer.at(1)), 0.2F);
+  EXPECT_FLOAT_EQ(static_cast<float>(mpc_traj.steer.at(2)), 0.4F);
+}
+
+TEST(TestMPC, LinearInterpMPCTrajectoryInterpolatesSteering)
+{
+  using autoware::motion::control::mpc_lateral_controller::MPCTrajectory;
+
+  MPCTrajectory input;
+  input.push_back(0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.1, 0.0);
+  input.push_back(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.3, 1.0);
+
+  MPCTrajectory output;
+  ASSERT_TRUE(MPCUtils::linearInterpMPCTrajectory({0.0, 1.0}, input, {0.0, 0.5, 1.0}, output));
+  ASSERT_EQ(output.steer.size(), 3UL);
+  EXPECT_DOUBLE_EQ(output.steer.at(0), 0.1);
+  EXPECT_DOUBLE_EQ(output.steer.at(1), 0.2);
+  EXPECT_DOUBLE_EQ(output.steer.at(2), 0.3);
 }
 
 TEST(TestMPC, CalcNearestPoseInterpUsesTimeWindowCandidates)

--- a/control/autoware_trajectory_follower_node/param/lateral/mpc.param.yaml
+++ b/control/autoware_trajectory_follower_node/param/lateral/mpc.param.yaml
@@ -4,6 +4,8 @@
     traj_resample_dist: 0.1         # path resampling interval [m]
     use_steer_prediction: false     # flag for using steer prediction (do not use steer measurement)
     use_delayed_initial_state: true # flag to use x0_delayed as initial state for predicted trajectory
+    # Use temporal trajectory steering for Uref when at least one input steering value is nonzero.
+    use_trajectory_steering_for_feedforward: true
 
     # -- path smoothing --
     enable_path_smoothing: false   # flag for path smoothing


### PR DESCRIPTION
## Description

This PR adds the option to directly use steering values from the input trajectory message for its feed forward steering.
Requires https://github.com/autowarefoundation/autoware_launch/pull/1931

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Psim

## Notes for reviewers

None.

## Interface changes

None.

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added | `use_trajectory_steering_for_feedforward`   | `bool` | `false`         | Use temporal trajectory steering for Uref when at least one input steering value is nonzero |

## Effects on system behavior

None.
