### PR TITLE
chore: drop unused interface-spec dependencies

### DIFF
--- a/control/autoware_control_validator/package.xml
+++ b/control/autoware_control_validator/package.xml
@@ -21,7 +21,6 @@
   <build_depend>rosidl_default_generators</build_depend>
 
   <depend>angles</depend>
-  <depend>autoware_adapi_specs</depend>
   <depend>autoware_control_msgs</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_planning_msgs</depend>

--- a/visualization/tier4_camera_view_rviz_plugin/package.xml
+++ b/visualization/tier4_camera_view_rviz_plugin/package.xml
@@ -11,8 +11,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>autoware_adapi_specs</depend>
-  <depend>autoware_component_interface_utils</depend>
   <depend>geometry_msgs</depend>
   <depend>libqt5-core</depend>
   <depend>libqt5-gui</depend>


### PR DESCRIPTION
## Description

Two packages declare interface dependencies that nothing in their sources uses.

- `autoware_control_validator` declares `autoware_adapi_specs`. Its endpoints are created with raw ROS types throughout — `create_subscription<Control>`, `create_publisher<ControlValidatorStatus>`, `MarkerArray` — all reached through plain `using` aliases to message headers. Nothing in `src/`, `include/` or `test/` names `autoware_adapi_specs`, `component_interface_specs` or `component_interface_utils`.
- `tier4_camera_view_rviz_plugin` declares both `autoware_adapi_specs` and `autoware_component_interface_utils`, and references neither.

A dependency that no longer has a user is a claim the manifest makes and the code does not back. It slows resolution, widens the rebuild graph, and quietly misrepresents what the package couples to.

This PR removes the three declarations.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware/issues/7210

## How was this PR tested?

An unused-looking dependency can still be load-bearing in two ways that a source grep does not see, so both were checked before deleting anything:

1. **CMake.** Neither package has a `find_package` or `ament_target_dependencies` naming any of the three. `tier4_camera_view_rviz_plugin` has no `ament_target_dependencies` call at all, so the `<depend>` could not have been reaching the target that way.
2. **Transitive include paths.** `ament_cmake_auto` derives include directories from `package.xml`, so a package can compile only because a declared dependency supplies a path it never names. The only way to rule that out is to rebuild after the manifest edit, which is what was done: both packages were built in the `autoware:universe-devel-jazzy` image with `colcon build --symlink-install --packages-select autoware_control_validator tier4_camera_view_rviz_plugin` **after** the declarations were removed. Both build.

`pre-commit` (including `sort-package-xml`) runs clean on both changed files.

## Notes for reviewers

**`tier4_camera_view_rviz_plugin` is an rviz plugin, so a runtime-only dependency would leave no compile-time trace.** Worth a second opinion from someone who knows the plugin: neither `autoware_adapi_specs` nor `autoware_component_interface_utils` exports a plugin, a launch file or a parameter file, and both are header-only C++ interface packages with nothing loadable at runtime, so there is no `<exec_depend>` half left uncovered by removing the `<depend>`.

**Separate defect, deliberately not folded in.** `control/autoware_control_validator/include/.../control_validator.hpp:29,46` uses `autoware_adapi_v1_msgs::msg::OperationModeState`, but `package.xml` never declares `autoware_adapi_v1_msgs`. That is the mirror image of what this PR fixes — a *used* dependency that is undeclared, compiling today only through a transitive path — and it deserves its own PR rather than being bundled into a removal-only change.

**Fork-staging note.** On this fork the branch is based on the fork's `main`, which is two commits behind `autowarefoundation/autoware_universe@main`; the change itself does not depend on either. The upstream branch will be cut from `upstream/main` directly.

## Interface changes

None. No ROS topics, services, or parameters change.

## Effects on system behavior

None. No source file is touched — the change is three `<depend>` lines in two `package.xml` files, each proven to have no user in code and no effect on the build.

