### PR TITLE
test(autoware_ptv3): validate detection grid compatibility

### DIFF
--- a/perception/autoware_ptv3/CMakeLists.txt
+++ b/perception/autoware_ptv3/CMakeLists.txt
@@ -135,6 +135,11 @@ if(TRT_AVAIL AND CUDA_AVAIL)
   )
 
   if(BUILD_TESTING)
+    ament_add_gtest(ptv3_config_test
+      test/ptv3_config_test.cpp
+    )
+    target_include_directories(ptv3_config_test PRIVATE include)
+
     ament_add_gtest(serialized_pooling_metadata_test
       test/serialized_pooling_metadata_test.cpp
     )

--- a/perception/autoware_ptv3/include/autoware/ptv3/ptv3_config.hpp
+++ b/perception/autoware_ptv3/include/autoware/ptv3/ptv3_config.hpp
@@ -216,6 +216,15 @@ public:
       if (bbox_grid_x_size == 0 || bbox_grid_y_size == 0) {
         throw std::runtime_error("bbox_voxel_size produces an empty detection grid.");
       }
+      if (
+        std::abs(
+          (static_cast<float>(bbox_grid_x_size) * bbox_voxel_x_size_) -
+          (max_x_range_ - min_x_range_)) > eps ||
+        std::abs(
+          (static_cast<float>(bbox_grid_y_size) * bbox_voxel_y_size_) -
+          (max_y_range_ - min_y_range_)) > eps) {
+        throw std::runtime_error("bbox_voxel_size must evenly cover the point cloud xy range.");
+      }
       det_grid_x_size_ = bbox_grid_x_size;
       det_grid_y_size_ = bbox_grid_y_size;
 

--- a/perception/autoware_ptv3/test/ptv3_config_test.cpp
+++ b/perception/autoware_ptv3/test/ptv3_config_test.cpp
@@ -1,0 +1,58 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/ptv3/ptv3_config.hpp"
+
+#include <gtest/gtest.h>
+
+#include <stdexcept>
+#include <vector>
+
+namespace autoware::ptv3
+{
+namespace test
+{
+
+PTv3Config makeDetectionConfig(
+  const std::vector<float> & point_cloud_range = {0.0F, 0.0F, 0.0F, 16.0F, 16.0F, 4.0F},
+  const std::vector<float> & bbox_voxel_size = {8.0F, 8.0F, 4.0F})
+{
+  return PTv3Config(
+    false, true, "", 8, {1, 4, 8}, point_cloud_range, {1.0F, 1.0F, 1.0F}, {}, {"z", "z-trans"},
+    {2, 2, 2, 2}, {8, 16, 32, 64, 128}, {}, {}, "", false, "", {}, {"CAR", "PEDESTRIAN"},
+    bbox_voxel_size, {10.0F, 20.0F}, {0.1F, 0.2F, 0.3F, 0.4F}, {0.1F, 0.2F}, true, 8,
+    {-2.0F, -2.0F, -2.0F, 4.0F, 4.0F, 4.0F});
+}
+
+TEST(PTv3ConfigTest, AcceptsCompatibleDetectionGrid)
+{
+  const auto config = makeDetectionConfig();
+  EXPECT_EQ(config.det_grid_x_size_, 2U);
+  EXPECT_EQ(config.det_grid_y_size_, 2U);
+}
+
+TEST(PTv3ConfigTest, RejectsDetectionGridThatDoesNotMatchFeatureDepth)
+{
+  EXPECT_THROW(
+    makeDetectionConfig({0.0F, 0.0F, 0.0F, 16.0F, 16.0F, 4.0F}, {4.0F, 8.0F, 4.0F}),
+    std::runtime_error);
+}
+
+TEST(PTv3ConfigTest, RejectsDetectionGridThatDoesNotCoverVoxelGridExactly)
+{
+  EXPECT_THROW(makeDetectionConfig({0.0F, 0.0F, 0.0F, 18.0F, 16.0F, 4.0F}), std::runtime_error);
+}
+
+}  // namespace test
+}  // namespace autoware::ptv3

--- a/perception/autoware_ptv3/test/ptv3_test_fixture.hpp
+++ b/perception/autoware_ptv3/test/ptv3_test_fixture.hpp
@@ -54,6 +54,14 @@ struct PTv3ConfigParams
   bool filter_apply_to_segmentation = false;
   std::string source_reconstruction = "partial";
   std::vector<std::int64_t> dec_depths = {0, 0};
