### PR TITLE
test(autoware_ptv3): cover detection ROS conversion

### DIFF
--- a/perception/autoware_ptv3/CMakeLists.txt
+++ b/perception/autoware_ptv3/CMakeLists.txt
@@ -186,6 +186,14 @@ if(TRT_AVAIL AND CUDA_AVAIL)
       ${PROJECT_NAME}_cuda_lib
     )
 
+    ament_add_gtest(ros_utils_test
+      test/ros_utils_test.cpp
+    )
+
+    target_link_libraries(ros_utils_test
+      ${PROJECT_NAME}_lib
+    )
+
   endif()
 
   ament_auto_package(

--- a/perception/autoware_ptv3/test/ros_utils_test.cpp
+++ b/perception/autoware_ptv3/test/ros_utils_test.cpp
@@ -1,0 +1,56 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/ptv3/ros_utils.hpp"
+
+#include <autoware_perception_msgs/msg/object_classification.hpp>
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+namespace autoware::ptv3
+{
+namespace test
+{
+using autoware_perception_msgs::msg::ObjectClassification;
+
+TEST(RosUtilsTest, MapsDetectionClassNames)
+{
+  EXPECT_EQ(get_classification_type("CAR"), ObjectClassification::CAR);
+  EXPECT_EQ(get_classification_type("MOTORBIKE"), ObjectClassification::MOTORCYCLE);
+  EXPECT_EQ(get_classification_type("TRAFFIC_CONE"), ObjectClassification::HAZARD);
+  EXPECT_EQ(get_classification_type("UNKNOWN_CLASS"), ObjectClassification::UNKNOWN);
+}
+
+TEST(RosUtilsTest, ConvertsBox3DToDetectedObject)
+{
+  constexpr float pi = 3.14159265358979323846F;
+  const Box3D box{1, 0.75F, 1.0F, 2.0F, 3.0F, 4.0F, 5.0F, 6.0F, 0.5F * pi, 1.0F, 2.0F};
+  autoware_perception_msgs::msg::DetectedObject object;
+
+  box3d_to_detected_object(box, {"CAR", "PEDESTRIAN"}, true, object);
+
+  ASSERT_EQ(object.classification.size(), 1U);
+  EXPECT_EQ(object.classification.front().label, ObjectClassification::PEDESTRIAN);
+  EXPECT_FLOAT_EQ(object.existence_probability, 0.75F);
+  EXPECT_FLOAT_EQ(object.kinematics.pose_with_covariance.pose.position.x, 1.0F);
+  EXPECT_FLOAT_EQ(object.shape.dimensions.x, 4.0F);
+  EXPECT_TRUE(object.kinematics.has_twist);
+  EXPECT_NEAR(object.kinematics.twist_with_covariance.twist.linear.x, 2.0F, 1e-5F);
+  EXPECT_NEAR(object.kinematics.twist_with_covariance.twist.linear.y, -1.0F, 1e-5F);
+}
+
+}  // namespace test
+}  // namespace autoware::ptv3


### PR DESCRIPTION
## Summary
- add ROS utility tests for detection class mapping
- verify Box3D to DetectedObject conversion, dimensions, probability, and twist rotation

## Stack

All PRs in this stack target `autowarefoundation/autoware_universe:main`.

- PR 1: https://github.com/autowarefoundation/autoware_universe/pull/13133 - test(autoware_ptv3): add detection fixture defaults
- PR 2: https://github.com/autowarefoundation/autoware_universe/pull/13138 - test(autoware_ptv3): exclude max range voxel coords
- PR 3: https://github.com/autowarefoundation/autoware_universe/pull/13139 - test(autoware_ptv3): assert pooling index invariants
- PR 4: https://github.com/autowarefoundation/autoware_universe/pull/13140 - test(autoware_ptv3): validate detection grid compatibility
- PR 5: https://github.com/autowarefoundation/autoware_universe/pull/13141 - test(autoware_ptv3): check detection BEV grid bounds
- PR 6: https://github.com/autowarefoundation/autoware_universe/pull/13142 - test(autoware_ptv3): cover detection postprocess decode
- PR 7: https://github.com/autowarefoundation/autoware_universe/pull/13143 - test(autoware_ptv3): cover detection ROS conversion
- PR 8: https://github.com/autowarefoundation/autoware_universe/pull/13144 - test(autoware_ptv3): cover detection threshold config
- PR 9: https://github.com/autowarefoundation/autoware_universe/pull/13145 - test(autoware_ptv3): cover unknown detection label

## Validation
- git diff --check
- local colcon test blocked by stale install dependencies in this checkout
