### PR TITLE
fix(autoware_system_monitor): add missing dependency to edac-utils

### DIFF
--- a/system/autoware_system_monitor/package.xml
+++ b/system/autoware_system_monitor/package.xml
@@ -28,6 +28,7 @@
   <depend>tier4_external_api_msgs</depend>
 
   <exec_depend>chrony</exec_depend>
+  <exec_depend>edac-utils</exec_depend>
   <exec_depend>sysstat</exec_depend>
 
   <test_depend>ament_cmake_ros</test_depend>


### PR DESCRIPTION
## Description
Dependency to edac-utils were added in https://github.com/autowarefoundation/autoware_universe/pull/3795. 
I have added edac-utils to rosdep so we should be able to install edac-utils from rosdep install now. 

## Related links

- https://github.com/autowarefoundation/autoware_universe/pull/3795
- https://github.com/ros/rosdistro/pull/51519

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

I ran rosdep install and made sure that edac-utils is installed. 

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