+  std::vector<std::string> detection_class_names = {"CAR", "PEDESTRIAN"};
+  std::vector<float> bbox_voxel_size = {2.0F, 2.0F, 4.0F};
+  std::vector<float> distance_bin_upper_limits = {10.0F, 20.0F};
+  std::vector<float> detection_score_thresholds = {0.1F, 0.2F, 0.3F, 0.4F};
+  std::vector<float> yaw_norm_thresholds = {0.1F, 0.2F};
+  bool has_twist = true;
+  std::size_t num_proposals = 8;
+  std::vector<float> post_center_range = {-2.0F, -2.0F, -2.0F, 4.0F, 4.0F, 4.0F};
 };
 
 inline PTv3Config makeConfig(const PTv3ConfigParams & params = {})
@@ -63,7 +71,10 @@ inline PTv3Config makeConfig(const PTv3ConfigParams & params = {})
     params.voxels_num, params.point_cloud_range, params.voxel_size, params.segmentation_class_names,
     params.serialization_orders, params.pooling_strides, params.enc_channels, params.palette,
     params.filter_classes, params.filter_output_format, params.filter_apply_to_segmentation,
-    params.source_reconstruction, params.dec_depths);
+    params.source_reconstruction, params.dec_depths, params.detection_class_names,
+    params.bbox_voxel_size,
+    params.distance_bin_upper_limits, params.detection_score_thresholds, params.yaw_norm_thresholds,
+    params.has_twist, params.num_proposals, params.post_center_range);
 }
 
 // Base fixture for all autoware_ptv3 CUDA unit tests: owns a CUDA stream and the

--- a/perception/autoware_ptv3/test/ptv3_test_fixture.hpp
+++ b/perception/autoware_ptv3/test/ptv3_test_fixture.hpp
@@ -72,9 +72,8 @@ inline PTv3Config makeConfig(const PTv3ConfigParams & params = {})
     params.serialization_orders, params.pooling_strides, params.enc_channels, params.palette,
     params.filter_classes, params.filter_output_format, params.filter_apply_to_segmentation,
     params.source_reconstruction, params.dec_depths, params.detection_class_names,
-    params.bbox_voxel_size,
-    params.distance_bin_upper_limits, params.detection_score_thresholds, params.yaw_norm_thresholds,
-    params.has_twist, params.num_proposals, params.post_center_range);
+    params.bbox_voxel_size, params.distance_bin_upper_limits, params.detection_score_thresholds,
+    params.yaw_norm_thresholds, params.has_twist, params.num_proposals, params.post_center_range);
 }
 
 // Base fixture for all autoware_ptv3 CUDA unit tests: owns a CUDA stream and the

--- a/perception/autoware_ptv3/test/serialized_pooling_metadata_test.cpp
+++ b/perception/autoware_ptv3/test/serialized_pooling_metadata_test.cpp
@@ -213,6 +213,25 @@ void expect_equal(
   EXPECT_EQ(actual, expected) << name;
 }
 
+void expect_all_in_range(
+  const std::vector<std::int64_t> & values, const std::int64_t upper_bound,
+  const std::string & name)
+{
+  for (std::size_t i = 0; i < values.size(); ++i) {
+    EXPECT_GE(values[i], 0) << name << " at index " << i;
+    EXPECT_LT(values[i], upper_bound) << name << " at index " << i;
+  }
+}
+
+void expect_permutation(const std::vector<std::int64_t> & values, const std::string & name)
+{
+  std::vector<std::int64_t> sorted = values;
+  std::sort(sorted.begin(), sorted.end());
+  std::vector<std::int64_t> expected(values.size());
+  std::iota(expected.begin(), expected.end(), 0);
+  EXPECT_EQ(sorted, expected) << name;
+}
+
 class SerializedPoolingMetadataTest : public PTv3CudaTest
 {
 };
@@ -269,25 +288,40 @@ TEST_F(SerializedPoolingMetadataTest, MatchesCpuReferenceForOnnxFacingInputs)
     const auto out_count = static_cast<std::size_t>(stage_counts[stage_index + 1]);
     const auto prefix = "stage " + std::to_string(stage_index) + " ";
 
