### PR TITLE
feat(autoware_system_monitor): add argument to override hdd_mount_point

### DIFF
--- a/system/autoware_system_monitor/launch/system_monitor.launch.xml
+++ b/system/autoware_system_monitor/launch/system_monitor.launch.xml
@@ -7,6 +7,7 @@
   <arg name="process_monitor_config_file" default="$(find-pkg-share autoware_system_monitor)/config/process_monitor.param.yaml"/>
   <arg name="gpu_monitor_config_file" default="$(find-pkg-share autoware_system_monitor)/config/gpu_monitor.param.yaml"/>
   <arg name="voltage_monitor_config_file" default="$(find-pkg-share autoware_system_monitor)/config/voltage_monitor.param.yaml"/>
+  <arg name="hdd_mount_point" default="/" description="mount point of the disk to monitor. Set to a bind mount of the host root (e.g. /host_root) when running in a container, because the container root is overlayfs and has no block device"/>
 
   <group>
     <node_container pkg="rclcpp_components" exec="component_container_mt" name="system_monitor_container" namespace="system_monitor" output="screen">
@@ -27,6 +28,7 @@
       </composable_node>
       <composable_node pkg="autoware_system_monitor" plugin="HddMonitor" name="hdd_monitor">
         <param from="$(var hdd_monitor_config_file)"/>
+        <param name="disks.disk0.name" value="$(var hdd_mount_point)"/>
       </composable_node>
       <composable_node pkg="autoware_system_monitor" plugin="GPUMonitor" name="gpu_monitor">
         <param from="$(var gpu_monitor_config_file)"/>

--- a/system/autoware_system_monitor/launch/system_monitor.launch.xml
+++ b/system/autoware_system_monitor/launch/system_monitor.launch.xml
@@ -7,7 +7,11 @@
   <arg name="process_monitor_config_file" default="$(find-pkg-share autoware_system_monitor)/config/process_monitor.param.yaml"/>
   <arg name="gpu_monitor_config_file" default="$(find-pkg-share autoware_system_monitor)/config/gpu_monitor.param.yaml"/>
   <arg name="voltage_monitor_config_file" default="$(find-pkg-share autoware_system_monitor)/config/voltage_monitor.param.yaml"/>
-  <arg name="hdd_mount_point" default="/" description="mount point of the disk to monitor. Set to a bind mount of the host root (e.g. /host_root) when running in a container, because the container root is overlayfs and has no block device"/>
+  <arg
+    name="hdd_mount_point"
+    default="/"
+    description="mount point of the disk to monitor. Set to a bind mount of the host root (e.g. /host_root) when running in a container, because the container root is overlayfs and has no block device"
+  />
 
   <group>
     <node_container pkg="rclcpp_components" exec="component_container_mt" name="system_monitor_container" namespace="system_monitor" output="screen">


### PR DESCRIPTION
## Description
The HddMonitor node monitors the disk mounted at disks.disk0.name, which defaults to / in hdd_monitor.param.yaml. When Autoware runs inside a container, however, the container's root filesystem is an overlayfs with no backing block device, so HddMonitor cannot resolve the underlying device and disk monitoring does not work.

This PR adds an hdd_mount_point launch argument to system_monitor.launch.xml that overrides disks.disk0.name for the HddMonitor composable node. It defaults to /, preserving the current behavior. In containerized deployments, it can be set to a bind mount of the host root (e.g. /host_root) so that the monitored mount point resolves to a real block device on the host.

This allows containerized deployments to point the disk monitor at the host disk without maintaining a full copy of hdd_monitor.param.yaml just to change the mount point.

## Related links

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

* Launched system_monitor.launch.xml without the argument and confirmed that HddMonitor behaves as before (monitoring /).
* Launched it in a container with hdd_mount_point:=/host_root (host root bind-mounted) and confirmed that HddMonitor reports the host disk correctly.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
