### PR TITLE
test(autoware_ptv3): cover unknown detection label

### DIFF
--- a/perception/autoware_ptv3/test/ros_utils_test.cpp
+++ b/perception/autoware_ptv3/test/ros_utils_test.cpp
@@ -52,5 +52,17 @@ TEST(RosUtilsTest, ConvertsBox3DToDetectedObject)
   EXPECT_NEAR(object.kinematics.twist_with_covariance.twist.linear.y, -1.0F, 1e-5F);
 }
 
+TEST(RosUtilsTest, ConvertsUnknownBoxLabelWithoutTwist)
+{
+  const Box3D box{99, 0.5F, 0.0F, 0.0F, 0.0F, 1.0F, 1.0F, 1.0F, 0.0F, 1.0F, 1.0F};
+  autoware_perception_msgs::msg::DetectedObject object;
+
+  box3d_to_detected_object(box, {"CAR"}, false, object);
+
+  ASSERT_EQ(object.classification.size(), 1U);
+  EXPECT_EQ(object.classification.front().label, ObjectClassification::UNKNOWN);
+  EXPECT_FALSE(object.kinematics.has_twist);
+}
+
 }  // namespace test
 }  // namespace autoware::ptv3


### PR DESCRIPTION
## Summary
- add a ROS conversion edge-case test for unknown detection labels
- verify no-twist conversion leaves has_twist false

## Stack

All PRs in this stack target `autowarefoundation/autoware_universe:main`.

- PR 1: https://github.com/autowarefoundation/autoware_universe/pull/13133 - test(autoware_ptv3): add detection fixture defaults
- PR 2: https://github.com/autowarefoundation/autoware_universe/pull/13138 - test(autoware_ptv3): exclude max range voxel coords
- PR 3: https://github.com/autowarefoundation/autoware_universe/pull/13139 - test(autoware_ptv3): assert pooling index invariants
- PR 4: https://github.com/autowarefoundation/autoware_universe/pull/13140 - test(autoware_ptv3): validate detection grid compatibility
- PR 5: https://github.com/autowarefoundation/autoware_universe/pull/13141 - test(autoware_ptv3): check detection BEV grid bounds
- PR 6: https://github.com/autowarefoundation/autoware_universe/pull/13142 - test(autoware_ptv3): cover detection postprocess decode
- PR 7: https://github.com/autowarefoundation/autoware_universe/pull/13143 - test(autoware_ptv3): cover detection ROS conversion
- PR 8: https://github.com/autowarefoundation/autoware_universe/pull/13144 - test(autoware_ptv3): cover detection threshold config
- PR 9: https://github.com/autowarefoundation/autoware_universe/pull/13145 - test(autoware_ptv3): cover unknown detection label

## Validation
- git diff --check
- local colcon test blocked by stale install dependencies in this checkout