-    expect_equal(copyToHost(actual.indices.get(), in_count), expected.indices, prefix + "indices");
-    expect_equal(
-      copyToHost(actual.indptr.get(), out_count + 1), expected.indptr, prefix + "indptr");
-    expect_equal(
-      copyToHost(actual.head_indices.get(), out_count), expected.head_indices,
-      prefix + "head_indices");
-    expect_equal(copyToHost(actual.cluster.get(), in_count), expected.cluster, prefix + "cluster");
+    const auto indices = copyToHost(actual.indices.get(), in_count);
+    const auto indptr = copyToHost(actual.indptr.get(), out_count + 1);
+    const auto head_indices = copyToHost(actual.head_indices.get(), out_count);
+    const auto cluster = copyToHost(actual.cluster.get(), in_count);
+    expect_all_in_range(indices, static_cast<std::int64_t>(in_count), prefix + "indices");
+    expect_all_in_range(head_indices, static_cast<std::int64_t>(in_count), prefix + "head_indices");
+    expect_all_in_range(cluster, static_cast<std::int64_t>(out_count), prefix + "cluster");
+    EXPECT_TRUE(std::is_sorted(indptr.begin(), indptr.end())) << prefix + "indptr";
+    expect_equal(indices, expected.indices, prefix + "indices");
+    expect_equal(indptr, expected.indptr, prefix + "indptr");
+    expect_equal(head_indices, expected.head_indices, prefix + "head_indices");
+    expect_equal(cluster, expected.cluster, prefix + "cluster");
     expect_equal(
       copyToHost(actual.grid_coord.get(), out_count * 3), expected.grid_coord,
       prefix + "grid_coord");
     expect_equal(
       copyToHost(actual.serialized_code.get(), out_count * kNumOrders), expected.serialized_code,
       prefix + "serialized_code");
-    expect_equal(
-      copyToHost(actual.serialized_order.get(), out_count * kNumOrders), expected.serialized_order,
-      prefix + "serialized_order");
-    expect_equal(
-      copyToHost(actual.serialized_inverse.get(), out_count * kNumOrders),
-      expected.serialized_inverse, prefix + "serialized_inverse");
+    const auto serialized_order = copyToHost(actual.serialized_order.get(), out_count * kNumOrders);
+    const auto serialized_inverse =
+      copyToHost(actual.serialized_inverse.get(), out_count * kNumOrders);
+    expect_equal(serialized_order, expected.serialized_order, prefix + "serialized_order");
+    expect_equal(serialized_inverse, expected.serialized_inverse, prefix + "serialized_inverse");
+    for (std::size_t order = 0; order < kNumOrders; ++order) {
+      const auto begin = static_cast<std::ptrdiff_t>(order * out_count);
+      const auto end = static_cast<std::ptrdiff_t>((order + 1) * out_count);
+      expect_permutation(
+        std::vector<std::int64_t>(serialized_order.begin() + begin, serialized_order.begin() + end),
+        prefix + "serialized_order " + std::to_string(order));
+      expect_permutation(
+        std::vector<std::int64_t>(
+          serialized_inverse.begin() + begin, serialized_inverse.begin() + end),
+        prefix + "serialized_inverse " + std::to_string(order));
+    }
   }
 }
 

--- a/perception/autoware_ptv3/test/test_preprocess_kernel.cpp
+++ b/perception/autoware_ptv3/test/test_preprocess_kernel.cpp
@@ -67,6 +67,11 @@ protected:
   {
     PTv3ConfigParams params;
     params.source_reconstruction = source_reconstruction;
+    initializePreprocess(params);
+  }
+
+  void initializePreprocess(const PTv3ConfigParams & params)
+  {
     config_.emplace(makeConfig(params));
     preprocess_ = std::make_unique<PreprocessCuda>(*config_, stream_);
   }
