### PR TITLE
test(autoware_ptv3): add detection fixture defaults

### DIFF
--- a/perception/autoware_ptv3/test/ptv3_test_fixture.hpp
+++ b/perception/autoware_ptv3/test/ptv3_test_fixture.hpp
@@ -54,6 +54,14 @@ struct PTv3ConfigParams
   bool filter_apply_to_segmentation = false;
   std::string source_reconstruction = "partial";
   std::vector<std::int64_t> dec_depths = {0, 0};
+  std::vector<std::string> detection_class_names = {"CAR", "PEDESTRIAN"};
+  std::vector<float> bbox_voxel_size = {2.0F, 2.0F, 4.0F};
+  std::vector<float> distance_bin_upper_limits = {10.0F, 20.0F};
+  std::vector<float> detection_score_thresholds = {0.1F, 0.2F, 0.3F, 0.4F};
+  std::vector<float> yaw_norm_thresholds = {0.1F, 0.2F};
+  bool has_twist = true;
+  std::size_t num_proposals = 8;
+  std::vector<float> post_center_range = {-2.0F, -2.0F, -2.0F, 4.0F, 4.0F, 4.0F};
 };
 
 inline PTv3Config makeConfig(const PTv3ConfigParams & params = {})
@@ -63,7 +71,10 @@ inline PTv3Config makeConfig(const PTv3ConfigParams & params = {})
     params.voxels_num, params.point_cloud_range, params.voxel_size, params.segmentation_class_names,
     params.serialization_orders, params.pooling_strides, params.enc_channels, params.palette,
     params.filter_classes, params.filter_output_format, params.filter_apply_to_segmentation,
-    params.source_reconstruction, params.dec_depths);
+    params.source_reconstruction, params.dec_depths, params.detection_class_names,
+    params.bbox_voxel_size,
+    params.distance_bin_upper_limits, params.detection_score_thresholds, params.yaw_norm_thresholds,
+    params.has_twist, params.num_proposals, params.post_center_range);
 }
 
 // Base fixture for all autoware_ptv3 CUDA unit tests: owns a CUDA stream and the

--- a/perception/autoware_ptv3/test/ptv3_test_fixture.hpp
+++ b/perception/autoware_ptv3/test/ptv3_test_fixture.hpp
@@ -72,9 +72,8 @@ inline PTv3Config makeConfig(const PTv3ConfigParams & params = {})
     params.serialization_orders, params.pooling_strides, params.enc_channels, params.palette,
     params.filter_classes, params.filter_output_format, params.filter_apply_to_segmentation,
     params.source_reconstruction, params.dec_depths, params.detection_class_names,
-    params.bbox_voxel_size,
-    params.distance_bin_upper_limits, params.detection_score_thresholds, params.yaw_norm_thresholds,
-    params.has_twist, params.num_proposals, params.post_center_range);
+    params.bbox_voxel_size, params.distance_bin_upper_limits, params.detection_score_thresholds,
+    params.yaw_norm_thresholds, params.has_twist, params.num_proposals, params.post_center_range);
 }
 
 // Base fixture for all autoware_ptv3 CUDA unit tests: owns a CUDA stream and the


### PR DESCRIPTION
## Summary
- add detection-capable defaults to the shared PTv3 test fixture
- pass detection config fields through makeConfig()

This is part of a larger PR stack: 
* https://github.com/mojomex/autoware_universe/pull/19
* https://github.com/mojomex/autoware_universe/pull/20
* https://github.com/mojomex/autoware_universe/pull/21
* https://github.com/mojomex/autoware_universe/pull/22
* https://github.com/mojomex/autoware_universe/pull/23
* https://github.com/mojomex/autoware_universe/pull/24
* https://github.com/mojomex/autoware_universe/pull/25
* https://github.com/mojomex/autoware_universe/pull/26

## Stack

All PRs in this stack target `autowarefoundation/autoware_universe:main`.

- PR 1: https://github.com/autowarefoundation/autoware_universe/pull/13133 - test(autoware_ptv3): add detection fixture defaults
- PR 2: https://github.com/autowarefoundation/autoware_universe/pull/13138 - test(autoware_ptv3): exclude max range voxel coords
- PR 3: https://github.com/autowarefoundation/autoware_universe/pull/13139 - test(autoware_ptv3): assert pooling index invariants
- PR 4: https://github.com/autowarefoundation/autoware_universe/pull/13140 - test(autoware_ptv3): validate detection grid compatibility
- PR 5: https://github.com/autowarefoundation/autoware_universe/pull/13141 - test(autoware_ptv3): check detection BEV grid bounds
- PR 6: https://github.com/autowarefoundation/autoware_universe/pull/13142 - test(autoware_ptv3): cover detection postprocess decode
- PR 7: https://github.com/autowarefoundation/autoware_universe/pull/13143 - test(autoware_ptv3): cover detection ROS conversion
- PR 8: https://github.com/autowarefoundation/autoware_universe/pull/13144 - test(autoware_ptv3): cover detection threshold config
- PR 9: https://github.com/autowarefoundation/autoware_universe/pull/13145 - test(autoware_ptv3): cover unknown detection label

## Validation
- colcon build --packages-select autoware_ptv3
- colcon test --packages-select autoware_ptv3: 10/10 tests passed
