### PR TITLE
chore(pre-commit): update clang-format to v22.1.5

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,7 +80,7 @@ repos:
         args: [--line-length=100]
 
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v21.1.8
+    rev: v22.1.5
     hooks:
       - id: clang-format
         types_or: [c++, c, cuda]

--- a/common/autoware_boundary_departure_checker/src/detail/boundary_segment_finder.cpp
+++ b/common/autoware_boundary_departure_checker/src/detail/boundary_segment_finder.cpp
@@ -142,8 +142,8 @@ std::vector<SegmentWithIdx> find_closest_boundary_segments(
 
     auto boundary_segment = utils::to_segment_2d(boundary_segment_3d);
 
-    if (is_closest_to_boundary_segment(
-          boundary_segment, ego_ref_segment, ego_opposite_ref_segment)) {
+    if (
+      is_closest_to_boundary_segment(boundary_segment, ego_ref_segment, ego_opposite_ref_segment)) {
       new_segments.emplace_back(boundary_segment, id);
     }
   }

--- a/common/autoware_deprecated_boundary_departure_checker/src/uncrossable_boundary_checker.cpp
+++ b/common/autoware_deprecated_boundary_departure_checker/src/uncrossable_boundary_checker.cpp
@@ -381,8 +381,8 @@ std::vector<SegmentWithIdx> UncrossableBoundaryDepartureChecker::find_closest_bo
 
     auto boundary_segment = utils::to_segment_2d(boundary_segment_3d);
 
-    if (is_closest_to_boundary_segment(
-          boundary_segment, ego_ref_segment, ego_opposite_ref_segment)) {
+    if (
+      is_closest_to_boundary_segment(boundary_segment, ego_ref_segment, ego_opposite_ref_segment)) {
       new_segments.emplace_back(boundary_segment, id);
     }
   }

--- a/common/autoware_polar_grid/src/polar_grid_display.cpp
+++ b/common/autoware_polar_grid/src/polar_grid_display.cpp
@@ -137,15 +137,17 @@ void PolarGridDisplay::update(float /*dt*/, float ros_dt)
 
   Ogre::Vector3 position;
   Ogre::Quaternion orientation;
-  if (context_->getFrameManager()->getTransform(
-        frame, rclcpp::Time(0, 0, context_->getClock()->get_clock_type()), position, orientation)) {
+  if (
+    context_->getFrameManager()->getTransform(
+      frame, rclcpp::Time(0, 0, context_->getClock()->get_clock_type()), position, orientation)) {
     scene_node_->setPosition(position);
     scene_node_->setOrientation(orientation);
     setStatus(rviz_common::properties::StatusProperty::Ok, "Transform", "Transform OK");
   } else {
     std::string error;
-    if (context_->getFrameManager()->transformHasProblems(
-          frame, rclcpp::Time(0, 0, context_->getClock()->get_clock_type()), error)) {
+    if (
+      context_->getFrameManager()->transformHasProblems(
+        frame, rclcpp::Time(0, 0, context_->getClock()->get_clock_type()), error)) {
       setStatus(
         rviz_common::properties::StatusProperty::Error, "Transform", QString::fromStdString(error));
     } else {

--- a/common/autoware_traffic_light_utils/src/traffic_light_utils.cpp
+++ b/common/autoware_traffic_light_utils/src/traffic_light_utils.cpp
@@ -68,9 +68,10 @@ bool isTrafficSignalStop(
   const autoware_perception_msgs::msg::TrafficLightGroup & tl_state)
 {
   const auto & elements = tl_state.elements;
-  if (hasTrafficLightShapeAndColor(
-        elements, autoware_perception_msgs::msg::TrafficLightElement::CIRCLE,
-        autoware_perception_msgs::msg::TrafficLightElement::GREEN)) {
+  if (
+    hasTrafficLightShapeAndColor(
+      elements, autoware_perception_msgs::msg::TrafficLightElement::CIRCLE,
+      autoware_perception_msgs::msg::TrafficLightElement::GREEN)) {
     return false;
   }
 

--- a/localization/yabloc/yabloc_pose_initializer/src/camera/camera_pose_initializer_core.cpp
+++ b/localization/yabloc/yabloc_pose_initializer/src/camera/camera_pose_initializer_core.cpp
@@ -133,9 +133,10 @@ std::optional<double> CameraPoseInitializer::estimate_pose(
   query_pose.position.z = position.z();
 
   std::optional<double> lane_angle_rad = std::nullopt;
-  if (const auto current_lanelet_opt =
-        autoware::experimental::lanelet2_utils::get_closest_lanelet(const_lanelets_, query_pose);
-      current_lanelet_opt) {
+  if (
+    const auto current_lanelet_opt =
+      autoware::experimental::lanelet2_utils::get_closest_lanelet(const_lanelets_, query_pose);
+    current_lanelet_opt) {
     lane_angle_rad = autoware::experimental::lanelet2_utils::get_lanelet_angle(
       current_lanelet_opt.value(),
       autoware::experimental::lanelet2_utils::from_ros(query_pose.position).basicPoint());

--- a/perception/autoware_compare_map_segmentation/lib/voxel_grid_map_loader.cpp
+++ b/perception/autoware_compare_map_segmentation/lib/voxel_grid_map_loader.cpp
@@ -125,156 +125,174 @@ bool VoxelGridMapLoader::is_close_to_neighbor_voxels(
   if (map == nullptr) {
     return false;
   }
-  if (is_in_voxel(
-        pcl::PointXYZ(point.x, point.y, point.z), point, distance_threshold, map, voxel)) {
+  if (
+    is_in_voxel(pcl::PointXYZ(point.x, point.y, point.z), point, distance_threshold, map, voxel)) {
     return true;
   }
-  if (is_in_voxel(
-        pcl::PointXYZ(point.x, point.y - distance_threshold, point.z - distance_threshold_z), point,
-        distance_threshold, map, voxel)) {
+  if (
+    is_in_voxel(
+      pcl::PointXYZ(point.x, point.y - distance_threshold, point.z - distance_threshold_z), point,
+      distance_threshold, map, voxel)) {
     return true;
   }
-  if (is_in_voxel(
-        pcl::PointXYZ(point.x, point.y - distance_threshold, point.z), point, distance_threshold,
-        map, voxel)) {
+  if (
+    is_in_voxel(
+      pcl::PointXYZ(point.x, point.y - distance_threshold, point.z), point, distance_threshold, map,
+      voxel)) {
     return true;
   }
-  if (is_in_voxel(
-        pcl::PointXYZ(point.x, point.y - distance_threshold, point.z + distance_threshold_z), point,
-        distance_threshold, map, voxel)) {
+  if (
+    is_in_voxel(
+      pcl::PointXYZ(point.x, point.y - distance_threshold, point.z + distance_threshold_z), point,
+      distance_threshold, map, voxel)) {
     return true;
   }
-  if (is_in_voxel(
-        pcl::PointXYZ(point.x, point.y, point.z - distance_threshold_z), point, distance_threshold,
-        map, voxel)) {
+  if (
+    is_in_voxel(
+      pcl::PointXYZ(point.x, point.y, point.z - distance_threshold_z), point, distance_threshold,
+      map, voxel)) {
     return true;
   }
-  if (is_in_voxel(
-        pcl::PointXYZ(point.x, point.y, point.z + distance_threshold_z), point, distance_threshold,
-        map, voxel)) {
+  if (
+    is_in_voxel(
+      pcl::PointXYZ(point.x, point.y, point.z + distance_threshold_z), point, distance_threshold,
+      map, voxel)) {
     return true;
   }
-  if (is_in_voxel(
-        pcl::PointXYZ(point.x, point.y + distance_threshold, point.z - distance_threshold_z), point,
-        distance_threshold, map, voxel)) {
+  if (
+    is_in_voxel(
+      pcl::PointXYZ(point.x, point.y + distance_threshold, point.z - distance_threshold_z), point,
+      distance_threshold, map, voxel)) {
     return true;
   }
-  if (is_in_voxel(
-        pcl::PointXYZ(point.x, point.y + distance_threshold, point.z), point, distance_threshold,
-        map, voxel)) {
+  if (
+    is_in_voxel(
+      pcl::PointXYZ(point.x, point.y + distance_threshold, point.z), point, distance_threshold, map,
+      voxel)) {
     return true;
   }
-  if (is_in_voxel(
-        pcl::PointXYZ(point.x, point.y + distance_threshold, point.z + distance_threshold_z), point,
-        distance_threshold, map, voxel)) {
-    return true;
-  }
-
-  if (is_in_voxel(
-        pcl::PointXYZ(
-          point.x - distance_threshold, point.y - distance_threshold,
-          point.z - distance_threshold_z),
-        point, distance_threshold, map, voxel)) {
-    return true;
-  }
-  if (is_in_voxel(
-        pcl::PointXYZ(point.x - distance_threshold, point.y - distance_threshold, point.z), point,
-        distance_threshold, map, voxel)) {
-    return true;
-  }
-  if (is_in_voxel(
-        pcl::PointXYZ(
-          point.x - distance_threshold, point.y - distance_threshold,
-          point.z + distance_threshold_z),
-        point, distance_threshold, map, voxel)) {
-    return true;
-  }
-  if (is_in_voxel(
-        pcl::PointXYZ(point.x - distance_threshold, point.y, point.z - distance_threshold_z), point,
-        distance_threshold, map, voxel)) {
-    return true;
-  }
-  if (is_in_voxel(
-        pcl::PointXYZ(point.x - distance_threshold, point.y, point.z), point, distance_threshold,
-        map, voxel)) {
-    return true;
-  }
-  if (is_in_voxel(
-        pcl::PointXYZ(point.x - distance_threshold, point.y, point.z + distance_threshold_z), point,
-        distance_threshold, map, voxel)) {
-    return true;
-  }
-  if (is_in_voxel(
-        pcl::PointXYZ(
-          point.x - distance_threshold, point.y + distance_threshold,
-          point.z - distance_threshold_z),
-        point, distance_threshold, map, voxel)) {
-    return true;
-  }
-  if (is_in_voxel(
-        pcl::PointXYZ(point.x - distance_threshold, point.y + distance_threshold, point.z), point,
-        distance_threshold, map, voxel)) {
-    return true;
-  }
-  if (is_in_voxel(
-        pcl::PointXYZ(
-          point.x - distance_threshold, point.y + distance_threshold,
-          point.z + distance_threshold_z),
-        point, distance_threshold, map, voxel)) {
+  if (
+    is_in_voxel(
+      pcl::PointXYZ(point.x, point.y + distance_threshold, point.z + distance_threshold_z), point,
+      distance_threshold, map, voxel)) {
     return true;
   }
 
-  if (is_in_voxel(
-        pcl::PointXYZ(
-          point.x + distance_threshold, point.y - distance_threshold,
-          point.z - distance_threshold_z),
-        point, distance_threshold, map, voxel)) {
+  if (
+    is_in_voxel(
+      pcl::PointXYZ(
+        point.x - distance_threshold, point.y - distance_threshold, point.z - distance_threshold_z),
+      point, distance_threshold, map, voxel)) {
     return true;
   }
-  if (is_in_voxel(
-        pcl::PointXYZ(point.x + distance_threshold, point.y - distance_threshold, point.z), point,
-        distance_threshold, map, voxel)) {
+  if (
+    is_in_voxel(
+      pcl::PointXYZ(point.x - distance_threshold, point.y - distance_threshold, point.z), point,
+      distance_threshold, map, voxel)) {
     return true;
   }
-  if (is_in_voxel(
-        pcl::PointXYZ(
-          point.x + distance_threshold, point.y - distance_threshold,
-          point.z + distance_threshold_z),
-        point, distance_threshold, map, voxel)) {
+  if (
+    is_in_voxel(
+      pcl::PointXYZ(
+        point.x - distance_threshold, point.y - distance_threshold, point.z + distance_threshold_z),
+      point, distance_threshold, map, voxel)) {
     return true;
   }
-  if (is_in_voxel(
-        pcl::PointXYZ(point.x + distance_threshold, point.y, point.z - distance_threshold_z), point,
-        distance_threshold, map, voxel)) {
+  if (
+    is_in_voxel(
+      pcl::PointXYZ(point.x - distance_threshold, point.y, point.z - distance_threshold_z), point,
+      distance_threshold, map, voxel)) {
     return true;
   }
-  if (is_in_voxel(
-        pcl::PointXYZ(point.x + distance_threshold, point.y, point.z), point, distance_threshold,
-        map, voxel)) {
+  if (
+    is_in_voxel(
+      pcl::PointXYZ(point.x - distance_threshold, point.y, point.z), point, distance_threshold, map,
+      voxel)) {
     return true;
   }
-  if (is_in_voxel(
-        pcl::PointXYZ(point.x + distance_threshold, point.y, point.z + distance_threshold_z), point,
-        distance_threshold, map, voxel)) {
+  if (
+    is_in_voxel(
+      pcl::PointXYZ(point.x - distance_threshold, point.y, point.z + distance_threshold_z), point,
+      distance_threshold, map, voxel)) {
     return true;
   }
-  if (is_in_voxel(
-        pcl::PointXYZ(
-          point.x + distance_threshold, point.y + distance_threshold,
-          point.z - distance_threshold_z),
-        point, distance_threshold, map, voxel)) {
+  if (
+    is_in_voxel(
+      pcl::PointXYZ(
+        point.x - distance_threshold, point.y + distance_threshold, point.z - distance_threshold_z),
+      point, distance_threshold, map, voxel)) {
     return true;
   }
-  if (is_in_voxel(
-        pcl::PointXYZ(point.x + distance_threshold, point.y + distance_threshold, point.z), point,
-        distance_threshold, map, voxel)) {
+  if (
+    is_in_voxel(
+      pcl::PointXYZ(point.x - distance_threshold, point.y + distance_threshold, point.z), point,
+      distance_threshold, map, voxel)) {
     return true;
   }
-  if (is_in_voxel(
-        pcl::PointXYZ(
-          point.x + distance_threshold, point.y + distance_threshold,
-          point.z + distance_threshold_z),
-        point, distance_threshold, map, voxel)) {
+  if (
+    is_in_voxel(
+      pcl::PointXYZ(
+        point.x - distance_threshold, point.y + distance_threshold, point.z + distance_threshold_z),
+      point, distance_threshold, map, voxel)) {
+    return true;
+  }
+
+  if (
+    is_in_voxel(
+      pcl::PointXYZ(
+        point.x + distance_threshold, point.y - distance_threshold, point.z - distance_threshold_z),
+      point, distance_threshold, map, voxel)) {
+    return true;
+  }
+  if (
+    is_in_voxel(
+      pcl::PointXYZ(point.x + distance_threshold, point.y - distance_threshold, point.z), point,
+      distance_threshold, map, voxel)) {
+    return true;
+  }
+  if (
+    is_in_voxel(
+      pcl::PointXYZ(
+        point.x + distance_threshold, point.y - distance_threshold, point.z + distance_threshold_z),
+      point, distance_threshold, map, voxel)) {
+    return true;
+  }
+  if (
+    is_in_voxel(
+      pcl::PointXYZ(point.x + distance_threshold, point.y, point.z - distance_threshold_z), point,
+      distance_threshold, map, voxel)) {
+    return true;
+  }
+  if (
+    is_in_voxel(
+      pcl::PointXYZ(point.x + distance_threshold, point.y, point.z), point, distance_threshold, map,
+      voxel)) {
+    return true;
+  }
+  if (
+    is_in_voxel(
+      pcl::PointXYZ(point.x + distance_threshold, point.y, point.z + distance_threshold_z), point,
+      distance_threshold, map, voxel)) {
+    return true;
+  }
+  if (
+    is_in_voxel(
+      pcl::PointXYZ(
+        point.x + distance_threshold, point.y + distance_threshold, point.z - distance_threshold_z),
+      point, distance_threshold, map, voxel)) {
+    return true;
+  }
+  if (
+    is_in_voxel(
+      pcl::PointXYZ(point.x + distance_threshold, point.y + distance_threshold, point.z), point,
+      distance_threshold, map, voxel)) {
+    return true;
+  }
+  if (
+    is_in_voxel(
+      pcl::PointXYZ(
+        point.x + distance_threshold, point.y + distance_threshold, point.z + distance_threshold_z),
+      point, distance_threshold, map, voxel)) {
     return true;
   }
   return false;
@@ -406,10 +424,11 @@ bool VoxelGridDynamicMapLoader::is_close_to_next_map_grid(
     current_voxel_grid_array_.at(neighbor_map_grid_index) != nullptr) {
     return false;
   }
-  if (is_close_to_neighbor_voxels(
-        point, distance_threshold,
-        current_voxel_grid_array_.at(neighbor_map_grid_index)->map_cell_pc_ptr,
-        current_voxel_grid_array_.at(neighbor_map_grid_index)->map_cell_voxel_grid)) {
+  if (
+    is_close_to_neighbor_voxels(
+      point, distance_threshold,
+      current_voxel_grid_array_.at(neighbor_map_grid_index)->map_cell_pc_ptr,
+      current_voxel_grid_array_.at(neighbor_map_grid_index)->map_cell_voxel_grid)) {
     return true;
   }
   return false;
@@ -450,26 +469,30 @@ bool VoxelGridDynamicMapLoader::is_close_to_map(
 
   // Compare point with the neighbor map cells if point close to map cell boundary
 
-  if (is_close_to_next_map_grid(
-        pcl::PointXYZ(point.x - distance_threshold, point.y, point.z), map_grid_index,
-        distance_threshold, origin_x, origin_y, map_grid_size_x, map_grid_size_y, map_grids_x)) {
+  if (
+    is_close_to_next_map_grid(
+      pcl::PointXYZ(point.x - distance_threshold, point.y, point.z), map_grid_index,
+      distance_threshold, origin_x, origin_y, map_grid_size_x, map_grid_size_y, map_grids_x)) {
     return true;
   }
 
-  if (is_close_to_next_map_grid(
-        pcl::PointXYZ(point.x + distance_threshold, point.y, point.z), map_grid_index,
-        distance_threshold, origin_x, origin_y, map_grid_size_x, map_grid_size_y, map_grids_x)) {
+  if (
+    is_close_to_next_map_grid(
+      pcl::PointXYZ(point.x + distance_threshold, point.y, point.z), map_grid_index,
+      distance_threshold, origin_x, origin_y, map_grid_size_x, map_grid_size_y, map_grids_x)) {
     return true;
   }
 
-  if (is_close_to_next_map_grid(
-        pcl::PointXYZ(point.x, point.y - distance_threshold, point.z), map_grid_index,
-        distance_threshold, origin_x, origin_y, map_grid_size_x, map_grid_size_y, map_grids_x)) {
+  if (
+    is_close_to_next_map_grid(
+      pcl::PointXYZ(point.x, point.y - distance_threshold, point.z), map_grid_index,
+      distance_threshold, origin_x, origin_y, map_grid_size_x, map_grid_size_y, map_grids_x)) {
     return true;
   }
-  if (is_close_to_next_map_grid(
-        pcl::PointXYZ(point.x, point.y + distance_threshold, point.z), map_grid_index,
-        distance_threshold, origin_x, origin_y, map_grid_size_x, map_grid_size_y, map_grids_x)) {
+  if (
+    is_close_to_next_map_grid(
+      pcl::PointXYZ(point.x, point.y + distance_threshold, point.z), map_grid_index,
+      distance_threshold, origin_x, origin_y, map_grid_size_x, map_grid_size_y, map_grids_x)) {
     return true;
   }
 

--- a/perception/autoware_crosswalk_traffic_light_estimator/src/crosswalk_traffic_light_estimator.cpp
+++ b/perception/autoware_crosswalk_traffic_light_estimator/src/crosswalk_traffic_light_estimator.cpp
@@ -462,8 +462,9 @@ void CrosswalkTrafficLightEstimator::set_crosswalk_traffic_signal(
     };
 
     // 1. Map-based override (highest priority)
-    if (auto it = crosswalk_traffic_signal_overrides.find(id);
-        it != crosswalk_traffic_signal_overrides.end()) {
+    if (
+      auto it = crosswalk_traffic_signal_overrides.find(id);
+      it != crosswalk_traffic_signal_overrides.end()) {
       replace_out_signal_elements(base_traffic_signal_element);
       out_signal.elements[0].color = it->second;  // override color
       continue;
@@ -479,8 +480,8 @@ void CrosswalkTrafficLightEstimator::set_crosswalk_traffic_signal(
       }
 
       // Update flashing state and apply the most recent color
-      if (out_signal.elements
-            .empty()) {  // unnecessary check because msg has detection but for safety
+      if (out_signal.elements.empty()) {  // unnecessary check because msg has detection but for
+                                          // safety
         out_signal.elements.push_back(base_traffic_signal_element);
       }
       out_signal.elements[0].color =
@@ -553,8 +554,9 @@ lanelet::ConstLanelets CrosswalkTrafficLightEstimator::get_non_red_lanelets(
   lanelet::ConstLanelets non_red_lanelets{};
 
   for (const auto & lanelet : lanelets) {
-    if (is_lanelet_non_red(
-          lanelet, traffic_light_id_map, last_detect_color_, config_.use_last_detect_color)) {
+    if (
+      is_lanelet_non_red(
+        lanelet, traffic_light_id_map, last_detect_color_, config_.use_last_detect_color)) {
       non_red_lanelets.push_back(lanelet);
     }
   }

--- a/perception/autoware_image_projection_based_fusion/src/pointpainting_fusion/node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/pointpainting_fusion/node.cpp
@@ -470,8 +470,9 @@ dc   | dc dc dc  dc ||zc|
 
       // project
       Eigen::Vector2d projected_point;
-      if (det2d_status.camera_projector_ptr->calcImageProjectedPoint(
-            cv::Point3d(p_x, p_y, p_z), projected_point)) {
+      if (
+        det2d_status.camera_projector_ptr->calcImageProjectedPoint(
+          cv::Point3d(p_x, p_y, p_z), projected_point)) {
         // iterate 2d bbox
         for (const auto & feature_object : objects) {
           sensor_msgs::msg::RegionOfInterest roi = feature_object.feature.roi;

--- a/perception/autoware_image_projection_based_fusion/src/roi_cluster_fusion/node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/roi_cluster_fusion/node.cpp
@@ -174,8 +174,9 @@ void RoiClusterFusionNode::fuse_on_single_image(
       }
 
       Eigen::Vector2d projected_point;
-      if (det2d_status.camera_projector_ptr->calcImageProjectedPoint(
-            cv::Point3d(*iter_x, *iter_y, *iter_z), projected_point)) {
+      if (
+        det2d_status.camera_projector_ptr->calcImageProjectedPoint(
+          cv::Point3d(*iter_x, *iter_y, *iter_z), projected_point)) {
         const int px = static_cast<int>(projected_point.x());
         const int py = static_cast<int>(projected_point.y());
 

--- a/perception/autoware_image_projection_based_fusion/src/roi_detected_object_fusion/node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/roi_detected_object_fusion/node.cpp
@@ -164,8 +164,9 @@ RoiDetectedObjectFusionNode::generateDetectedObjectRoIs(
       }
 
       Eigen::Vector2d proj_point;
-      if (det2d_status.camera_projector_ptr->calcImageProjectedPoint(
-            cv::Point3d(point.x(), point.y(), point.z()), proj_point)) {
+      if (
+        det2d_status.camera_projector_ptr->calcImageProjectedPoint(
+          cv::Point3d(point.x(), point.y(), point.z()), proj_point)) {
         const double px = proj_point.x();
         const double py = proj_point.y();
 

--- a/perception/autoware_image_projection_based_fusion/src/roi_pointcloud_fusion/node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/roi_pointcloud_fusion/node.cpp
@@ -153,8 +153,9 @@ void RoiPointCloudFusionNode::fuse_on_single_image(
     }
 
     Eigen::Vector2d projected_point;
-    if (det2d_status.camera_projector_ptr->calcImageProjectedPoint(
-          cv::Point3d(transformed_x, transformed_y, transformed_z), projected_point)) {
+    if (
+      det2d_status.camera_projector_ptr->calcImageProjectedPoint(
+        cv::Point3d(transformed_x, transformed_y, transformed_z), projected_point)) {
       for (std::size_t i = 0; i < output_objs.size(); ++i) {
         auto & feature_obj = output_objs.at(i);
         const auto & check_roi = feature_obj.feature.roi;

--- a/perception/autoware_map_based_prediction/lib/predictor_vehicle/path_processing.cpp
+++ b/perception/autoware_map_based_prediction/lib/predictor_vehicle/path_processing.cpp
@@ -283,8 +283,9 @@ std::optional<PredictedObject> PathProcessor::predict(
 
     const auto trajectory_with_const_velocity = toTrajectoryPoints(predicted_path, abs_obj_speed);
 
-    if (isLateralAccelerationConstraintSatisfied(
-          trajectory_with_const_velocity, params_.prediction_sampling_time_interval)) {
+    if (
+      isLateralAccelerationConstraintSatisfied(
+        trajectory_with_const_velocity, params_.prediction_sampling_time_interval)) {
       predicted_path.confidence = ref_path.probability;
       predicted_paths.push_back(predicted_path);
       continue;

--- a/perception/autoware_map_based_prediction/lib/predictor_vru/fence.cpp
+++ b/perception/autoware_map_based_prediction/lib/predictor_vru/fence.cpp
@@ -44,8 +44,9 @@ void FenceModule::buildFromMap(std::shared_ptr<lanelet::LaneletMap> lanelet_map_
 {
   lanelet::LineStrings3d fences;
   for (const auto & linestring : lanelet_map_ptr->lineStringLayer) {
-    if (const std::string type = linestring.attributeOr(lanelet::AttributeName::Type, "none");
-        type == "fence") {
+    if (
+      const std::string type = linestring.attributeOr(lanelet::AttributeName::Type, "none");
+      type == "fence") {
       fences.emplace_back(std::const_pointer_cast<lanelet::LineStringData>(linestring.constData()));
     }
   }
@@ -106,8 +107,8 @@ PredictedPath FenceModule::cutPathBeforeFences(const PredictedPath & predicted_p
     lanelet::BasicLineString2d path_segment(
       lanelet::BasicPoints2d{predicted_path_ls[i], predicted_path_ls[i + 1]});
     for (const auto & fence : crossed_fences) {
-      if (boost::geometry::intersects(
-            path_segment, lanelet::utils::to2D(fence).basicLineString())) {
+      if (
+        boost::geometry::intersects(path_segment, lanelet::utils::to2D(fence).basicLineString())) {
         closest_cross_index = i;
       }
     }

--- a/perception/autoware_map_based_prediction/lib/predictor_vru/predictor_vru.cpp
+++ b/perception/autoware_map_based_prediction/lib/predictor_vru/predictor_vru.cpp
@@ -280,22 +280,24 @@ PredictedObject PredictorVru::getPredictedObjectAsCrosswalkUser(const TrackedObj
   if (crossing_crosswalk) {
     const auto edge_points = getCrosswalkEdgePoints(crossing_crosswalk.get());
 
-    if (history_manager_.hasPotentialToReachWithHistory(
-          mutable_object, edge_points.front_center_point, edge_points.front_right_point,
-          edge_points.front_left_point, std::numeric_limits<double>::max(),
-          params_.min_crosswalk_user_velocity,
-          params_.max_crosswalk_user_delta_yaw_threshold_for_lanelet, true)) {
+    if (
+      history_manager_.hasPotentialToReachWithHistory(
+        mutable_object, edge_points.front_center_point, edge_points.front_right_point,
+        edge_points.front_left_point, std::numeric_limits<double>::max(),
+        params_.min_crosswalk_user_velocity,
+        params_.max_crosswalk_user_delta_yaw_threshold_for_lanelet, true)) {
       PredictedPath predicted_path =
         path_generator_->generatePathToTargetPoint(mutable_object, edge_points.front_center_point);
       predicted_path.confidence = 1.0;
       predicted_object.kinematics.predicted_paths.push_back(predicted_path);
     }
 
-    if (history_manager_.hasPotentialToReachWithHistory(
-          mutable_object, edge_points.back_center_point, edge_points.back_right_point,
-          edge_points.back_left_point, std::numeric_limits<double>::max(),
-          params_.min_crosswalk_user_velocity,
-          params_.max_crosswalk_user_delta_yaw_threshold_for_lanelet, true)) {
+    if (
+      history_manager_.hasPotentialToReachWithHistory(
+        mutable_object, edge_points.back_center_point, edge_points.back_right_point,
+        edge_points.back_left_point, std::numeric_limits<double>::max(),
+        params_.min_crosswalk_user_velocity,
+        params_.max_crosswalk_user_delta_yaw_threshold_for_lanelet, true)) {
       PredictedPath predicted_path =
         path_generator_->generatePathToTargetPoint(mutable_object, edge_points.back_center_point);
       predicted_path.confidence = 1.0;
@@ -310,22 +312,24 @@ PredictedObject PredictorVru::getPredictedObjectAsCrosswalkUser(const TrackedObj
       closest_crosswalk_opt &&
       within_minimum_distance(obj_pose.position, closest_crosswalk_opt.value())) {
       const auto edge_points = getCrosswalkEdgePoints(closest_crosswalk_opt.value());
-      if (history_manager_.hasPotentialToReachWithHistory(
-            mutable_object, edge_points.front_center_point, edge_points.front_right_point,
-            edge_points.front_left_point, params_.prediction_time_horizon * 2.0,
-            params_.min_crosswalk_user_velocity,
-            params_.max_crosswalk_user_delta_yaw_threshold_for_lanelet, true)) {
+      if (
+        history_manager_.hasPotentialToReachWithHistory(
+          mutable_object, edge_points.front_center_point, edge_points.front_right_point,
+          edge_points.front_left_point, params_.prediction_time_horizon * 2.0,
+          params_.min_crosswalk_user_velocity,
+          params_.max_crosswalk_user_delta_yaw_threshold_for_lanelet, true)) {
         PredictedPath predicted_path = path_generator_->generatePathToTargetPoint(
           mutable_object, edge_points.front_center_point);
         predicted_path.confidence = 1.0;
         predicted_object.kinematics.predicted_paths.push_back(predicted_path);
       }
 
-      if (history_manager_.hasPotentialToReachWithHistory(
-            mutable_object, edge_points.back_center_point, edge_points.back_right_point,
-            edge_points.back_left_point, params_.prediction_time_horizon * 2.0,
-            params_.min_crosswalk_user_velocity,
-            params_.max_crosswalk_user_delta_yaw_threshold_for_lanelet, true)) {
+      if (
+        history_manager_.hasPotentialToReachWithHistory(
+          mutable_object, edge_points.back_center_point, edge_points.back_right_point,
+          edge_points.back_left_point, params_.prediction_time_horizon * 2.0,
+          params_.min_crosswalk_user_velocity,
+          params_.max_crosswalk_user_delta_yaw_threshold_for_lanelet, true)) {
         PredictedPath predicted_path =
           path_generator_->generatePathToTargetPoint(mutable_object, edge_points.back_center_point);
         predicted_path.confidence = 1.0;

--- a/perception/autoware_multi_object_tracker/lib/odometry.cpp
+++ b/perception/autoware_multi_object_tracker/lib/odometry.cpp
@@ -319,8 +319,9 @@ std::optional<geometry_msgs::msg::Transform> Odometry::getTransform(
       }
       try {
         std::string errstr;
-        if (tf_buffer_->canTransform(
-              ego_frame_id_, source_frame_id, tf2::TimePointZero, tf2::Duration::zero(), &errstr)) {
+        if (
+          tf_buffer_->canTransform(
+            ego_frame_id_, source_frame_id, tf2::TimePointZero, tf2::Duration::zero(), &errstr)) {
           const auto ego_to_source =
             tf_buffer_->lookupTransform(ego_frame_id_, source_frame_id, tf2::TimePointZero);
           tf2::Transform tf_world_to_ego;

--- a/perception/autoware_object_merger/src/object_association_merger_node.cpp
+++ b/perception/autoware_object_merger/src/object_association_merger_node.cpp
@@ -269,11 +269,12 @@ void ObjectAssociationMergerNode::objectsCallback(
     for (const auto & unknown_object : unknown_objects) {
       bool is_overlapped = false;
       for (const auto & known_object : known_objects) {
-        if (isUnknownObjectOverlapped(
-              unknown_object, known_object, overlapped_judge_param_.precision_threshold,
-              overlapped_judge_param_.recall_threshold,
-              overlapped_judge_param_.distance_threshold_map,
-              overlapped_judge_param_.generalized_iou_threshold)) {
+        if (
+          isUnknownObjectOverlapped(
+            unknown_object, known_object, overlapped_judge_param_.precision_threshold,
+            overlapped_judge_param_.recall_threshold,
+            overlapped_judge_param_.distance_threshold_map,
+            overlapped_judge_param_.generalized_iou_threshold)) {
           is_overlapped = true;
           break;
         }

--- a/perception/autoware_predicted_path_postprocessor/src/processor/collision.cpp
+++ b/perception/autoware_predicted_path_postprocessor/src/processor/collision.cpp
@@ -99,8 +99,9 @@ std::optional<CollisionHit> find_collision(
 
     for (const auto & obstacle : obstacles) {
       // if the obstacle has a high speed or is the same as the path, skip it
-      if (auto speed = std::abs(obstacle.kinematics.initial_twist_with_covariance.twist.linear.x);
-          speed > speed_threshold || obstacle.object_id == target.object_id) {
+      if (
+        auto speed = std::abs(obstacle.kinematics.initial_twist_with_covariance.twist.linear.x);
+        speed > speed_threshold || obstacle.object_id == target.object_id) {
         continue;
       }
 

--- a/perception/autoware_ptv3/lib/ptv3_trt.cpp
+++ b/perception/autoware_ptv3/lib/ptv3_trt.cpp
@@ -775,9 +775,10 @@ bool PTv3TRT::infer(
     "debug/processing_time/inference_ms", stop_watch_ptr_->toc("processing/inner", true));
 
   if (seg_ok && should_run_seg3d) {
-    if (postProcess(
-          msg_ptr->header, should_publish_segmented_pointcloud,
-          should_publish_visualization_pointcloud, should_publish_filtered_pointcloud)) {
+    if (
+      postProcess(
+        msg_ptr->header, should_publish_segmented_pointcloud,
+        should_publish_visualization_pointcloud, should_publish_filtered_pointcloud)) {
       seg_post_ok = true;
     } else {
       RCLCPP_ERROR(rclcpp::get_logger("ptv3"), "Seg post-process failed.");

--- a/perception/autoware_simpl_prediction/src/conversion/lanelet.cpp
+++ b/perception/autoware_simpl_prediction/src/conversion/lanelet.cpp
@@ -82,8 +82,8 @@ archetype::MapLabel to_boundary_label(const lanelet::ConstLineString3d & linestr
 {
   if (auto t_type = to_type(linestring); t_type && MAP_LABEL_MAPPING.count(*t_type)) {
     return MAP_LABEL_MAPPING.at(*t_type);
-  } else if (auto t_subtype = to_subtype(linestring);
-             t_subtype && MAP_LABEL_MAPPING.count(*t_subtype)) {
+  } else if (
+    auto t_subtype = to_subtype(linestring); t_subtype && MAP_LABEL_MAPPING.count(*t_subtype)) {
     return MAP_LABEL_MAPPING.at(*t_subtype);
   } else {
     return archetype::MapLabel::UNKNOWN;

--- a/perception/autoware_tensorrt_bevformer/src/bevformer_node.cpp
+++ b/perception/autoware_tensorrt_bevformer/src/bevformer_node.cpp
@@ -368,8 +368,9 @@ void TRTBEVFormerNode::calculateStaticLidar2EgoTransform()
   rclcpp::Time lidar_time = this->now();
 
   try {
-    if (tf_buffer_->canTransform(
-          "base_link", "LIDAR_TOP", lidar_time, rclcpp::Duration::from_seconds(1.0))) {
+    if (
+      tf_buffer_->canTransform(
+        "base_link", "LIDAR_TOP", lidar_time, rclcpp::Duration::from_seconds(1.0))) {
       auto tf_lidar2ego = tf_buffer_->lookupTransform("base_link", "LIDAR_TOP", lidar_time);
       getTransform(tf_lidar2ego, lidar2ego_rot_static_, lidar2ego_trans_static_);
       lidar2ego_transforms_ready_ = true;
@@ -415,8 +416,9 @@ void TRTBEVFormerNode::calculateSensor2LidarTransformsFromTF(
     Eigen::Translation3d ego2global_trans_cam = Eigen::Translation3d::Identity();
     bool got_camera_transform = false;
     try {
-      if (tf_buffer_->canTransform(
-            "world", "base_link", camera_timestamp, rclcpp::Duration::from_seconds(0.1))) {
+      if (
+        tf_buffer_->canTransform(
+          "world", "base_link", camera_timestamp, rclcpp::Duration::from_seconds(0.1))) {
         auto tf_ego2global_cam = tf_buffer_->lookupTransform(
           "world", "base_link", camera_timestamp, rclcpp::Duration::from_seconds(0.1));
 
@@ -530,8 +532,9 @@ void TRTBEVFormerNode::callback(
   Eigen::Translation3d ego2global_trans;
 
   try {
-    if (tf_buffer_->canTransform(
-          "world", "base_link", ref_time, rclcpp::Duration::from_seconds(0.5))) {
+    if (
+      tf_buffer_->canTransform(
+        "world", "base_link", ref_time, rclcpp::Duration::from_seconds(0.5))) {
       auto tf_ego2global = tf_buffer_->lookupTransform("world", "base_link", ref_time);
       getTransform(tf_ego2global, ego2global_rot, ego2global_trans);
       RCLCPP_DEBUG(this->get_logger(), "Got ego2global transform for CAN bus processing");

--- a/perception/autoware_tensorrt_plugins/src/argsort_plugin.cpp
+++ b/perception/autoware_tensorrt_plugins/src/argsort_plugin.cpp
@@ -151,11 +151,12 @@ std::int32_t ArgsortPlugin::enqueue(
   auto num_elements = static_cast<std::size_t>(input_desc[0].dims.d[0]);
   const auto workspace_size = get_argsort_workspace_size(num_elements);
 
-  if (const auto status = PLUGIN_CUDA_CHECK(argsort(
-        reinterpret_cast<std::int64_t const *>(inputs[0]),
-        reinterpret_cast<std::int64_t *>(outputs[0]), workspace, num_elements, workspace_size,
-        stream));
-      status != cudaSuccess) {
+  if (
+    const auto status = PLUGIN_CUDA_CHECK(argsort(
+      reinterpret_cast<std::int64_t const *>(inputs[0]),
+      reinterpret_cast<std::int64_t *>(outputs[0]), workspace, num_elements, workspace_size,
+      stream));
+    status != cudaSuccess) {
     return -1;
   }
 

--- a/perception/autoware_tensorrt_plugins/src/unique_ops/unique.cu
+++ b/perception/autoware_tensorrt_plugins/src/unique_ops/unique.cu
@@ -249,11 +249,12 @@ cudaError_t unique(
   if (const auto status = cudaPeekAtLastError(); status != cudaSuccess) {
     return status;
   }
-  if (const auto status = cub::DeviceRadixSort::SortPairs(
-        layout.cub_temp_storage, layout.cub_temp_storage_size, input_in, layout.sorted_input,
-        layout.input_positions, layout.sorted_input_positions, num_input_elements_in, 0, 64,
-        stream_in);
-      status != cudaSuccess) {
+  if (
+    const auto status = cub::DeviceRadixSort::SortPairs(
+      layout.cub_temp_storage, layout.cub_temp_storage_size, input_in, layout.sorted_input,
+      layout.input_positions, layout.sorted_input_positions, num_input_elements_in, 0, 64,
+      stream_in);
+    status != cudaSuccess) {
     return status;
   }
 
@@ -263,10 +264,11 @@ cudaError_t unique(
   if (const auto status = cudaPeekAtLastError(); status != cudaSuccess) {
     return status;
   }
-  if (const auto status = cub::DeviceScan::InclusiveSum(
-        layout.cub_temp_storage, layout.cub_temp_storage_size, layout.run_ids, layout.run_ids,
-        num_input_elements_in, stream_in);
-      status != cudaSuccess) {
+  if (
+    const auto status = cub::DeviceScan::InclusiveSum(
+      layout.cub_temp_storage, layout.cub_temp_storage_size, layout.run_ids, layout.run_ids,
+      num_input_elements_in, stream_in);
+    status != cudaSuccess) {
     return status;
   }
 
@@ -278,11 +280,11 @@ cudaError_t unique(
   }
 
   // 4. Compact sorted runs into unique values and occurrence counts.
-  if (const auto status = cub::DeviceRunLengthEncode::Encode(
-        layout.cub_temp_storage, layout.cub_temp_storage_size, layout.sorted_input,
-        unique_values_out, unique_counts_out, layout.num_unique,
-        static_cast<int>(num_input_elements_in), stream_in);
-      status != cudaSuccess) {
+  if (
+    const auto status = cub::DeviceRunLengthEncode::Encode(
+      layout.cub_temp_storage, layout.cub_temp_storage_size, layout.sorted_input, unique_values_out,
+      unique_counts_out, layout.num_unique, static_cast<int>(num_input_elements_in), stream_in);
+    status != cudaSuccess) {
     return status;
   }
 

--- a/perception/autoware_tensorrt_plugins/src/unique_plugin.cpp
+++ b/perception/autoware_tensorrt_plugins/src/unique_plugin.cpp
@@ -166,12 +166,13 @@ std::int32_t UniquePlugin::enqueue(
   std::int64_t num_elements = input_desc[0].dims.d[0];
   const auto workspace_size = get_unique_workspace_size(static_cast<std::size_t>(num_elements));
 
-  if (const auto status = PLUGIN_CUDA_CHECK(unique(
-        reinterpret_cast<const std::int64_t *>(inputs[0]),
-        reinterpret_cast<std::int64_t *>(outputs[0]), reinterpret_cast<std::int64_t *>(outputs[1]),
-        reinterpret_cast<std::int64_t *>(outputs[2]), reinterpret_cast<std::int64_t *>(outputs[3]),
-        workspace, num_elements, workspace_size, stream));
-      status != cudaSuccess) {
+  if (
+    const auto status = PLUGIN_CUDA_CHECK(unique(
+      reinterpret_cast<const std::int64_t *>(inputs[0]),
+      reinterpret_cast<std::int64_t *>(outputs[0]), reinterpret_cast<std::int64_t *>(outputs[1]),
+      reinterpret_cast<std::int64_t *>(outputs[2]), reinterpret_cast<std::int64_t *>(outputs[3]),
+      workspace, num_elements, workspace_size, stream));
+    status != cudaSuccess) {
     return -1;
   }
 

--- a/planning/autoware_freespace_planning_algorithms/src/rrtstar_core.cpp
+++ b/planning/autoware_freespace_planning_algorithms/src/rrtstar_core.cpp
@@ -390,8 +390,9 @@ NodeConstSharedPtr RRTStar::getReconnectTargeNode(
   NodeConstSharedPtr node_reconnect = nullptr;
 
   for (const auto & node_neighbor : neighbor_nodes) {
-    if (cspace_.isValidPath_child2parent(
-          node_neighbor->pose, node_new->pose, collision_check_resolution_)) {
+    if (
+      cspace_.isValidPath_child2parent(
+        node_neighbor->pose, node_new->pose, collision_check_resolution_)) {
       const double cost_from_start_rewired =
         *node_new->cost_from_start + cspace_.distance(node_new->pose, node_neighbor->pose);
       if (cost_from_start_rewired < *node_neighbor->cost_from_start) {

--- a/planning/autoware_minimum_rule_based_planner/src/path_planner.cpp
+++ b/planning/autoware_minimum_rule_based_planner/src/path_planner.cpp
@@ -1188,8 +1188,9 @@ bool PathPlanner::update_current_lanelet(const geometry_msgs::msg::Pose & curren
 {
   if (!current_lanelet_) {
     lanelet::ConstLanelet closest;
-    if (lanelet::utils::query::getClosestLanelet(
-          route_context_.route_lanelets, current_pose, &closest)) {
+    if (
+      lanelet::utils::query::getClosestLanelet(
+        route_context_.route_lanelets, current_pose, &closest)) {
       current_lanelet_ = closest;
       return true;
     }
@@ -1222,15 +1223,17 @@ bool PathPlanner::update_current_lanelet(const geometry_msgs::msg::Pose & curren
     }
   }
 
-  if (lanelet::utils::query::getClosestLaneletWithConstrains(
-        candidates, current_pose, &*current_lanelet_,
-        params_.path_planning.ego_nearest_lanelet.dist_threshold,
-        params_.path_planning.ego_nearest_lanelet.yaw_threshold)) {
+  if (
+    lanelet::utils::query::getClosestLaneletWithConstrains(
+      candidates, current_pose, &*current_lanelet_,
+      params_.path_planning.ego_nearest_lanelet.dist_threshold,
+      params_.path_planning.ego_nearest_lanelet.yaw_threshold)) {
     return true;
   }
 
-  if (lanelet::utils::query::getClosestLanelet(
-        route_context_.route_lanelets, current_pose, &*current_lanelet_)) {
+  if (
+    lanelet::utils::query::getClosestLanelet(
+      route_context_.route_lanelets, current_pose, &*current_lanelet_)) {
     return true;
   }
 
@@ -1254,8 +1257,9 @@ std::optional<PathWithLaneId> PathPlanner::plan_path(
       return *current_lanelet_;
     }
     lanelet::ConstLanelet closest;
-    if (lanelet::utils::query::getClosestLanelet(
-          route_context_.preferred_lanelets, current_pose, &closest)) {
+    if (
+      lanelet::utils::query::getClosestLanelet(
+        route_context_.preferred_lanelets, current_pose, &closest)) {
       route_context_.closest_preferred_lanelet = closest;
       return *route_context_.closest_preferred_lanelet;
     }

--- a/planning/autoware_mission_planner_universe/src/lanelet2_plugins/default_planner.cpp
+++ b/planning/autoware_mission_planner_universe/src/lanelet2_plugins/default_planner.cpp
@@ -286,10 +286,10 @@ bool DefaultPlanner::is_goal_valid(const geometry_msgs::msg::Pose & goal)
 
   // check if goal is in shoulder lanelet
   const auto shoulder_lanelets = route_handler_.getShoulderLaneletsAtPose(goal);
-  if (const auto closest_shoulder_lanelet_opt =
-        experimental::lanelet2_utils::get_closest_lanelet_within_constraint(
-          shoulder_lanelets, goal);
-      closest_shoulder_lanelet_opt) {
+  if (
+    const auto closest_shoulder_lanelet_opt =
+      experimental::lanelet2_utils::get_closest_lanelet_within_constraint(shoulder_lanelets, goal);
+    closest_shoulder_lanelet_opt) {
     const auto & closest_shoulder_lanelet = closest_shoulder_lanelet_opt.value();
     const auto lane_yaw = autoware::experimental::lanelet2_utils::get_lanelet_angle(
       closest_shoulder_lanelet,

--- a/planning/autoware_mission_planner_universe/src/mission_planner/mission_planner.cpp
+++ b/planning/autoware_mission_planner_universe/src/mission_planner/mission_planner.cpp
@@ -421,11 +421,12 @@ void MissionPlanner::on_set_preferred_primitive(
     auto & segment = current_route.segments.at(i);
     const auto & preferred_primitive = req->preferred_primitives.at(i);
 
-    if (std::none_of(
-          segment.primitives.begin(), segment.primitives.end(),
-          [&preferred_primitive](const autoware_planning_msgs::msg::LaneletPrimitive & p) {
-            return p.id == preferred_primitive.id;
-          })) {
+    if (
+      std::none_of(
+        segment.primitives.begin(), segment.primitives.end(),
+        [&preferred_primitive](const autoware_planning_msgs::msg::LaneletPrimitive & p) {
+          return p.id == preferred_primitive.id;
+        })) {
       res->status.success = false;
       throw service_utils::ServiceException(
         autoware_adapi_v1_msgs::srv::SetRoute::Response::ERROR_INVALID_STATE,

--- a/planning/autoware_surround_obstacle_checker/src/debug_marker.cpp
+++ b/planning/autoware_surround_obstacle_checker/src/debug_marker.cpp
@@ -63,9 +63,9 @@ SurroundObstacleCheckerDebugNode::SurroundObstacleCheckerDebugNode(
   const double & surround_check_back_distance, const double & surround_check_hysteresis_distance,
   const geometry_msgs::msg::Pose & self_pose, const rclcpp::Clock::SharedPtr clock,
   rclcpp::Node & node)
-: planning_factor_interface_{std::make_unique<
-    autoware::planning_factor_interface::PlanningFactorInterface>(
-    &node, "surround_obstacle_checker")},
+: planning_factor_interface_{
+    std::make_unique<autoware::planning_factor_interface::PlanningFactorInterface>(
+      &node, "surround_obstacle_checker")},
   vehicle_info_(vehicle_info),
   object_label_(object_label),
   surround_check_front_distance_(surround_check_front_distance),

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -217,8 +217,9 @@ bool ObstacleStop::set_stop_point(TrajectoryPoints & traj_points, const InputDat
     input.current_acceleration->accel.accel.linear.x, stopping_params_.maximum_deceleration,
     stopping_params_.jerk_limit);
 
-  if (utils::stop_point_exists(
-        traj_points, target_stop_point_arc_length, params_.duplicate_check_threshold)) {
+  if (
+    utils::stop_point_exists(
+      traj_points, target_stop_point_arc_length, params_.duplicate_check_threshold)) {
     RCLCPP_WARN_THROTTLE(
       get_node_ptr()->get_logger(), *get_clock(), 1000,
       "[TM ObstacleStop] Preceding (or duplicate) stop point exists, skip inserting stop point");

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/stop_point_fixer.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/stop_point_fixer.cpp
@@ -71,8 +71,8 @@ bool StopPointFixer::is_trajectory_modification_required(
     return false;
   }
 
-  if (utils::is_ego_vehicle_moving(
-        input.current_odometry->twist.twist, params_.velocity_threshold)) {
+  if (
+    utils::is_ego_vehicle_moving(input.current_odometry->twist.twist, params_.velocity_threshold)) {
     return false;
   }
 

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -214,8 +214,9 @@ std::optional<CollisionPoint> get_nearest_pcd_collision(
 
   PointCloud::Ptr pointcloud_in_polygon(new PointCloud);
   for (const auto & point : *pointcloud) {
-    if (boost::geometry::within(
-          autoware_utils::Point2d{point.x, point.y}, trajectory_shape.polygon)) {
+    if (
+      boost::geometry::within(
+        autoware_utils::Point2d{point.x, point.y}, trajectory_shape.polygon)) {
       pointcloud_in_polygon->push_back(point);
     }
   }

--- a/planning/behavior_path_planner/autoware_behavior_path_bidirectional_traffic_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_bidirectional_traffic_module/src/scene.cpp
@@ -42,7 +42,9 @@ BidirectionalTrafficModule::BidirectionalTrafficModule(
   std::unordered_map<std::string, std::shared_ptr<ObjectsOfInterestMarkerInterface>> &
     objects_of_interest_marker_interface_ptr_map,
   const std::shared_ptr<PlanningFactorInterface> & planning_factor_interface)
-: SceneModuleInterface{name.data(), node, rtc_interface_ptr_map, objects_of_interest_marker_interface_ptr_map, planning_factor_interface},  // NOLINT
+: SceneModuleInterface{
+    name.data(), node, rtc_interface_ptr_map, objects_of_interest_marker_interface_ptr_map,
+    planning_factor_interface},  // NOLINT
   parameters_(parameters),
   has_trajectory_bidirectional_lane_overlap_(false)
 {

--- a/planning/behavior_path_planner/autoware_behavior_path_direction_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_direction_change_module/src/scene.cpp
@@ -138,7 +138,9 @@ DirectionChangeModule::DirectionChangeModule(
   std::unordered_map<std::string, std::shared_ptr<ObjectsOfInterestMarkerInterface>> &
     objects_of_interest_marker_interface_ptr_map,
   const std::shared_ptr<PlanningFactorInterface> planning_factor_interface)
-: SceneModuleInterface{name, node, rtc_interface_ptr_map, objects_of_interest_marker_interface_ptr_map, planning_factor_interface},  // NOLINT
+: SceneModuleInterface{
+    name, node, rtc_interface_ptr_map, objects_of_interest_marker_interface_ptr_map,
+    planning_factor_interface},  // NOLINT
   parameters_{parameters},
   persistent_state_{persistent_state}
 {
@@ -506,9 +508,10 @@ bool DirectionChangeModule::shouldActivateModule() const
 
   const auto & ego_pose = planner_data_->self_odometry->pose.pose;
 
-  if (isEgoNearRouteGoal(
-        ego_pose, planner_data_->route_handler, parameters_->th_arrived_distance,
-        route_context_.suffix_lanelet_ids)) {
+  if (
+    isEgoNearRouteGoal(
+      ego_pose, planner_data_->route_handler, parameters_->th_arrived_distance,
+      route_context_.suffix_lanelet_ids)) {
     RCLCPP_DEBUG_EXPRESSION(
       getLogger(), parameters_->print_debug_info,
       "shouldActivateModule: ego at route goal, module INACTIVE");

--- a/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/src/manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/src/manager.cpp
@@ -234,8 +234,9 @@ void DynamicObstacleAvoidanceModuleManager::updateModuleParams(
   {  // drivable_area_generation
     const std::string ns = "dynamic_avoidance.drivable_area_generation.";
     std::string polygon_generation_method_str;
-    if (update_param<std::string>(
-          parameters, ns + "polygon_generation_method", polygon_generation_method_str)) {
+    if (
+      update_param<std::string>(
+        parameters, ns + "polygon_generation_method", polygon_generation_method_str)) {
       p->polygon_generation_method =
         convertToPolygonGenerationMethod(polygon_generation_method_str);
     }

--- a/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/src/scene.cpp
@@ -313,7 +313,9 @@ DynamicObstacleAvoidanceModule::DynamicObstacleAvoidanceModule(
   std::unordered_map<std::string, std::shared_ptr<ObjectsOfInterestMarkerInterface>> &
     objects_of_interest_marker_interface_ptr_map,
   const std::shared_ptr<PlanningFactorInterface> planning_factor_interface)
-: SceneModuleInterface{name, node, rtc_interface_ptr_map, objects_of_interest_marker_interface_ptr_map, planning_factor_interface},  // NOLINT
+: SceneModuleInterface{
+    name, node, rtc_interface_ptr_map, objects_of_interest_marker_interface_ptr_map,
+    planning_factor_interface},  // NOLINT
   parameters_{std::move(parameters)},
   target_objects_manager_{TargetObjectsManager(
     parameters_->successive_num_to_entry_dynamic_avoidance_condition,

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/decision_state.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/decision_state.cpp
@@ -129,12 +129,13 @@ PathDecisionState PathDecisionStateController::get_next_state(
   const auto & parking_path_curvatures = pull_over_path.parking_path_curvatures();
   const double margin =
     parameters.object_recognition_collision_check_hard_margins.back() * hysteresis_factor;
-  if (goal_planner_utils::checkObjectsCollision(
-        parking_path, parking_path_curvatures, static_target_objects, dynamic_target_objects,
-        planner_data->parameters, margin,
-        /*extract_static_objects=*/false, parameters.maximum_deceleration,
-        parameters.object_recognition_collision_check_max_extra_stopping_margin,
-        parameters.collision_check_outer_margin_factor, ego_polygons_expanded, true)) {
+  if (
+    goal_planner_utils::checkObjectsCollision(
+      parking_path, parking_path_curvatures, static_target_objects, dynamic_target_objects,
+      planner_data->parameters, margin,
+      /*extract_static_objects=*/false, parameters.maximum_deceleration,
+      parameters.object_recognition_collision_check_max_extra_stopping_margin,
+      parameters.collision_check_outer_margin_factor, ego_polygons_expanded, true)) {
     if (is_deciding) {
       RCLCPP_INFO(
         logger_, "[DecidingPathStatus]: DECIDING->NOT_DECIDED. path has collision with objects");

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
@@ -96,7 +96,9 @@ GoalPlannerModule::GoalPlannerModule(
   std::unordered_map<std::string, std::shared_ptr<ObjectsOfInterestMarkerInterface>> &
     objects_of_interest_marker_interface_ptr_map,
   const std::shared_ptr<PlanningFactorInterface> planning_factor_interface)
-: SceneModuleInterface{name, node, rtc_interface_ptr_map, objects_of_interest_marker_interface_ptr_map, planning_factor_interface},  // NOLINT
+: SceneModuleInterface{
+    name, node, rtc_interface_ptr_map, objects_of_interest_marker_interface_ptr_map,
+    planning_factor_interface},  // NOLINT
   parameters_{*parameters},
   vehicle_info_{autoware::vehicle_info_utils::VehicleInfoUtils(node).getVehicleInfo()},
   vehicle_footprint_{vehicle_info_.createFootprint()},
@@ -315,8 +317,9 @@ void LaneParkingPlanner::onTimer()
       pull_over_path_opt
         ? std::make_optional<GoalCandidate>(pull_over_path_opt.value().modified_goal())
         : std::nullopt;
-    if (goal_planner_utils::is_on_modified_goal(
-          local_planner_data->self_odometry->pose.pose, modified_goal_opt, parameters_)) {
+    if (
+      goal_planner_utils::is_on_modified_goal(
+        local_planner_data->self_odometry->pose.pose, modified_goal_opt, parameters_)) {
       return false;
     }
     return goal_planner_utils::should_regenerate_path_candidates(
@@ -563,8 +566,9 @@ void FreespaceParkingPlanner::onTimer()
     pull_over_path_opt
       ? std::make_optional<GoalCandidate>(pull_over_path_opt.value().modified_goal())
       : std::nullopt;
-  if (goal_planner_utils::is_on_modified_goal(
-        local_planner_data->self_odometry->pose.pose, modified_goal_opt, parameters)) {
+  if (
+    goal_planner_utils::is_on_modified_goal(
+      local_planner_data->self_odometry->pose.pose, modified_goal_opt, parameters)) {
     return;
   }
 
@@ -1018,13 +1022,13 @@ bool GoalPlannerModule::canReturnToLaneParking(const PullOverContextData & conte
 
   const auto & path = lane_parking_path.full_path();
   const auto & curvatures = lane_parking_path.full_path_curvatures();
-  if (goal_planner_utils::checkObjectsCollision(
-        path, curvatures, context_data.static_target_objects, context_data.dynamic_target_objects,
-        planner_data_->parameters,
-        parameters_.object_recognition_collision_check_hard_margins.back(),
-        /*extract_static_objects=*/false, parameters_.maximum_deceleration,
-        parameters_.object_recognition_collision_check_max_extra_stopping_margin,
-        parameters_.collision_check_outer_margin_factor, debug_data_.ego_polygons_expanded)) {
+  if (
+    goal_planner_utils::checkObjectsCollision(
+      path, curvatures, context_data.static_target_objects, context_data.dynamic_target_objects,
+      planner_data_->parameters, parameters_.object_recognition_collision_check_hard_margins.back(),
+      /*extract_static_objects=*/false, parameters_.maximum_deceleration,
+      parameters_.object_recognition_collision_check_max_extra_stopping_margin,
+      parameters_.collision_check_outer_margin_factor, debug_data_.ego_polygons_expanded)) {
     return false;
   }
 
@@ -1351,13 +1355,13 @@ std::optional<PullOverPath> GoalPlannerModule::selectPullOverPath(
     const auto & path = pull_over_path_candidates[i];
     const PathWithLaneId & parking_path = path.parking_path();
     const auto & parking_path_curvatures = path.parking_path_curvatures();
-    if (goal_planner_utils::checkObjectsCollision(
-          parking_path, parking_path_curvatures, context_data.static_target_objects,
-          context_data.dynamic_target_objects, planner_data_->parameters, collision_check_margin,
-          true, parameters_.maximum_deceleration,
-          parameters_.object_recognition_collision_check_max_extra_stopping_margin,
-          parameters_.collision_check_outer_margin_factor, debug_data_.ego_polygons_expanded,
-          true)) {
+    if (
+      goal_planner_utils::checkObjectsCollision(
+        parking_path, parking_path_curvatures, context_data.static_target_objects,
+        context_data.dynamic_target_objects, planner_data_->parameters, collision_check_margin,
+        true, parameters_.maximum_deceleration,
+        parameters_.object_recognition_collision_check_max_extra_stopping_margin,
+        parameters_.collision_check_outer_margin_factor, debug_data_.ego_polygons_expanded, true)) {
       continue;
     }
     if (
@@ -2066,8 +2070,9 @@ bool FreespaceParkingPlanner::isStuck(
     req.get_pull_over_path()
       ? std::make_optional<GoalCandidate>(req.get_pull_over_path().value().modified_goal())
       : std::nullopt;
-  if (goal_planner_utils::is_on_modified_goal(
-        planner_data->self_odometry->pose.pose, modified_goal_opt, parameters)) {
+  if (
+    goal_planner_utils::is_on_modified_goal(
+      planner_data->self_odometry->pose.pose, modified_goal_opt, parameters)) {
     return false;
   }
 
@@ -2082,12 +2087,13 @@ bool FreespaceParkingPlanner::isStuck(
   const auto & path = req.get_pull_over_path().value().getCurrentPath();
   const auto curvatures = autoware::motion_utils::calcCurvature(path.points);
   std::vector<Polygon2d> ego_polygons_expanded;
-  if (goal_planner_utils::checkObjectsCollision(
-        path, curvatures, static_target_objects, dynamic_target_objects, planner_data->parameters,
-        parameters.object_recognition_collision_check_hard_margins.back(),
-        /*extract_static_objects=*/false, parameters.maximum_deceleration,
-        parameters.object_recognition_collision_check_max_extra_stopping_margin,
-        parameters.collision_check_outer_margin_factor, ego_polygons_expanded)) {
+  if (
+    goal_planner_utils::checkObjectsCollision(
+      path, curvatures, static_target_objects, dynamic_target_objects, planner_data->parameters,
+      parameters.object_recognition_collision_check_hard_margins.back(),
+      /*extract_static_objects=*/false, parameters.maximum_deceleration,
+      parameters.object_recognition_collision_check_max_extra_stopping_margin,
+      parameters.collision_check_outer_margin_factor, ego_polygons_expanded)) {
     return true;
   }
 

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_searcher.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_searcher.cpp
@@ -379,14 +379,16 @@ GoalCandidates GoalSearcher::search(
         continue;
       }
 
-      if (goal_planner_utils::isIntersectingAreas(
-            transformed_vehicle_footprint, no_parking_area_polygons_)) {
+      if (
+        goal_planner_utils::isIntersectingAreas(
+          transformed_vehicle_footprint, no_parking_area_polygons_)) {
         // break here to exclude goals located laterally in no_parking_areas
         break;
       }
 
-      if (goal_planner_utils::isIntersectingAreas(
-            transformed_vehicle_footprint, no_stopping_area_polygons_)) {
+      if (
+        goal_planner_utils::isIntersectingAreas(
+          transformed_vehicle_footprint, no_stopping_area_polygons_)) {
         // break here to exclude goals located laterally in no_stopping_areas
         break;
       }
@@ -533,8 +535,9 @@ void GoalSearcher::update(
     const auto target_objects = goal_planner_utils::filterObjectsByLateralDistance(
       goal_pose, planner_data->parameters.vehicle_width, objects,
       parameters_.object_recognition_collision_check_hard_margins.back(), filter_inside);
-    if (checkCollisionWithLongitudinalDistance(
-          goal_pose, target_objects, occupancy_grid_map, planner_data)) {
+    if (
+      checkCollisionWithLongitudinalDistance(
+        goal_pose, target_objects, occupancy_grid_map, planner_data)) {
       goal_candidate.is_safe = false;
       continue;
     }
@@ -555,8 +558,9 @@ bool GoalSearcher::isSafeGoalWithMarginScaleFactor(
   const double margin =
     parameters_.object_recognition_collision_check_hard_margins.back() * margin_scale_factor;
 
-  if (utils::checkCollisionBetweenFootprintAndObjects(
-        vehicle_footprint_, goal_pose, objects, margin)) {
+  if (
+    utils::checkCollisionBetweenFootprintAndObjects(
+      vehicle_footprint_, goal_pose, objects, margin)) {
     return false;
   }
 
@@ -564,8 +568,9 @@ bool GoalSearcher::isSafeGoalWithMarginScaleFactor(
   constexpr bool filter_inside = true;
   const auto target_objects = goal_planner_utils::filterObjectsByLateralDistance(
     goal_pose, planner_data->parameters.vehicle_width, objects, margin, filter_inside);
-  if (checkCollisionWithLongitudinalDistance(
-        goal_pose, target_objects, occupancy_grid_map, planner_data)) {
+  if (
+    checkCollisionWithLongitudinalDistance(
+      goal_pose, target_objects, occupancy_grid_map, planner_data)) {
     return false;
   }
 
@@ -586,9 +591,10 @@ bool GoalSearcher::checkCollision(
     }
   }
 
-  if (utils::checkCollisionBetweenFootprintAndObjects(
-        vehicle_footprint_, pose, objects,
-        parameters_.object_recognition_collision_check_hard_margins.back())) {
+  if (
+    utils::checkCollisionBetweenFootprintAndObjects(
+      vehicle_footprint_, pose, objects,
+      parameters_.object_recognition_collision_check_hard_margins.back())) {
     return true;
   }
   return false;

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/pull_over_planner/geometric_pull_over.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/pull_over_planner/geometric_pull_over.cpp
@@ -80,8 +80,8 @@ std::optional<PullOverPath> GeometricPullOver::plan(
   // todo: Implement lane departure detection that does not depend on the footprint
   const auto resampled_arc_path =
     utils::resamplePathWithSpline(arc_path, parameters_.center_line_path_interval / 2);
-  if (boundary_departure_checker_.checkPathWillLeaveLane(
-        {departure_check_lane}, resampled_arc_path))
+  if (
+    boundary_departure_checker_.checkPathWillLeaveLane({departure_check_lane}, resampled_arc_path))
     return {};
 
   auto pull_over_path_opt = PullOverPath::create(

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/interface.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/interface.cpp
@@ -46,7 +46,13 @@ LaneChangeInterface::LaneChangeInterface(
     objects_of_interest_marker_interface_ptr_map,
   const std::shared_ptr<PlanningFactorInterface> & planning_factor_interface,
   std::unique_ptr<LaneChangeBase> && module_type)
-: SceneModuleInterface{name, node, rtc_interface_ptr_map, objects_of_interest_marker_interface_ptr_map, planning_factor_interface, ModuleStatus::WAITING_APPROVAL},  // NOLINT
+: SceneModuleInterface{
+    name,
+    node,
+    rtc_interface_ptr_map,
+    objects_of_interest_marker_interface_ptr_map,
+    planning_factor_interface,
+    ModuleStatus::WAITING_APPROVAL},  // NOLINT
   parameters_{std::move(parameters)},
   module_type_{std::move(module_type)}
 {

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
@@ -1041,9 +1041,10 @@ FilteredLanesObjects NormalLaneChange::filter_objects() const
 
     const auto ahead_of_ego = ego_object_proximity.is_ahead_of_ego;
 
-    if (utils::lane_change::filter_target_lane_objects(
-          common_data_ptr_, ext_object, dist_ego_to_current_lanes_center, ego_object_proximity,
-          is_before_terminal, target_lane_leading, filtered_objects.target_lane_trailing)) {
+    if (
+      utils::lane_change::filter_target_lane_objects(
+        common_data_ptr_, ext_object, dist_ego_to_current_lanes_center, ego_object_proximity,
+        is_before_terminal, target_lane_leading, filtered_objects.target_lane_trailing)) {
       continue;
     }
 
@@ -1371,8 +1372,9 @@ bool NormalLaneChange::check_candidate_path_safety(
   const LaneChangePath & candidate_path, const lane_change::TargetObjects & target_objects) const
 {
   const auto is_stuck = common_data_ptr_->transient_data.is_ego_stuck;
-  if (utils::lane_change::has_overtaking_turn_lane_object(
-        common_data_ptr_, filtered_objects_.target_lane_trailing)) {
+  if (
+    utils::lane_change::has_overtaking_turn_lane_object(
+      common_data_ptr_, filtered_objects_.target_lane_trailing)) {
     throw std::logic_error("Ego is nearby intersection, and there might be overtaking vehicle.");
   }
 
@@ -1527,8 +1529,9 @@ PathSafetyStatus NormalLaneChange::isApprovedPathSafe() const
     return {false, true};
   }
 
-  if (utils::lane_change::is_delay_lane_change(
-        common_data_ptr_, path, filtered_objects_.target_lane_leading.stopped, debug_data)) {
+  if (
+    utils::lane_change::is_delay_lane_change(
+      common_data_ptr_, path, filtered_objects_.target_lane_leading.stopped, debug_data)) {
     RCLCPP_DEBUG(logger_, "Lane change has been delayed.");
     return {false, false};
   }

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/path.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/path.cpp
@@ -507,8 +507,9 @@ LaneChangePath construct_candidate_path(
     point.lane_ids = target_lane_reference_path.points.at(*nearest_idx).lane_ids;
   }
 
-  if (utils::lane_change::is_intersecting_no_lane_change_lines(
-        common_data_ptr, lane_change_info.length, shifted_path.path.points)) {
+  if (
+    utils::lane_change::is_intersecting_no_lane_change_lines(
+      common_data_ptr, lane_change_info.length, shifted_path.path.points)) {
     throw std::logic_error("Intersect no lane change lines.");
   }
 
@@ -732,8 +733,9 @@ std::optional<LaneChangePath> get_candidate_path(
   info.lane_changing_start = prepare_segment.points.back().point.pose;
   info.lane_changing_end = lane_changing_candidate.poses.back();
 
-  if (utils::lane_change::is_intersecting_no_lane_change_lines(
-        common_data_ptr, info.length, shifted_path.path.points)) {
+  if (
+    utils::lane_change::is_intersecting_no_lane_change_lines(
+      common_data_ptr, info.length, shifted_path.path.points)) {
     throw std::logic_error("Intersect no lane change lines.");
   }
 

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -875,8 +875,9 @@ SetParametersResult BehaviorPathPlannerNode::onSetParam(
       parameters, DrivableAreaExpansionParameters::AVOID_DYN_OBJECTS_PARAM,
       planner_data_->drivable_area_expansion_parameters.object_exclusion.exclude_dynamic);
     std::vector<std::string> strings;
-    if (update_param(
-          parameters, DrivableAreaExpansionParameters::AVOID_LINESTRING_TYPES_PARAM, strings)) {
+    if (
+      update_param(
+        parameters, DrivableAreaExpansionParameters::AVOID_LINESTRING_TYPES_PARAM, strings)) {
       planner_data_->drivable_area_expansion_parameters.avoid_linestring_types.clear();
       for (const auto & s : strings) {
         planner_data_->drivable_area_expansion_parameters.avoid_linestring_types.emplace_back(s);

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/src/planner_manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/src/planner_manager.cpp
@@ -276,8 +276,9 @@ void PlannerManager::updateCurrentRouteLanelet(
       return;
     }
     lanelet::ConstLanelet constrained{};
-    if (route_handler->getClosestLaneletWithConstrainsWithinRoute(
-          pose, &constrained, p.ego_nearest_dist_threshold, p.ego_nearest_yaw_threshold)) {
+    if (
+      route_handler->getClosestLaneletWithConstrainsWithinRoute(
+        pose, &constrained, p.ego_nearest_dist_threshold, p.ego_nearest_yaw_threshold)) {
       *current_route_lanelet_ = constrained;
       return;
     }
@@ -292,9 +293,10 @@ void PlannerManager::updateCurrentRouteLanelet(
 
   lanelet::ConstLanelet closest_lane{};
 
-  if (route_handler->getClosestRouteLaneletFromLanelet(
-        pose, current_route_lanelet_->value(), &closest_lane, p.ego_nearest_dist_threshold,
-        p.ego_nearest_yaw_threshold)) {
+  if (
+    route_handler->getClosestRouteLaneletFromLanelet(
+      pose, current_route_lanelet_->value(), &closest_lane, p.ego_nearest_dist_threshold,
+      p.ego_nearest_yaw_threshold)) {
     *current_route_lanelet_ = closest_lane;
     snap_to_global_route_if_ego_out();
     return;
@@ -309,9 +311,10 @@ void PlannerManager::updateCurrentRouteLanelet(
     closest_lane = *opt;
     *current_route_lanelet_ = closest_lane;
     snap_to_global_route_if_ego_out();
-  } else if (const auto opt_constraint =
-               experimental::lanelet2_utils::get_closest_lanelet(lanelet_sequence, pose);
-             opt_constraint) {
+  } else if (
+    const auto opt_constraint =
+      experimental::lanelet2_utils::get_closest_lanelet(lanelet_sequence, pose);
+    opt_constraint) {
     *current_route_lanelet_ = opt_constraint.value();
     snap_to_global_route_if_ego_out();
   } else if (!is_any_approved_module_running) {
@@ -500,10 +503,11 @@ std::vector<SceneModulePtr> SubPlannerManager::getRequestModules(
     }
     BOOST_SCOPE_EXIT_END;
 
-    if (const auto deleted_it = std::find_if(
-          deleted_modules.begin(), deleted_modules.end(),
-          [&](const auto & m) { return m->name() == manager_ptr->name(); });
-        deleted_it != deleted_modules.end()) {
+    if (
+      const auto deleted_it = std::find_if(
+        deleted_modules.begin(), deleted_modules.end(),
+        [&](const auto & m) { return m->name() == manager_ptr->name(); });
+      deleted_it != deleted_modules.end()) {
       continue;
     }
 

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/turn_signal_decider.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/turn_signal_decider.cpp
@@ -104,8 +104,9 @@ TurnIndicatorsCommand TurnSignalDecider::getTurnSignal(
   // In roundabouts, backward length is needed to adjust the backward length to ensure proper path
   // planning.
   lanelet::ConstLanelet current_lanelet;
-  if (route_handler->getClosestLaneletWithConstrainsWithinRoute(
-        current_pose, &current_lanelet, nearest_dist_threshold, nearest_yaw_threshold)) {
+  if (
+    route_handler->getClosestLaneletWithConstrainsWithinRoute(
+      current_pose, &current_lanelet, nearest_dist_threshold, nearest_yaw_threshold)) {
     backward_length = calculateRoundaboutBackwardLength(
       current_lanelet, *route_handler, backward_length, roundabout_backward_depth_);
   }
@@ -1042,9 +1043,10 @@ std::pair<TurnSignalInfo, bool> TurnSignalDecider::getBehaviorTurnSignalInfo(
   // If the ego has stopped and its close to completing its shift, turn off the blinkers
   constexpr double STOPPED_THRESHOLD = 0.1;  // [m/s]
   if (ego_speed < STOPPED_THRESHOLD && !override_ego_stopped_check) {
-    if (isNearEndOfShift(
-          start_shift_length, end_shift_length, ego_pose.position, current_lanelets,
-          p.turn_signal_shift_length_threshold)) {
+    if (
+      isNearEndOfShift(
+        start_shift_length, end_shift_length, ego_pose.position, current_lanelets,
+        p.turn_signal_shift_length_threshold)) {
       return std::make_pair(TurnSignalInfo(p_path_start, p_path_end), true);
     }
   }

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
@@ -256,9 +256,10 @@ std::vector<double> calculate_maximum_distance(
         maximum_distances[i + 1] = 0.0;
         break;
       }
-      if (std::all_of(
-            uncrossable_poly.outer().begin(), uncrossable_poly.outer().end(),
-            is_point_on_correct_side)) {
+      if (
+        std::all_of(
+          uncrossable_poly.outer().begin(), uncrossable_poly.outer().end(),
+          is_point_on_correct_side)) {
         const auto bound_to_poly_dist = boost::geometry::distance(segment_ls, uncrossable_poly);
         maximum_distances[i] = std::min(maximum_distances[i], bound_to_poly_dist);
         maximum_distances[i + 1] = std::min(maximum_distances[i + 1], bound_to_poly_dist);

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/static_drivable_area.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/static_drivable_area.cpp
@@ -1433,11 +1433,13 @@ std::pair<std::vector<lanelet::ConstPoint3d>, bool> getBoundWithFreeSpaceAreas(
   const auto route_case = [&]() {
     if (original_bound_itr->id() != original_bound_rev_itr->id()) {
       return RouteCase::ROUTE_IS_PASS_THROUGH_FREESPACE;
-    } else if (boost::geometry::within(
-                 to2D(original_bound.front().basicPoint()), to2D(polygon).basicPolygon())) {
+    } else if (
+      boost::geometry::within(
+        to2D(original_bound.front().basicPoint()), to2D(polygon).basicPolygon())) {
       return RouteCase::INIT_POS_IS_IN_FREESPACE;
-    } else if (boost::geometry::within(
-                 to2D(original_bound.back().basicPoint()), to2D(polygon).basicPolygon())) {
+    } else if (
+      boost::geometry::within(
+        to2D(original_bound.back().basicPoint()), to2D(polygon).basicPolygon())) {
       return RouteCase::GOAL_POS_IS_IN_FREESPACE;
     }
     return RouteCase::OTHER;
@@ -1521,8 +1523,9 @@ std::vector<geometry_msgs::msg::Point> postProcess(
         if (checkHasSameLane(ignore_lanelets, transformed_lane)) {
           continue;
         }
-        if (boost::geometry::intersects(
-              lane.polygon2d().basicPolygon(), transformed_lane.polygon2d().basicPolygon())) {
+        if (
+          boost::geometry::intersects(
+            lane.polygon2d().basicPolygon(), transformed_lane.polygon2d().basicPolygon())) {
           return true;
         }
       }

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/traffic_light_utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/traffic_light_utils.cpp
@@ -149,8 +149,9 @@ bool isTrafficSignalStop(
         continue;
       }
 
-      if (autoware::traffic_light_utils::isTrafficSignalStop(
-            lanelet, traffic_signal_stamped.value().signal)) {
+      if (
+        autoware::traffic_light_utils::isTrafficSignalStop(
+          lanelet, traffic_signal_stamped.value().signal)) {
         return true;
       }
     }

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/utils.cpp
@@ -129,8 +129,9 @@ bool checkCollisionBetweenPathFootprintsAndObjects(
   const PredictedObjects & dynamic_objects, const double margin)
 {
   for (const auto & p : ego_path.points) {
-    if (checkCollisionBetweenFootprintAndObjects(
-          local_vehicle_footprint, p.point.pose, dynamic_objects, margin)) {
+    if (
+      checkCollisionBetweenFootprintAndObjects(
+        local_vehicle_footprint, p.point.pose, dynamic_objects, margin)) {
       return true;
     }
   }
@@ -292,9 +293,10 @@ void fillLaneIdsFromMap(Iterator begin, Iterator end, const lanelet::ConstLanele
 {
   for (auto it = begin; it != end; ++it) {
     const auto point = it->point;
-    if (const auto lanelet_opt =
-          experimental::lanelet2_utils::get_closest_lanelet(lanelets, point.pose);
-        lanelet_opt) {
+    if (
+      const auto lanelet_opt =
+        experimental::lanelet2_utils::get_closest_lanelet(lanelets, point.pose);
+      lanelet_opt) {
       // TODO(hisaki): Writing "it->lane_ids = {lanelet.id()}" may cause a segmentation fault.
       // I'm not sure of the reason. (╥﹏╥)
       auto & ids = it->lane_ids;
@@ -480,9 +482,10 @@ PathWithLaneId refinePathForGoal(
     filtered_path.points.back().point.longitudinal_velocity_mps = 0.0;
   }
 
-  if (set_goal(
-        search_radius_range, search_rad_range, output_path_interval, filtered_path, goal,
-        goal_lane_id, get_lanelet_by_id, &path_with_goal)) {
+  if (
+    set_goal(
+      search_radius_range, search_rad_range, output_path_interval, filtered_path, goal,
+      goal_lane_id, get_lanelet_by_id, &path_with_goal)) {
     return path_with_goal;
   }
   return filtered_path;

--- a/planning/behavior_path_planner/autoware_behavior_path_sampling_planner_module/src/sampling_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_sampling_planner_module/src/sampling_planner_module.cpp
@@ -47,7 +47,9 @@ SamplingPlannerModule::SamplingPlannerModule(
   std::unordered_map<std::string, std::shared_ptr<ObjectsOfInterestMarkerInterface>> &
     objects_of_interest_marker_interface_ptr_map,
   const std::shared_ptr<PlanningFactorInterface> planning_factor_interface)
-: SceneModuleInterface{name, node, rtc_interface_ptr_map, objects_of_interest_marker_interface_ptr_map, planning_factor_interface},  // NOLINT
+: SceneModuleInterface{
+    name, node, rtc_interface_ptr_map, objects_of_interest_marker_interface_ptr_map,
+    planning_factor_interface},  // NOLINT
   vehicle_info_{autoware::vehicle_info_utils::VehicleInfoUtils(node).getVehicleInfo()}
 {
   internal_params_ = std::make_shared<SamplingPlannerInternalParameters>();

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
@@ -47,7 +47,9 @@ SideShiftModule::SideShiftModule(
   std::unordered_map<std::string, std::shared_ptr<ObjectsOfInterestMarkerInterface>> &
     objects_of_interest_marker_interface_ptr_map,
   const std::shared_ptr<PlanningFactorInterface> planning_factor_interface)
-: SceneModuleInterface{name, node, rtc_interface_ptr_map, objects_of_interest_marker_interface_ptr_map, planning_factor_interface},  // NOLINT
+: SceneModuleInterface{
+    name, node, rtc_interface_ptr_map, objects_of_interest_marker_interface_ptr_map,
+    planning_factor_interface},  // NOLINT
   parameters_{parameters}
 {
 }

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/clothoid_pull_out.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/clothoid_pull_out.cpp
@@ -1425,9 +1425,9 @@ std::optional<PullOutPath> ClothoidPullOut::plan(
     // Create PullOutPath for collision check
     const PullOutPath temp_pull_out_path{{clothoid_path}, {}, start_pose, target_pose, {}};
 
-    if (isPullOutPathCollided(
-          temp_pull_out_path, planner_data,
-          parameters_.clothoid_collision_check_distance_from_end)) {
+    if (
+      isPullOutPathCollided(
+        temp_pull_out_path, planner_data, parameters_.clothoid_collision_check_distance_from_end)) {
       RCLCPP_INFO(
         rclcpp::get_logger("ClothoidPullOut"),
         "Collision detected for steer angle %.2f deg with margin %.2f m. Continuing to next "

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/geometric_pull_out.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/geometric_pull_out.cpp
@@ -136,8 +136,9 @@ std::optional<PullOutPath> GeometricPullOut::plan(
     start_planner_utils::calc_start_and_end_shift_length(
       pull_out_lanes, output.start_pose, output.end_pose);
 
-  if (isPullOutPathCollided(
-        output, planner_data, parameters_.geometric_collision_check_distance_from_end)) {
+  if (
+    isPullOutPathCollided(
+      output, planner_data, parameters_.geometric_collision_check_distance_from_end)) {
     planner_debug_data.conditions_evaluation.emplace_back("collision");
     return {};
   }

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/shift_pull_out.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/shift_pull_out.cpp
@@ -170,8 +170,9 @@ std::optional<PullOutPath> ShiftPullOut::plan(
     shift_path.points = cropped_path.points;
     shift_path.header = planner_data->route_handler->getRouteHeader();
 
-    if (isPullOutPathCollided(
-          pull_out_path, planner_data, parameters_.shift_collision_check_distance_from_end)) {
+    if (
+      isPullOutPathCollided(
+        pull_out_path, planner_data, parameters_.shift_collision_check_distance_from_end)) {
       planner_debug_data.conditions_evaluation.emplace_back("collision");
       continue;
     }
@@ -219,10 +220,11 @@ bool ShiftPullOut::refineShiftedPathToStartPose(
       return false;
     }
 
-    if (is_within_tolerance(
-          lateral_offset,
-          autoware::motion_utils::calcLateralOffset(shifted_path.path.points, start_pose.position),
-          TOLERANCE)) {
+    if (
+      is_within_tolerance(
+        lateral_offset,
+        autoware::motion_utils::calcLateralOffset(shifted_path.path.points, start_pose.position),
+        TOLERANCE)) {
       return true;
     }
 

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -107,7 +107,9 @@ StartPlannerModule::StartPlannerModule(
   std::unordered_map<std::string, std::shared_ptr<ObjectsOfInterestMarkerInterface>> &
     objects_of_interest_marker_interface_ptr_map,
   const std::shared_ptr<PlanningFactorInterface> planning_factor_interface)
-: SceneModuleInterface{name, node, rtc_interface_ptr_map, objects_of_interest_marker_interface_ptr_map, planning_factor_interface},  // NOLINT
+: SceneModuleInterface{
+    name, node, rtc_interface_ptr_map, objects_of_interest_marker_interface_ptr_map,
+    planning_factor_interface},  // NOLINT
   parameters_{parameters},
   vehicle_info_{autoware::vehicle_info_utils::VehicleInfoUtils(node).getVehicleInfo()},
   is_freespace_planner_cb_running_{false}
@@ -1235,9 +1237,10 @@ void StartPlannerModule::planWithPriority(
 
     for (const auto & collision_check_margin : parameters_->collision_check_margins) {
       for (const auto & [index, planner] : order_priority) {
-        if (findPullOutPath(
-              start_pose_candidates[index], planner, refined_start_pose, goal_pose,
-              collision_check_margin, debug_data_vector)) {
+        if (
+          findPullOutPath(
+            start_pose_candidates[index], planner, refined_start_pose, goal_pose,
+            collision_check_margin, debug_data_vector)) {
           debug_data_.selected_start_pose_candidate_index = index;
           debug_data_.margin_for_start_pose_candidate = collision_check_margin;
           set_planner_evaluation_table(debug_data_vector);
@@ -1620,9 +1623,10 @@ std::vector<Pose> StartPlannerModule::searchPullOutStartPoseCandidates(
       back_path_from_start_pose.points, start_pose.position, -back_distance);
     if (!backed_pose) continue;
 
-    if (utils::checkCollisionBetweenFootprintAndObjects(
-          local_vehicle_footprint, *backed_pose, front_stop_objects_in_pull_out_lanes,
-          parameters_->collision_check_margin_from_front_object))
+    if (
+      utils::checkCollisionBetweenFootprintAndObjects(
+        local_vehicle_footprint, *backed_pose, front_stop_objects_in_pull_out_lanes,
+        parameters_->collision_check_margin_from_front_object))
       continue;
 
     const double backed_pose_arc_length =
@@ -1640,9 +1644,10 @@ std::vector<Pose> StartPlannerModule::searchPullOutStartPoseCandidates(
       continue;
     }
 
-    if (utils::checkCollisionBetweenFootprintAndObjects(
-          local_vehicle_footprint, *backed_pose, stop_objects_in_pull_out_lanes,
-          parameters_->collision_check_margins.back())) {
+    if (
+      utils::checkCollisionBetweenFootprintAndObjects(
+        local_vehicle_footprint, *backed_pose, stop_objects_in_pull_out_lanes,
+        parameters_->collision_check_margins.back())) {
       break;  // poses behind this has a collision, so break.
     }
 

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
@@ -85,7 +85,9 @@ StaticObstacleAvoidanceModule::StaticObstacleAvoidanceModule(
   std::unordered_map<std::string, std::shared_ptr<ObjectsOfInterestMarkerInterface>> &
     objects_of_interest_marker_interface_ptr_map,
   const std::shared_ptr<PlanningFactorInterface> & planning_factor_interface)
-: SceneModuleInterface{name, node, rtc_interface_ptr_map, objects_of_interest_marker_interface_ptr_map, planning_factor_interface},  // NOLINT
+: SceneModuleInterface{
+    name, node, rtc_interface_ptr_map, objects_of_interest_marker_interface_ptr_map,
+    planning_factor_interface},  // NOLINT
   helper_{std::make_shared<AvoidanceHelper>(parameters)},
   parameters_{parameters},
   generator_{parameters}
@@ -1573,9 +1575,10 @@ bool StaticObstacleAvoidanceModule::isValidShiftLine(
       const size_t start_idx = shift_line.start_idx;
       const size_t end_idx = shift_line.end_idx;
 
-      if (is_return_shift(
-            shift_line.start_shift_length, shift_line.end_shift_length,
-            parameters_->lateral_small_shift_threshold)) {
+      if (
+        is_return_shift(
+          shift_line.start_shift_length, shift_line.end_shift_length,
+          parameters_->lateral_small_shift_threshold)) {
         continue;
       }
 
@@ -1657,9 +1660,10 @@ bool StaticObstacleAvoidanceModule::is_operator_approval_required(
   if (is_close_distance_avoidance) {
     return parameters_->policy_close_distance_avoidance == "manual";
   }
-  if (is_return_shift(
-        shift_line.start_shift_length, shift_line.end_shift_length,
-        parameters_->lateral_small_shift_threshold)) {
+  if (
+    is_return_shift(
+      shift_line.start_shift_length, shift_line.end_shift_length,
+      parameters_->lateral_small_shift_threshold)) {
     return false;
   }
 

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
@@ -343,20 +343,22 @@ bool isWithinFreespace(
  */
 bool isOnEgoLane(const ObjectData & object, const std::shared_ptr<RouteHandler> & route_handler)
 {
-  if (boost::geometry::within(
-        lanelet::utils::to2D(experimental::lanelet2_utils::from_ros(object.getPosition()))
-          .basicPoint(),
-        object.overhang_lanelet.polygon2d().basicPolygon())) {
+  if (
+    boost::geometry::within(
+      lanelet::utils::to2D(experimental::lanelet2_utils::from_ros(object.getPosition()))
+        .basicPoint(),
+      object.overhang_lanelet.polygon2d().basicPolygon())) {
     return true;
   }
 
   // push previous lanelet
   lanelet::ConstLanelets prev_lanelet;
   if (route_handler->getPreviousLaneletsWithinRoute(object.overhang_lanelet, &prev_lanelet)) {
-    if (boost::geometry::within(
-          lanelet::utils::to2D(experimental::lanelet2_utils::from_ros(object.getPosition()))
-            .basicPoint(),
-          prev_lanelet.front().polygon2d().basicPolygon())) {
+    if (
+      boost::geometry::within(
+        lanelet::utils::to2D(experimental::lanelet2_utils::from_ros(object.getPosition()))
+          .basicPoint(),
+        prev_lanelet.front().polygon2d().basicPolygon())) {
       return true;
     }
   }
@@ -364,18 +366,20 @@ bool isOnEgoLane(const ObjectData & object, const std::shared_ptr<RouteHandler> 
   // push next lanelet
   lanelet::ConstLanelet next_lanelet;
   if (route_handler->getNextLaneletWithinRoute(object.overhang_lanelet, &next_lanelet)) {
-    if (boost::geometry::within(
-          lanelet::utils::to2D(experimental::lanelet2_utils::from_ros(object.getPosition()))
-            .basicPoint(),
-          next_lanelet.polygon2d().basicPolygon())) {
+    if (
+      boost::geometry::within(
+        lanelet::utils::to2D(experimental::lanelet2_utils::from_ros(object.getPosition()))
+          .basicPoint(),
+        next_lanelet.polygon2d().basicPolygon())) {
       return true;
     }
   } else {
     for (const auto & lane : route_handler->getNextLanelets(object.overhang_lanelet)) {
-      if (boost::geometry::within(
-            lanelet::utils::to2D(experimental::lanelet2_utils::from_ros(object.getPosition()))
-              .basicPoint(),
-            lane.polygon2d().basicPolygon())) {
+      if (
+        boost::geometry::within(
+          lanelet::utils::to2D(experimental::lanelet2_utils::from_ros(object.getPosition()))
+            .basicPoint(),
+          lane.polygon2d().basicPolygon())) {
         return true;
       }
     }
@@ -475,9 +479,10 @@ double getShiftableRatio(
       most_left_lanelet.attribute(lanelet::AttributeName::Subtype);
     if (sub_type == "road_shoulder") {
       // assuming it's parked vehicle if its CoG is within road shoulder lanelet.
-      if (boost::geometry::within(
-            to2D(from_ros(object.getPosition())).basicPoint(),
-            most_left_lanelet.polygon2d().basicPolygon())) {
+      if (
+        boost::geometry::within(
+          to2D(from_ros(object.getPosition())).basicPoint(),
+          most_left_lanelet.polygon2d().basicPolygon())) {
         return true;
       }
     } else {
@@ -522,9 +527,10 @@ double getShiftableRatio(
       most_right_lanelet.attribute(lanelet::AttributeName::Subtype);
     if (sub_type == "road_shoulder") {
       // assuming it's parked vehicle if its CoG is within road shoulder lanelet.
-      if (boost::geometry::within(
-            to2D(from_ros(object.getPosition())).basicPoint(),
-            most_right_lanelet.polygon2d().basicPolygon())) {
+      if (
+        boost::geometry::within(
+          to2D(from_ros(object.getPosition())).basicPoint(),
+          most_right_lanelet.polygon2d().basicPolygon())) {
         return true;
       }
     } else {
@@ -1475,16 +1481,18 @@ std::vector<UUID> concatParentIds(const std::vector<UUID> & ids1, const std::vec
   std::vector<UUID> ret;
 
   for (const auto & id : ids1) {
-    if (std::any_of(
-          ret.begin(), ret.end(), [&id](const auto & exist_id) { return exist_id == id; })) {
+    if (std::any_of(ret.begin(), ret.end(), [&id](const auto & exist_id) {
+          return exist_id == id;
+        })) {
       continue;
     }
     ret.push_back(id);
   }
 
   for (const auto & id : ids2) {
-    if (std::any_of(
-          ret.begin(), ret.end(), [&id](const auto & exist_id) { return exist_id == id; })) {
+    if (std::any_of(ret.begin(), ret.end(), [&id](const auto & exist_id) {
+          return exist_id == id;
+        })) {
       continue;
     }
     ret.push_back(id);

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/experimental/manager.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/experimental/manager.cpp
@@ -61,8 +61,9 @@ void BlindSpotModuleManager::launchNewModules(
       continue;
     }
 
-    if (get_neighboring_turn_lanelet(
-          planner_data.route_handler_, ll, planner_data.current_odometry->pose)) {
+    if (
+      get_neighboring_turn_lanelet(
+        planner_data.route_handler_, ll, planner_data.current_odometry->pose)) {
       continue;
     }
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/experimental/time_to_collision.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/experimental/time_to_collision.cpp
@@ -110,8 +110,9 @@ std::optional<TimeInterval> compute_passage_time_interval(
   for (const auto & [pose, time] : future_profile) {
     const auto path_point_footprint =
       autoware_utils::transform_vector(footprint, autoware_utils::pose2transform(pose));
-    if (boost::geometry::intersects(
-          path_point_footprint, lanelet::utils::to2D(entry_line).basicLineString())) {
+    if (
+      boost::geometry::intersects(
+        path_point_footprint, lanelet::utils::to2D(entry_line).basicLineString())) {
       entry_time = time;
       break;
     }
@@ -125,8 +126,9 @@ std::optional<TimeInterval> compute_passage_time_interval(
   for (const auto & [pose, time] : future_profile | ranges::views::reverse) {
     const auto path_point_footprint =
       autoware_utils::transform_vector(footprint, autoware_utils::pose2transform(pose));
-    if (boost::geometry::intersects(
-          path_point_footprint, lanelet::utils::to2D(exit_line).basicLineString())) {
+    if (
+      boost::geometry::intersects(
+        path_point_footprint, lanelet::utils::to2D(exit_line).basicLineString())) {
       exit_time = time;
       break;
     }
@@ -167,8 +169,9 @@ compute_passage_time_intervals(
       if (boost::geometry::intersects(object_poly, lanelet::utils::to2D(line1).basicLineString())) {
         entry_time = i * new_time_step;
         break;
-      } else if (boost::geometry::intersects(
-                   object_poly, lanelet::utils::to2D(entry_line).basicLineString())) {
+      } else if (
+        boost::geometry::intersects(
+          object_poly, lanelet::utils::to2D(entry_line).basicLineString())) {
         entry_time = i * new_time_step;
         break;
       }

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/manager.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/manager.cpp
@@ -60,8 +60,9 @@ void BlindSpotModuleManager::launchNewModules(
     const auto turn_direction =
       turn_direction_str == "left" ? TurnDirection::Left : TurnDirection::Right;
 
-    if (get_neighboring_turn_lanelet(
-          planner_data_->route_handler_, ll, planner_data_->current_odometry->pose)) {
+    if (
+      get_neighboring_turn_lanelet(
+        planner_data_->route_handler_, ll, planner_data_->current_odometry->pose)) {
       continue;
     }
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/scene.cpp
@@ -384,10 +384,11 @@ std::vector<UnsafeObject> BlindSpotModule::collect_unsafe_objects(
       compute_time_interval_for_passing_line(attention_object, first_line, entry_line, second_line);
     for (const auto & object_passage_interval : object_passage_intervals) {
       const auto & [object_entry, object_exit, predicted_path] = object_passage_interval;
-      if (const auto collision_time = get_unsafe_time_if_critical(
-            ego_passage_time_interval, {object_entry, object_exit}, planner_param_.ttc_start_margin,
-            planner_param_.ttc_end_margin);
-          collision_time) {
+      if (
+        const auto collision_time = get_unsafe_time_if_critical(
+          ego_passage_time_interval, {object_entry, object_exit}, planner_param_.ttc_start_margin,
+          planner_param_.ttc_end_margin);
+        collision_time) {
         unsafe_objects.emplace_back(
           attention_object, collision_time.value(), predicted_path,
           std::make_pair(object_entry, object_exit));

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/time_to_collision.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/time_to_collision.cpp
@@ -126,8 +126,9 @@ std::optional<std::pair<double, double>> compute_time_interval_for_passing_line(
     const auto & base_pose = path_point.point.pose;
     const auto path_point_footprint =
       autoware_utils::transform_vector(footprint, autoware_utils::pose2transform(base_pose));
-    if (boost::geometry::intersects(
-          path_point_footprint, lanelet::utils::to2D(line1).basicLineString())) {
+    if (
+      boost::geometry::intersects(
+        path_point_footprint, lanelet::utils::to2D(line1).basicLineString())) {
       entry_time = time;
       break;
     }
@@ -142,8 +143,9 @@ std::optional<std::pair<double, double>> compute_time_interval_for_passing_line(
     const auto & base_pose = path_point.point.pose;
     const auto path_point_footprint =
       autoware_utils::transform_vector(footprint, autoware_utils::pose2transform(base_pose));
-    if (boost::geometry::intersects(
-          path_point_footprint, lanelet::utils::to2D(line2).basicLineString())) {
+    if (
+      boost::geometry::intersects(
+        path_point_footprint, lanelet::utils::to2D(line2).basicLineString())) {
       exit_time = time;
       break;
     }

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/util.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/util.cpp
@@ -152,12 +152,14 @@ lanelet::ConstLanelet get_leftside_lanelet(
   const auto leftmost_ex =
     autoware::experimental::lanelet2_utils::leftmost_lanelet(lanelet, routing_graph_ptr);
   const auto leftmost_road_lane = leftmost_ex ? leftmost_ex.value() : lanelet;
-  if (const auto left_shoulder = route_handler->getLeftShoulderLanelet(leftmost_road_lane);
-      left_shoulder) {
+  if (
+    const auto left_shoulder = route_handler->getLeftShoulderLanelet(leftmost_road_lane);
+    left_shoulder) {
     return left_shoulder.value();
   }
-  if (const auto left_bicycle_lane = route_handler->getLeftBicycleLanelet(leftmost_road_lane);
-      left_bicycle_lane) {
+  if (
+    const auto left_bicycle_lane = route_handler->getLeftBicycleLanelet(leftmost_road_lane);
+    left_bicycle_lane) {
     return left_bicycle_lane.value();
   }
   return leftmost_road_lane;
@@ -175,12 +177,14 @@ lanelet::ConstLanelet get_rightside_lanelet(
   const auto rightmost_ex =
     autoware::experimental::lanelet2_utils::rightmost_lanelet(lanelet, routing_graph_ptr);
   const auto rightmost_road_lane = rightmost_ex ? rightmost_ex.value() : lanelet;
-  if (const auto right_shoulder = route_handler->getRightShoulderLanelet(rightmost_road_lane);
-      right_shoulder) {
+  if (
+    const auto right_shoulder = route_handler->getRightShoulderLanelet(rightmost_road_lane);
+    right_shoulder) {
     return right_shoulder.value();
   }
-  if (const auto right_bicycle_lane = route_handler->getRightBicycleLanelet(rightmost_road_lane);
-      right_bicycle_lane) {
+  if (
+    const auto right_bicycle_lane = route_handler->getRightBicycleLanelet(rightmost_road_lane);
+    right_bicycle_lane) {
     return right_bicycle_lane.value();
   }
   return rightmost_road_lane;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/experimental/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/experimental/scene_crosswalk.cpp
@@ -935,8 +935,9 @@ std::optional<double> CrosswalkModule::findObjectPassageDirectionAlongVehicleLan
     for (unsigned i = 0; i < path.path.size() - 1; ++i) {
       const auto & start = path.path.at(i).position;
       const auto & end = path.path.at(i + 1).position;
-      if (const auto intersect = autoware_utils::intersect(line_start, line_end, start, end);
-          intersect.has_value()) {
+      if (
+        const auto intersect = autoware_utils::intersect(line_start, line_end, start, end);
+        intersect.has_value()) {
         return std::make_optional(std::make_pair(i, intersect.value()));
       }
     }
@@ -1187,8 +1188,9 @@ void CrosswalkModule::applySlowDownByOcclusion(
     detection_range);
   debug_data_.occlusion_detection_areas = detection_areas;
   debug_data_.crosswalk_origin = first_path_point_on_crosswalk;
-  if (is_crosswalk_occluded(
-        *planner_data.occupancy_grid, detection_areas, objects_ptr->objects, planner_param_)) {
+  if (
+    is_crosswalk_occluded(
+      *planner_data.occupancy_grid, detection_areas, objects_ptr->objects, planner_param_)) {
     if (!current_initial_occlusion_time_) {
       current_initial_occlusion_time_ = now;
     }
@@ -1390,9 +1392,10 @@ std::optional<StopPoseWithObjectUuids> CrosswalkModule::checkStopForParkedVehicl
       const auto zero_vel_s =
         autoware::experimental::trajectory::search_zero_velocity_position(ego_path, ego_s)) {
       const auto zero_vel_point = ego_path.compute(*zero_vel_s).point;
-      if (boost::geometry::within(
-            lanelet::BasicPoint2d(zero_vel_point.pose.position.x, zero_vel_point.pose.position.y),
-            parked_vehicles_stop_.search_area)) {
+      if (
+        boost::geometry::within(
+          lanelet::BasicPoint2d(zero_vel_point.pose.position.x, zero_vel_point.pose.position.y),
+          parked_vehicles_stop_.search_area)) {
         is_stop_planned = true;
       }
     }
@@ -1442,8 +1445,9 @@ std::optional<StopPoseWithObjectUuids> CrosswalkModule::checkStopForParkedVehicl
     const auto & obj_pose = target.kinematics.initial_pose_with_covariance.pose;
     const auto obj_point = obj_pose.position;
 
-    if (boost::geometry::within(
-          lanelet::BasicPoint2d(obj_point.x, obj_point.y), parked_vehicles_stop_.search_area)) {
+    if (
+      boost::geometry::within(
+        lanelet::BasicPoint2d(obj_point.x, obj_point.y), parked_vehicles_stop_.search_area)) {
       const auto obj_s =
         autoware::experimental::trajectory::find_nearest_index(ego_path, obj_point);
       if (obj_s > max_s_value) {

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
@@ -722,8 +722,9 @@ std::optional<double> CrosswalkModule::findEgoPassageDirectionAlongPath(
     for (unsigned i = 0; i < sparse_resample_path.points.size() - 1; ++i) {
       const auto & start = sparse_resample_path.points.at(i).point.pose.position;
       const auto & end = sparse_resample_path.points.at(i + 1).point.pose.position;
-      if (const auto intersect = autoware_utils::intersect(line_start, line_end, start, end);
-          intersect.has_value()) {
+      if (
+        const auto intersect = autoware_utils::intersect(line_start, line_end, start, end);
+        intersect.has_value()) {
         return intersect;
       }
     }
@@ -753,8 +754,9 @@ std::optional<double> CrosswalkModule::findObjectPassageDirectionAlongVehicleLan
     for (unsigned i = 0; i < path.path.size() - 1; ++i) {
       const auto & start = path.path.at(i).position;
       const auto & end = path.path.at(i + 1).position;
-      if (const auto intersect = autoware_utils::intersect(line_start, line_end, start, end);
-          intersect.has_value()) {
+      if (
+        const auto intersect = autoware_utils::intersect(line_start, line_end, start, end);
+        intersect.has_value()) {
         return std::make_optional(std::make_pair(i, intersect.value()));
       }
     }
@@ -998,8 +1000,9 @@ void CrosswalkModule::applySlowDownByOcclusion(
     detection_range);
   debug_data_.occlusion_detection_areas = detection_areas;
   debug_data_.crosswalk_origin = first_path_point_on_crosswalk;
-  if (is_crosswalk_occluded(
-        *planner_data_->occupancy_grid, detection_areas, objects_ptr->objects, planner_param_)) {
+  if (
+    is_crosswalk_occluded(
+      *planner_data_->occupancy_grid, detection_areas, objects_ptr->objects, planner_param_)) {
     if (!current_initial_occlusion_time_) {
       current_initial_occlusion_time_ = now;
     }

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/experimental/manager.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/experimental/manager.cpp
@@ -341,8 +341,9 @@ void IntersectionModuleManager::launchNewModules(
     const auto associative_ids =
       planning_utils::getAssociativeIntersectionLanelets(ll, lanelet_map, routing_graph);
     bool has_traffic_light = false;
-    if (const auto tl_reg_elems = ll.regulatoryElementsAs<lanelet::TrafficLight>();
-        tl_reg_elems.size() != 0) {
+    if (
+      const auto tl_reg_elems = ll.regulatoryElementsAs<lanelet::TrafficLight>();
+      tl_reg_elems.size() != 0) {
       const auto tl_reg_elem = tl_reg_elems.front();
       const auto stopline_opt = tl_reg_elem->stopLine();
       if (!!stopline_opt) has_traffic_light = true;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/experimental/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/experimental/scene_intersection.cpp
@@ -308,8 +308,8 @@ DecisionResult IntersectionModule::modifyPathVelocityDetail(
   const auto is_stuck_status =
     isStuckStatus(*path, intersection_stoplines, path_lanelets, planner_data);
   if (is_stuck_status) {
-    if (can_smoothly_stop_at(
-          *path, closest_idx, is_stuck_status->stuck_stopline_idx, planner_data)) {
+    if (
+      can_smoothly_stop_at(*path, closest_idx, is_stuck_status->stuck_stopline_idx, planner_data)) {
       return is_stuck_status.value();
     }
     RCLCPP_ERROR_THROTTLE(
@@ -449,9 +449,10 @@ DecisionResult IntersectionModule::modifyPathVelocityDetail(
     if (
       has_collision_with_margin && !has_traffic_light_ && enable_conservative_yield_merging &&
       intersection_stoplines.maximum_footprint_overshoot_line) {
-      if (can_smoothly_stop_at(
-            *path, closest_idx, intersection_stoplines.maximum_footprint_overshoot_line.value(),
-            planner_data)) {
+      if (
+        can_smoothly_stop_at(
+          *path, closest_idx, intersection_stoplines.maximum_footprint_overshoot_line.value(),
+          planner_data)) {
         // NOTE(soblin): intersection_stoplines.maximum_footprint_overshoot_line.value() is not used
         // as stop line. in this case, ego tries to stop at current position
         const auto stop_line_idx = closest_idx;
@@ -489,8 +490,9 @@ DecisionResult IntersectionModule::modifyPathVelocityDetail(
   const auto yield_stuck_status =
     isYieldStuckStatus(*path, interpolated_path_info, intersection_stoplines, planner_data);
   if (yield_stuck_status) {
-    if (can_smoothly_stop_at(
-          *path, closest_idx, yield_stuck_status->stuck_stopline_idx, planner_data)) {
+    if (
+      can_smoothly_stop_at(
+        *path, closest_idx, yield_stuck_status->stuck_stopline_idx, planner_data)) {
       return yield_stuck_status.value();
     }
     RCLCPP_WARN_THROTTLE(

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/experimental/scene_intersection_collision.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/experimental/scene_intersection_collision.cpp
@@ -305,12 +305,13 @@ void IntersectionModule::updateObjectInfoManagerCollision(
       const auto object_enter_time = std::get<0>(object_enter_exit_time);
       const auto object_exit_time = std::get<1>(object_enter_exit_time);
 
-      if (const auto initial_passage_index = object_passage_interval.interval_position.first;
-          check_if_path_is_overtaking_ego(
-            ego_lane, autoware_utils::to_polygon2d(
-                        precise_predicted_path.at(
-                          std::min(initial_passage_index + 1, precise_predicted_path.size() - 1)),
-                        predicted_object.shape))) {
+      if (
+        const auto initial_passage_index = object_passage_interval.interval_position.first;
+        check_if_path_is_overtaking_ego(
+          ego_lane, autoware_utils::to_polygon2d(
+                      precise_predicted_path.at(
+                        std::min(initial_passage_index + 1, precise_predicted_path.size() - 1)),
+                      predicted_object.shape))) {
         // NOTE(soblin): this is to ignore a path overtaking ego from behind
         continue;
       }

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/experimental/scene_intersection_occlusion.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/experimental/scene_intersection_occlusion.cpp
@@ -285,10 +285,11 @@ IntersectionModule::OcclusionType IntersectionModule::detectOcclusion(
     if (poly_area < possible_object_area) continue;
     // check bounding box size
     const auto bbox = cv::minAreaRect(approx_contour);
-    if (const auto size = bbox.size; std::min(size.height, size.width) <
-                                       std::min(possible_object_bbox_x, possible_object_bbox_y) ||
-                                     std::max(size.height, size.width) <
-                                       std::max(possible_object_bbox_x, possible_object_bbox_y)) {
+    if (
+      const auto size = bbox.size; std::min(size.height, size.width) <
+                                     std::min(possible_object_bbox_x, possible_object_bbox_y) ||
+                                   std::max(size.height, size.width) <
+                                     std::max(possible_object_bbox_x, possible_object_bbox_y)) {
       continue;
     }
     valid_contours.push_back(approx_contour);

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/experimental/scene_intersection_prepare_data.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/experimental/scene_intersection_prepare_data.cpp
@@ -283,9 +283,10 @@ std::optional<IntersectionStopLines> IntersectionModule::generateIntersectionSto
   const auto default_stopline_ip_and_valid = [&]() -> std::pair<size_t, bool> {
     bool default_stopline_valid = true;
     int stop_idx_ip_int = -1;
-    if (const auto map_stop_idx_ip =
-          getStopLineIndexFromMap(interpolated_path_info, assigned_lanelet, planner_data);
-        map_stop_idx_ip) {
+    if (
+      const auto map_stop_idx_ip =
+        getStopLineIndexFromMap(interpolated_path_info, assigned_lanelet, planner_data);
+      map_stop_idx_ip) {
       stop_idx_ip_int = static_cast<int>(map_stop_idx_ip.value()) - base2front_idx_dist;
     }
     if (stop_idx_ip_int < 0) {
@@ -349,8 +350,8 @@ std::optional<IntersectionStopLines> IntersectionModule::generateIntersectionSto
     const auto & base_pose0 = path_ip.points.at(default_stopline_ip).point.pose;
     const auto path_footprint0 =
       autoware_utils::transform_vector(local_footprint, autoware_utils::pose2transform(base_pose0));
-    if (bg::intersects(
-          path_footprint0, lanelet::utils::to2D(first_attention_area).basicPolygon())) {
+    if (
+      bg::intersects(path_footprint0, lanelet::utils::to2D(first_attention_area).basicPolygon())) {
       return {0, false};
     }
     int occlusion_peeking_line_ip_int = static_cast<int>(first_attention_stopline_ip) +
@@ -531,8 +532,9 @@ static std::vector<std::deque<lanelet::ConstLanelet>> getPrecedingLaneletsUptoIn
       // remove prev_lanelet from preceding_lanelet_sequences
       continue;
     }
-    if (const std::string turn_direction = prev_lanelet.attributeOr("turn_direction", "else");
-        turn_direction == "left" || turn_direction == "right") {
+    if (
+      const std::string turn_direction = prev_lanelet.attributeOr("turn_direction", "else");
+      turn_direction == "left" || turn_direction == "right") {
       continue;
     }
 
@@ -563,8 +565,9 @@ static std::vector<lanelet::ConstLanelets> getPrecedingLaneletsUptoIntersection(
       // remove prev_lanelet from preceding_lanelet_sequences
       continue;
     }
-    if (const std::string turn_direction = prev_lanelet.attributeOr("turn_direction", "else");
-        turn_direction == "left" || turn_direction == "right") {
+    if (
+      const std::string turn_direction = prev_lanelet.attributeOr("turn_direction", "else");
+      turn_direction == "left" || turn_direction == "right") {
       continue;
     }
     // convert deque into vector
@@ -589,8 +592,9 @@ IntersectionLanelets IntersectionModule::generateObjectiveLanelets(
 
   // retrieve a stopline associated with a traffic light
   bool has_traffic_light = false;
-  if (const auto tl_reg_elems = assigned_lanelet.regulatoryElementsAs<lanelet::TrafficLight>();
-      tl_reg_elems.size() != 0) {
+  if (
+    const auto tl_reg_elems = assigned_lanelet.regulatoryElementsAs<lanelet::TrafficLight>();
+    tl_reg_elems.size() != 0) {
     const auto tl_reg_elem = tl_reg_elems.front();
     const auto stopline_opt = tl_reg_elem->stopLine();
     if (!!stopline_opt) has_traffic_light = true;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/experimental/scene_intersection_stuck.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/experimental/scene_intersection_stuck.cpp
@@ -160,8 +160,8 @@ std::optional<StuckStop> IntersectionModule::isStuckStatus(
           default_stopline_idx_opt &&
           can_smoothly_stop_at(path, closest_idx, default_stopline_idx_opt.value(), planner_data)) {
           stopline_idx = default_stopline_idx_opt.value();
-        } else if (can_smoothly_stop_at(
-                     path, closest_idx, first_attention_stopline_idx, planner_data)) {
+        } else if (
+          can_smoothly_stop_at(path, closest_idx, first_attention_stopline_idx, planner_data)) {
           stopline_idx = first_attention_stopline_idx;
         }
       }

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/manager.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/manager.cpp
@@ -342,8 +342,9 @@ void IntersectionModuleManager::launchNewModules(
     const auto associative_ids =
       planning_utils::getAssociativeIntersectionLanelets(ll, lanelet_map, routing_graph);
     bool has_traffic_light = false;
-    if (const auto tl_reg_elems = ll.regulatoryElementsAs<lanelet::TrafficLight>();
-        tl_reg_elems.size() != 0) {
+    if (
+      const auto tl_reg_elems = ll.regulatoryElementsAs<lanelet::TrafficLight>();
+      tl_reg_elems.size() != 0) {
       const auto tl_reg_elem = tl_reg_elems.front();
       const auto stopline_opt = tl_reg_elem->stopLine();
       if (!!stopline_opt) has_traffic_light = true;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.cpp
@@ -322,8 +322,9 @@ DecisionResult IntersectionModule::modifyPathVelocityDetail(PathWithLaneId * pat
     if (
       has_collision_with_margin && !has_traffic_light_ && enable_conservative_yield_merging &&
       intersection_stoplines.maximum_footprint_overshoot_line) {
-      if (can_smoothly_stop_at(
-            *path, closest_idx, intersection_stoplines.maximum_footprint_overshoot_line.value())) {
+      if (
+        can_smoothly_stop_at(
+          *path, closest_idx, intersection_stoplines.maximum_footprint_overshoot_line.value())) {
         // NOTE(soblin): intersection_stoplines.maximum_footprint_overshoot_line.value() is not used
         // as stop line. in this case, ego tries to stop at current position
         const auto stop_line_idx = closest_idx;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection_collision.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection_collision.cpp
@@ -302,12 +302,13 @@ void IntersectionModule::updateObjectInfoManagerCollision(
       const auto object_enter_time = std::get<0>(object_enter_exit_time);
       const auto object_exit_time = std::get<1>(object_enter_exit_time);
 
-      if (const auto initial_passage_index = object_passage_interval.interval_position.first;
-          check_if_path_is_overtaking_ego(
-            ego_lane, autoware_utils::to_polygon2d(
-                        precise_predicted_path.at(
-                          std::min(initial_passage_index + 1, precise_predicted_path.size() - 1)),
-                        predicted_object.shape))) {
+      if (
+        const auto initial_passage_index = object_passage_interval.interval_position.first;
+        check_if_path_is_overtaking_ego(
+          ego_lane, autoware_utils::to_polygon2d(
+                      precise_predicted_path.at(
+                        std::min(initial_passage_index + 1, precise_predicted_path.size() - 1)),
+                      predicted_object.shape))) {
         // NOTE(soblin): this is to ignore a path overtaking ego from behind
         continue;
       }

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection_occlusion.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection_occlusion.cpp
@@ -285,10 +285,11 @@ IntersectionModule::OcclusionType IntersectionModule::detectOcclusion(
     if (poly_area < possible_object_area) continue;
     // check bounding box size
     const auto bbox = cv::minAreaRect(approx_contour);
-    if (const auto size = bbox.size; std::min(size.height, size.width) <
-                                       std::min(possible_object_bbox_x, possible_object_bbox_y) ||
-                                     std::max(size.height, size.width) <
-                                       std::max(possible_object_bbox_x, possible_object_bbox_y)) {
+    if (
+      const auto size = bbox.size; std::min(size.height, size.width) <
+                                     std::min(possible_object_bbox_x, possible_object_bbox_y) ||
+                                   std::max(size.height, size.width) <
+                                     std::max(possible_object_bbox_x, possible_object_bbox_y)) {
       continue;
     }
     valid_contours.push_back(approx_contour);

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection_prepare_data.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection_prepare_data.cpp
@@ -280,9 +280,10 @@ std::optional<IntersectionStopLines> IntersectionModule::generateIntersectionSto
   const auto default_stopline_ip_and_valid = [&]() -> std::pair<size_t, bool> {
     bool default_stopline_valid = true;
     int stop_idx_ip_int = -1;
-    if (const auto map_stop_idx_ip =
-          getStopLineIndexFromMap(interpolated_path_info, assigned_lanelet);
-        map_stop_idx_ip) {
+    if (
+      const auto map_stop_idx_ip =
+        getStopLineIndexFromMap(interpolated_path_info, assigned_lanelet);
+      map_stop_idx_ip) {
       stop_idx_ip_int = static_cast<int>(map_stop_idx_ip.value()) - base2front_idx_dist;
     }
     if (stop_idx_ip_int < 0) {
@@ -346,8 +347,8 @@ std::optional<IntersectionStopLines> IntersectionModule::generateIntersectionSto
     const auto & base_pose0 = path_ip.points.at(default_stopline_ip).point.pose;
     const auto path_footprint0 =
       autoware_utils::transform_vector(local_footprint, autoware_utils::pose2transform(base_pose0));
-    if (bg::intersects(
-          path_footprint0, lanelet::utils::to2D(first_attention_area).basicPolygon())) {
+    if (
+      bg::intersects(path_footprint0, lanelet::utils::to2D(first_attention_area).basicPolygon())) {
       return {0, false};
     }
     int occlusion_peeking_line_ip_int = static_cast<int>(first_attention_stopline_ip) +
@@ -527,8 +528,9 @@ static std::vector<std::deque<lanelet::ConstLanelet>> getPrecedingLaneletsUptoIn
       // remove prev_lanelet from preceding_lanelet_sequences
       continue;
     }
-    if (const std::string turn_direction = prev_lanelet.attributeOr("turn_direction", "else");
-        turn_direction == "left" || turn_direction == "right") {
+    if (
+      const std::string turn_direction = prev_lanelet.attributeOr("turn_direction", "else");
+      turn_direction == "left" || turn_direction == "right") {
       continue;
     }
 
@@ -559,8 +561,9 @@ static std::vector<lanelet::ConstLanelets> getPrecedingLaneletsUptoIntersection(
       // remove prev_lanelet from preceding_lanelet_sequences
       continue;
     }
-    if (const std::string turn_direction = prev_lanelet.attributeOr("turn_direction", "else");
-        turn_direction == "left" || turn_direction == "right") {
+    if (
+      const std::string turn_direction = prev_lanelet.attributeOr("turn_direction", "else");
+      turn_direction == "left" || turn_direction == "right") {
       continue;
     }
     // convert deque into vector
@@ -585,8 +588,9 @@ IntersectionLanelets IntersectionModule::generateObjectiveLanelets(
 
   // retrieve a stopline associated with a traffic light
   bool has_traffic_light = false;
-  if (const auto tl_reg_elems = assigned_lanelet.regulatoryElementsAs<lanelet::TrafficLight>();
-      tl_reg_elems.size() != 0) {
+  if (
+    const auto tl_reg_elems = assigned_lanelet.regulatoryElementsAs<lanelet::TrafficLight>();
+    tl_reg_elems.size() != 0) {
     const auto tl_reg_elem = tl_reg_elems.front();
     const auto stopline_opt = tl_reg_elem->stopLine();
     if (!!stopline_opt) has_traffic_light = true;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/src/experimental/scene_no_stopping_area.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/src/experimental/scene_no_stopping_area.cpp
@@ -214,16 +214,18 @@ bool NoStoppingAreaModule::modifyPathVelocity(
     if (stuck_vehicle_detect_area) {
       debug_data_.stuck_vehicle_detect_area = toGeomPoly(*stuck_vehicle_detect_area);
       // Find stuck vehicle in no stopping area
-      if (check_stuck_vehicles_in_no_stopping_area(
-            *stuck_vehicle_detect_area, predicted_obj_arr_ptr)) {
+      if (
+        check_stuck_vehicles_in_no_stopping_area(
+          *stuck_vehicle_detect_area, predicted_obj_arr_ptr)) {
         return true;
       }
     }
     if (stop_line_detect_area) {
       debug_data_.stop_line_detect_area = toGeomPoly(*stop_line_detect_area);
       // Find stop line in no stopping area
-      if (no_stopping_area::check_stop_lines_in_no_stopping_area(
-            path, *stop_line_detect_area, debug_data_)) {
+      if (
+        no_stopping_area::check_stop_lines_in_no_stopping_area(
+          path, *stop_line_detect_area, debug_data_)) {
         return true;
       }
     }

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/src/scene_no_stopping_area.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/src/scene_no_stopping_area.cpp
@@ -92,8 +92,9 @@ bool NoStoppingAreaModule::modifyPathVelocity(PathWithLaneId * path)
   setDistance(
     autoware::motion_utils::calcSignedArcLength(
       original_path.points, current_pose->pose.position, stop_pose.position));
-  if (planning_utils::isOverLine(
-        original_path, current_pose->pose, stop_pose, planner_param_.dead_line_margin)) {
+  if (
+    planning_utils::isOverLine(
+      original_path, current_pose->pose, stop_pose, planner_param_.dead_line_margin)) {
     // ego can't stop in front of no stopping area -> GO or OR
     state_machine_.setState(StateMachine::State::GO);
     setSafe(true);

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_roundabout_module/src/object_manager.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_roundabout_module/src/object_manager.cpp
@@ -144,9 +144,10 @@ std::optional<CollisionInterval> findPassageInterval(
     static_cast<double>(exit_idx) * rclcpp::Duration(predicted_path.time_step).seconds();
   const auto lane_position = [&]() {
     if (first_attention_lane_opt) {
-      if (lanelet::geometry::inside(
-            first_attention_lane_opt.value(),
-            lanelet::BasicPoint2d(first_itr->position.x, first_itr->position.y))) {
+      if (
+        lanelet::geometry::inside(
+          first_attention_lane_opt.value(),
+          lanelet::BasicPoint2d(first_itr->position.x, first_itr->position.y))) {
         return CollisionInterval::LanePosition::FIRST;
       }
     }

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/utils.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/utils.hpp
@@ -75,9 +75,10 @@ std::optional<SegmentIndexWithPoint> findLastCollisionBeforeEndLine(
        --i) {  // NOTE: size_t can be used since it will not be negative.
     const auto & p1 = autoware_utils::get_point(points.at(i));
     const auto & p2 = autoware_utils::get_point(points.at(i - 1));
-    if (const auto collision_point =
-          autoware_utils_geometry::intersect(p1, p2, target_line_p1, target_line_p2);
-        collision_point) {
+    if (
+      const auto collision_point =
+        autoware_utils_geometry::intersect(p1, p2, target_line_p1, target_line_p2);
+      collision_point) {
       return SegmentIndexWithPoint{i, collision_point.value()};
     }
   }

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
@@ -208,8 +208,9 @@ void BoundaryDeparturePreventionModule::update_parameters(
   const std::string ns_slow_down{module_name + "slow_down_behavior.enable."};
 
   bool enable_slow_down_near_bound = pp.slow_down_types.count(DepartureType::NEAR_BOUNDARY);
-  if (update_param(
-        parameters, ns_slow_down + "slow_down_near_boundary", enable_slow_down_near_bound)) {
+  if (
+    update_param(
+      parameters, ns_slow_down + "slow_down_near_boundary", enable_slow_down_near_bound)) {
     if (enable_slow_down_near_bound)
       pp.slow_down_types.insert(DepartureType::NEAR_BOUNDARY);
     else
@@ -217,8 +218,8 @@ void BoundaryDeparturePreventionModule::update_parameters(
   }
 
   bool enable_approaching_dpt = pp.slow_down_types.count(DepartureType::APPROACHING_DEPARTURE);
-  if (update_param(
-        parameters, ns_slow_down + "slow_down_before_departure", enable_approaching_dpt)) {
+  if (
+    update_param(parameters, ns_slow_down + "slow_down_before_departure", enable_approaching_dpt)) {
     if (enable_approaching_dpt)
       pp.slow_down_types.insert(DepartureType::APPROACHING_DEPARTURE);
     else

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/src/obstacle_slow_down_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/src/obstacle_slow_down_module.cpp
@@ -771,10 +771,11 @@ std::vector<SlowdownInterval> ObstacleSlowDownModule::plan_slow_down(
       return feasible_slow_down_vel;
     }();
 
-    if (std::none_of(
-          slow_down_traj_points.begin() + (slow_down_start_idx ? *slow_down_start_idx : 0),
-          slow_down_traj_points.begin() + *slow_down_end_idx,
-          [&](const auto & tp) { return stable_slow_down_vel < tp.longitudinal_velocity_mps; })) {
+    if (
+      std::none_of(
+        slow_down_traj_points.begin() + (slow_down_start_idx ? *slow_down_start_idx : 0),
+        slow_down_traj_points.begin() + *slow_down_end_idx,
+        [&](const auto & tp) { return stable_slow_down_vel < tp.longitudinal_velocity_mps; })) {
       RCLCPP_DEBUG(
         logger_,
         "[SlowDown] Ignore obstacle (%s) since slow down velocity (%f) is higher than trajectory "

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_collisions.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_collisions.cpp
@@ -97,8 +97,9 @@ lanelet::Ids get_predicted_path_lanelet_ids(
     route_handler.getLaneletMapPtr()->laneletLayer.search({ls.back(), ls.back()});
   lanelet::Ids final_ids;
   for (const auto & final_candidate : final_candidates) {
-    if (lanelet::geometry::within(
-          ls.back(), route_handler.getLaneletsFromId(final_candidate.id()).polygon2d())) {
+    if (
+      lanelet::geometry::within(
+        ls.back(), route_handler.getLaneletsFromId(final_candidate.id()).polygon2d())) {
       final_ids.push_back(final_candidate.id());
     }
   }
@@ -107,8 +108,9 @@ lanelet::Ids get_predicted_path_lanelet_ids(
     route_handler.getLaneletMapPtr()->laneletLayer.search({ls.front(), ls.front()});
   lanelet::Ids initial_ids;
   for (const auto & initial_candidate : initial_candidates) {
-    if (lanelet::geometry::within(
-          ls.front(), route_handler.getLaneletsFromId(initial_candidate.id()).polygon2d())) {
+    if (
+      lanelet::geometry::within(
+        ls.front(), route_handler.getLaneletsFromId(initial_candidate.id()).polygon2d())) {
       initial_ids.push_back(initial_candidate.id());
     }
   }

--- a/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/objects_filtering.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/objects_filtering.cpp
@@ -202,8 +202,9 @@ std::optional<size_t> get_cut_predicted_path_index(
     cut_segments_rtree.query(
       boost::geometry::index::intersects(segment), std::back_inserter(query_results));
     for (const auto & candidate : query_results) {
-      if (universe_utils::intersect(
-            segment.first, segment.second, candidate.first.first, candidate.first.second)) {
+      if (
+        universe_utils::intersect(
+          segment.first, segment.second, candidate.first.first, candidate.first.second)) {
         return true;
       }
     }
@@ -293,9 +294,10 @@ std::vector<Object> prepare_dynamic_objects(
     classify(filtered_object, object->predicted_object, target_labels, params);
     calculate_current_footprint(filtered_object, object->predicted_object);
     const auto & previous_object_decisions = previous_decisions.get(filtered_object.uuid);
-    if (skip_object_condition(
-          filtered_object, previous_object_decisions, ego_rear_segment,
-          filtering_data[filtered_object.label], params)) {
+    if (
+      skip_object_condition(
+        filtered_object, previous_object_decisions, ego_rear_segment,
+        filtering_data[filtered_object.label], params)) {
       continue;
     }
     calculate_predicted_path_footprints(filtered_object, object->predicted_object, params);

--- a/planning/planning_validator/autoware_planning_validator_intersection_collision_checker/src/utils.cpp
+++ b/planning/planning_validator/autoware_planning_validator_intersection_collision_checker/src/utils.cpp
@@ -197,9 +197,10 @@ void set_right_turn_target_lanelets(
       const auto traffic_light_elements = context->get_traffic_signal(regulatory_element->id());
       if (!traffic_light_elements.has_value()) continue;
 
-      if (autoware::traffic_light_utils::hasTrafficLightShapeAndColor(
-            traffic_light_elements.value(), TrafficLightElement::RIGHT_ARROW,
-            TrafficLightElement::GREEN)) {
+      if (
+        autoware::traffic_light_utils::hasTrafficLightShapeAndColor(
+          traffic_light_elements.value(), TrafficLightElement::RIGHT_ARROW,
+          TrafficLightElement::GREEN)) {
         return true;
       }
     }
@@ -296,15 +297,17 @@ void set_left_turn_target_lanelets(
       const auto traffic_light_elements = context->get_traffic_signal(regulatory_element->id());
       if (!traffic_light_elements.has_value()) continue;
 
-      if (autoware::traffic_light_utils::hasTrafficLightShapeAndColor(
-            traffic_light_elements.value(), TrafficLightElement::CIRCLE,
-            TrafficLightElement::GREEN)) {
+      if (
+        autoware::traffic_light_utils::hasTrafficLightShapeAndColor(
+          traffic_light_elements.value(), TrafficLightElement::CIRCLE,
+          TrafficLightElement::GREEN)) {
         return true;
       }
 
-      if (autoware::traffic_light_utils::hasTrafficLightShapeAndColor(
-            traffic_light_elements.value(), TrafficLightElement::CIRCLE,
-            TrafficLightElement::AMBER)) {
+      if (
+        autoware::traffic_light_utils::hasTrafficLightShapeAndColor(
+          traffic_light_elements.value(), TrafficLightElement::CIRCLE,
+          TrafficLightElement::AMBER)) {
         return true;
       }
     }

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/utils.cpp
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/utils.cpp
@@ -711,8 +711,8 @@ auto get_obstacle_points(const lanelet::BasicPolygons3d & polygons, const PointC
       if (squared_dist > circle.second) {
         continue;
       }
-      if (boost::geometry::within(
-            autoware_utils::Point2d{p.x, p.y}, lanelet::utils::to2D(polygon))) {
+      if (
+        boost::geometry::within(autoware_utils::Point2d{p.x, p.y}, lanelet::utils::to2D(polygon))) {
         ret.push_back(p);
       }
     }

--- a/sensing/autoware_pointcloud_preprocessor/src/outlier_filter/polar_voxel_noise_filter_node.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/src/outlier_filter/polar_voxel_noise_filter_node.cpp
@@ -529,8 +529,9 @@ PolarVoxelNoiseFilterComponent::determine_valid_voxels_with_return_types(
   const VoxelStatsMap & voxel_stats_map) const
 {
   return determine_valid_voxels_generic(voxel_stats_map, [this](const VoxelStats & stats) {
-    if (stats.meets_noise_condition(
-          voxel_points_threshold_, avg_intensity_threshold_, secondary_noise_threshold_)) {
+    if (
+      stats.meets_noise_condition(
+        voxel_points_threshold_, avg_intensity_threshold_, secondary_noise_threshold_)) {
       return false;
     } else {
       return true;

--- a/sensing/autoware_pointcloud_preprocessor/src/vector_map_filter/lanelet2_map_filter_node.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/src/vector_map_filter/lanelet2_map_filter_node.cpp
@@ -181,8 +181,9 @@ pcl::PointCloud<pcl::PointXYZ> Lanelet2MapFilterComponent::getLaneFilteredPointC
   }
 
   for (auto & point : downsampled_cloud->points) {
-    if (pointWithinLanelets(
-          Point2d(point.x + centroid[0], point.y + centroid[1]), intersected_lanelets)) {
+    if (
+      pointWithinLanelets(
+        Point2d(point.x + centroid[0], point.y + centroid[1]), intersected_lanelets)) {
       const size_t index = voxel_grid.getCentroidIndex(point);
       for (auto & original_point : downsampled2original_map[index].points) {
         original_point.x += centroid[0];


### PR DESCRIPTION
## Description

Updates the `clang-format` pre-commit hook from `v21.1.8` to `v22.1.5` and includes the resulting reformat.

The sync bot proposes the same bump in #13125, but that PR only changes the rev, so `pre-commit-lite` fails there with `files were modified by this hook`. This PR carries the reformat so the bump can land.

### What changes in the formatting

clang-format 22 deprecated `AlignAfterOpenBracket: AlwaysBreak` and split it into per-construct options. Our `.clang-format` still uses `AlwaysBreak`, which clang-format 22 resolves with `BreakAfterOpenBracketIf: true`. clang-format 21 already broke after `if (` for multi-operand boolean conditions, but not when the condition was a single long call. Version 22 makes it uniform:

```diff
-    if (is_closest_to_boundary_segment(
-          boundary_segment, ego_ref_segment, ego_opposite_ref_segment)) {
+    if (
+      is_closest_to_boundary_segment(boundary_segment, ego_ref_segment, ego_opposite_ref_segment)) {
```

That is the entire diff. 183 of the 727 added lines are `if (` or `} else if (`, and nothing else in the style changed.

### Why `.clang-format` is not touched

- It is synced from `sync-file-templates`, so a local edit would be reverted by the next sync.
- `AlwaysBreak` still parses in 22.1.5 with no warning, so there is no urgency to migrate off it.
- Keeping the old look with `BreakAfterOpenBracketIf: false` is a bigger change, not a smaller one: 365 files, because it also collapses the multi-operand `if (` breaks the codebase already uses everywhere. Any explicit `BreakAfterOpenBracket*` key is also a parse error on clang-format 21.

## Updating your local clang-format

`pre-commit` runs clang-format from its own virtualenv, so CI and `pre-commit run -a` do not care what you have installed. Your system binary only affects manual runs, editors (CLion, VS Code, clangd) and `ament_clang_format`. Ubuntu 22.04 ships at most `clang-format-15` and 24.04 at most `clang-format-20`, so 22 needs an external source.

<details>
<summary>From apt (apt.llvm.org)</summary>

Ubuntu 24.04 (noble, jazzy):

```bash
sudo apt-get update
sudo apt-get install -y wget gnupg ca-certificates

sudo install -d -m 0755 /etc/apt/keyrings
wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
  | sudo tee /etc/apt/keyrings/apt.llvm.org.asc > /dev/null

echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/apt.llvm.org.asc] http://apt.llvm.org/noble/ llvm-toolchain-noble-22 main" \
  | sudo tee /etc/apt/sources.list.d/apt.llvm.org-22.list > /dev/null

sudo apt-get update
sudo apt-get install -y clang-format-22
```

Ubuntu 22.04 (jammy, humble) is identical except for the two `noble` tokens:

```bash
echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/apt.llvm.org.asc] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-22 main" \
  | sudo tee /etc/apt/sources.list.d/apt.llvm.org-22.list > /dev/null
```

The package installs `/usr/bin/clang-format-22` only, with no unversioned binary. Editors and `ament_clang_format` look for a plain `clang-format`, so register it:

```bash
sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-22 220
sudo update-alternatives --install /usr/bin/git-clang-format git-clang-format /usr/bin/git-clang-format-22 220
```

Optionally verify the signing key:

```bash
gpg --show-keys --with-fingerprint /etc/apt/keyrings/apt.llvm.org.asc
# expect: 6084 F3CF 814B 57C1 CF12  EFD5 15CF 4D18 AF4F 7421
```

apt.llvm.org does not ship 22.1.5 and cannot be pinned to it; it keeps only the current 22.x snapshot, which today reports 22.1.8. No commit between `llvmorg-22.1.5` and `llvmorg-22.1.8` touches `clang/lib/Format`, `clang/tools/clang-format` or `clang/unittests/Format`, so the output is the same today. That is not guaranteed for future snapshots.

</details>

<details>
<summary>From pipx, for a byte-exact match with CI</summary>

This installs the exact wheel the pre-commit hook uses, and works the same on 22.04 and 24.04, amd64 and arm64:

```bash
sudo apt-get install -y pipx
pipx ensurepath   # adds ~/.local/bin to PATH, open a new shell afterwards
pipx install clang-format==22.1.5

clang-format --version   # -> clang-format version 22.1.5
```

If you already installed it with pipx, use `pipx install --force clang-format==22.1.5`. Do not use `pipx upgrade clang-format` or plain `pipx install clang-format`: both give 22.1.8, which is not the pin. On Ubuntu 24.04, `pip install --user` fails with `externally-managed-environment` (PEP 668), so use pipx or a venv.

</details>

## Related links

**Parent Issue:**

- autowarefoundation/autoware#7245

- Supersedes #13125
- Source of the bump: autowarefoundation/sync-file-templates#69
- [clang-format 22 release notes](https://releases.llvm.org/22.1.0/tools/clang/docs/ReleaseNotes.html)

## How was this PR tested?

**AI usage:** produced with Claude Code. The second commit is `clang-format -i` output, not generated text. This description was drafted by it from my instructions and edited by me.

**Self-review:**

- Regenerated the second commit from the base with clang-format 22.1.5. Byte-identical, so it has no hand edits.
- Read every hunk. 10 of the 196 are constructor member-init lists breaking after `{` rather than `if (` breaks, from the same option split.

**Verification:**

- `pre-commit run clang-format --all-files` twice; the second run is clean, so the result is idempotent.
- `pre-commit run` over all 88 changed files plus `.pre-commit-config.yaml`. Every hook passes, including `cpplint` and `fix include guard`.
- Confirmed the reformat is formatting-only: with all whitespace stripped, every one of the 88 files is byte-identical before and after, except `crosswalk_traffic_light_estimator.cpp`, where a trailing `//` comment reflows onto two lines.
- Measured the alternative before rejecting it: `BreakAfterOpenBracketIf: false` changes 365 files instead of 88.

No build or simulation was run. The change cannot affect behavior.

## Notes for reviewers

Review the first commit on its own; the second is mechanical and can be regenerated with `pre-commit run clang-format --all-files`.

`autoware_core` is still on `v21.1.8` and hits the same wall. Tracked in the epic above.

## Interface changes

None.

## Effects on system behavior

None. Formatting only.