@@ -94,7 +99,16 @@ protected:
     const std::string & source_reconstruction, const std::vector<CloudPointTypeXYZI> & host_points,
     const bool with_source_outputs)
   {
-    initializePreprocess(source_reconstruction);
+    PTv3ConfigParams params;
+    params.source_reconstruction = source_reconstruction;
+    return runGenerateFeatures(params, host_points, with_source_outputs);
+  }
+
+  GenerateFeaturesResult runGenerateFeatures(
+    const PTv3ConfigParams & params, const std::vector<CloudPointTypeXYZI> & host_points,
+    const bool with_source_outputs)
+  {
+    initializePreprocess(params);
     const auto & config = *config_;
 
     auto input_points_d = makeDeviceBuffer<CloudPointTypeXYZI>(host_points.size());
@@ -201,6 +215,43 @@ TEST_F(PreprocessKernelTest, PartialReconstructionBuildsVoxelCoords)
     const auto z = voxel_coords[voxel_idx * 3 + 2];
     EXPECT_TRUE(
       (x == 0 && y == 0 && z == 0) || (x == 1 && y == 1 && z == 1) || (x == 2 && y == 2 && z == 2));
+  }
+}
+
+TEST_F(PreprocessKernelTest, CroppedVoxelCoordsStayInsideGridBounds)
+{
+  PTv3ConfigParams params;
+  params.source_reconstruction = "partial";
+  params.point_cloud_range = {0.0F, 0.0F, 0.0F, 4.0F, 4.0F, 4.0F};
+
+  const std::vector<CloudPointTypeXYZI> host_points{
+    {0.0F, 0.0F, 0.0F, 1.0F},
+    {3.999F, 3.999F, 3.999F, 2.0F},
+    {4.0F, 0.0F, 0.0F, 3.0F},
+    {0.0F, 4.0F, 0.0F, 4.0F},
+    {0.0F, 0.0F, 4.0F, 5.0F},
+    {-0.001F, 0.0F, 0.0F, 6.0F},
+  };
+
+  const auto result = runGenerateFeatures(params, host_points, true);
+  EXPECT_EQ(result.num_cropped_points, 2U);
+  EXPECT_EQ(result.num_voxels, 2U);
+
+  const auto crop_mask = copyToHost(preprocess_->cropMask(), host_points.size());
+  EXPECT_EQ(crop_mask, (std::vector<std::uint32_t>{1, 1, 0, 0, 0, 0}));
+
+  const auto & config = *config_;
+  const auto voxel_coords = copyToHost(result.voxel_coords_d.get(), result.num_voxels * 3);
+  for (std::size_t voxel_idx = 0; voxel_idx < result.num_voxels; ++voxel_idx) {
+    const auto x = voxel_coords[voxel_idx * 3 + 0];
+    const auto y = voxel_coords[voxel_idx * 3 + 1];
+    const auto z = voxel_coords[voxel_idx * 3 + 2];
+    EXPECT_GE(x, 0);
+    EXPECT_GE(y, 0);
+    EXPECT_GE(z, 0);
+    EXPECT_LT(x, config.grid_x_size_);
+    EXPECT_LT(y, config.grid_y_size_);
+    EXPECT_LT(z, config.grid_z_size_);
   }
 }
 

--- a/perception/autoware_ptv3/test/test_preprocess_kernel.cpp
+++ b/perception/autoware_ptv3/test/test_preprocess_kernel.cpp
@@ -225,12 +225,8 @@ TEST_F(PreprocessKernelTest, CroppedVoxelCoordsStayInsideGridBounds)
   params.point_cloud_range = {0.0F, 0.0F, 0.0F, 4.0F, 4.0F, 4.0F};
 
   const std::vector<CloudPointTypeXYZI> host_points{
-    {0.0F, 0.0F, 0.0F, 1.0F},
-    {3.999F, 3.999F, 3.999F, 2.0F},
-    {4.0F, 0.0F, 0.0F, 3.0F},
-    {0.0F, 4.0F, 0.0F, 4.0F},
-    {0.0F, 0.0F, 4.0F, 5.0F},
-    {-0.001F, 0.0F, 0.0F, 6.0F},
+    {0.0F, 0.0F, 0.0F, 1.0F}, {3.999F, 3.999F, 3.999F, 2.0F}, {4.0F, 0.0F, 0.0F, 3.0F},
+    {0.0F, 4.0F, 0.0F, 4.0F}, {0.0F, 0.0F, 4.0F, 5.0F},       {-0.001F, 0.0F, 0.0F, 6.0F},
   };
 
   const auto result = runGenerateFeatures(params, host_points, true);


### PR DESCRIPTION
## Summary
- add CPU-only PTv3Config tests for detection grid compatibility
- reject detection configs whose BEV grid does not exactly cover the voxel grid or match detection feature depth 3

## Stack

All PRs in this stack target `autowarefoundation/autoware_universe:main`.

- PR 1: https://github.com/autowarefoundation/autoware_universe/pull/13133 - test(autoware_ptv3): add detection fixture defaults
- PR 2: https://github.com/autowarefoundation/autoware_universe/pull/13138 - test(autoware_ptv3): exclude max range voxel coords
- PR 3: https://github.com/autowarefoundation/autoware_universe/pull/13139 - test(autoware_ptv3): assert pooling index invariants
- PR 4: https://github.com/autowarefoundation/autoware_universe/pull/13140 - test(autoware_ptv3): validate detection grid compatibility
- PR 5: https://github.com/autowarefoundation/autoware_universe/pull/13141 - test(autoware_ptv3): check detection BEV grid bounds
- PR 6: https://github.com/autowarefoundation/autoware_universe/pull/13142 - test(autoware_ptv3): cover detection postprocess decode
- PR 7: https://github.com/autowarefoundation/autoware_universe/pull/13143 - test(autoware_ptv3): cover detection ROS conversion
- PR 8: https://github.com/autowarefoundation/autoware_universe/pull/13144 - test(autoware_ptv3): cover detection threshold config
- PR 9: https://github.com/autowarefoundation/autoware_universe/pull/13145 - test(autoware_ptv3): cover unknown detection label

## Validation
- git diff --check
- local colcon test blocked by stale install dependencies in this checkout
