### PR TITLE
feat(diffusion_planner): resolve model paths from base_model_directory

### DIFF
--- a/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
+++ b/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
@@ -6,13 +6,8 @@
       backend: "tensorrt" # "tensorrt" "ort_cpu" "ort_cuda" "ort_tensorrt"
       precision: "fp32"
       use_cuda_graph: false
-      args_path: $(var data_path)/diffusion_planner/v5.0/diffusion_planner.param.json
-      single_step_model:
-        onnx_model_path: $(var data_path)/diffusion_planner/v5.0/diffusion_planner.onnx
+      base_model_directory: $(var data_path)/diffusion_planner/v5.0
       multi_step_model:
-        encoder_onnx_model_path: $(var data_path)/diffusion_planner/v5.0/diffusion_planner_encoder.onnx
-        decoder_onnx_model_path: $(var data_path)/diffusion_planner/v5.0/diffusion_planner_decoder.onnx
-        turn_indicator_onnx_model_path: $(var data_path)/diffusion_planner/v5.0/diffusion_planner_turn_indicator.onnx
         dpm_solver_steps: 10
     guidance:
       start_guidance:

--- a/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
+++ b/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
@@ -7,7 +7,13 @@
       precision: "fp32"
       use_cuda_graph: false
       base_model_directory: $(var data_path)/diffusion_planner/v5.0
+      args_filename: diffusion_planner.param.json
+      single_step_model:
+        onnx_model_filename: diffusion_planner.onnx
       multi_step_model:
+        encoder_onnx_model_filename: diffusion_planner_encoder.onnx
+        decoder_onnx_model_filename: diffusion_planner_decoder.onnx
+        turn_indicator_onnx_model_filename: diffusion_planner_turn_indicator.onnx
         dpm_solver_steps: 10
     guidance:
       start_guidance:

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_core.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_core.hpp
@@ -116,6 +116,7 @@ struct DiffusionPlannerParams
   std::string decoder_model_path;
   std::string turn_indicator_model_path;
   std::string args_path;
+  std::string base_model_directory;
   std::string plugins_path;
   std::string backend;
   std::string trt_precision;
@@ -177,6 +178,8 @@ public:
    * @param params New parameters to apply
    */
   void update_params(const DiffusionPlannerParams & params);
+
+  void resolve_model_paths();
 
   /**
    * @brief Prepare frame context for inference.

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_core.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_core.hpp
@@ -111,12 +111,17 @@ struct FrameContext
 struct DiffusionPlannerParams
 {
   std::string model_type;
+  std::string base_model_directory;
+  std::string args_filename;
+  std::string single_step_model_filename;
+  std::string encoder_model_filename;
+  std::string decoder_model_filename;
+  std::string turn_indicator_model_filename;
   std::string single_step_model_path;
   std::string encoder_model_path;
   std::string decoder_model_path;
   std::string turn_indicator_model_path;
   std::string args_path;
-  std::string base_model_directory;
   std::string plugins_path;
   std::string backend;
   std::string trt_precision;

--- a/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
+++ b/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
@@ -23,7 +23,12 @@
             "base_model_directory": {
               "type": "string",
               "default": "$(var data_path)/diffusion_planner/v5.0",
-              "description": "Base directory containing ONNX models and diffusion_planner.param.json"
+              "description": "Base directory containing ONNX models and args file"
+            },
+            "args_filename": {
+              "type": "string",
+              "default": "diffusion_planner.param.json",
+              "description": "Args/configuration JSON filename relative to base_model_directory"
             },
             "backend": {
               "type": "string",
@@ -44,12 +49,33 @@
             },
             "single_step_model": {
               "type": "object",
-              "properties": {},
-              "additionalProperties": false
+              "properties": {
+                "onnx_model_filename": {
+                  "type": "string",
+                  "default": "diffusion_planner.onnx",
+                  "description": "Single-step ONNX model filename relative to base_model_directory"
+                }
+              },
+              "required": ["onnx_model_filename"]
             },
             "multi_step_model": {
               "type": "object",
               "properties": {
+                "encoder_onnx_model_filename": {
+                  "type": "string",
+                  "default": "diffusion_planner_encoder.onnx",
+                  "description": "Encoder ONNX model filename relative to base_model_directory"
+                },
+                "decoder_onnx_model_filename": {
+                  "type": "string",
+                  "default": "diffusion_planner_decoder.onnx",
+                  "description": "Decoder ONNX model filename relative to base_model_directory"
+                },
+                "turn_indicator_onnx_model_filename": {
+                  "type": "string",
+                  "default": "diffusion_planner_turn_indicator.onnx",
+                  "description": "Turn indicator ONNX model filename relative to base_model_directory"
+                },
                 "dpm_solver_steps": {
                   "type": "integer",
                   "default": 10,
@@ -57,12 +83,18 @@
                   "description": "Number of DPM-Solver denoising steps. The final denoise-to-zero step is added separately."
                 }
               },
-              "required": ["dpm_solver_steps"]
+              "required": [
+                "encoder_onnx_model_filename",
+                "decoder_onnx_model_filename",
+                "turn_indicator_onnx_model_filename",
+                "dpm_solver_steps"
+              ]
             }
           },
           "required": [
             "type",
             "base_model_directory",
+            "args_filename",
             "backend",
             "precision",
             "use_cuda_graph",

--- a/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
+++ b/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
@@ -20,10 +20,10 @@
               "enum": ["single_step", "multi_step"],
               "description": "Inference model type"
             },
-            "args_path": {
+            "base_model_directory": {
               "type": "string",
-              "default": "$(var data_path)/diffusion_planner/v5.0/args.json",
-              "description": "Path to model argument/configuration file"
+              "default": "$(var data_path)/diffusion_planner/v5.0",
+              "description": "Base directory containing ONNX models and diffusion_planner.param.json"
             },
             "backend": {
               "type": "string",
@@ -44,33 +44,12 @@
             },
             "single_step_model": {
               "type": "object",
-              "properties": {
-                "onnx_model_path": {
-                  "type": "string",
-                  "default": "$(var data_path)/diffusion_planner/v5.0/diffusion_planner.onnx",
-                  "description": "Path to the single-step ONNX model file"
-                }
-              },
-              "required": ["onnx_model_path"]
+              "properties": {},
+              "additionalProperties": false
             },
             "multi_step_model": {
               "type": "object",
               "properties": {
-                "encoder_onnx_model_path": {
-                  "type": "string",
-                  "default": "$(var data_path)/diffusion_planner/v5.0/diffusion_planner_encoder.onnx",
-                  "description": "Path to the encoder ONNX model file"
-                },
-                "decoder_onnx_model_path": {
-                  "type": "string",
-                  "default": "$(var data_path)/diffusion_planner/v5.0/diffusion_planner_decoder.onnx",
-                  "description": "Path to the decoder ONNX model file"
-                },
-                "turn_indicator_onnx_model_path": {
-                  "type": "string",
-                  "default": "$(var data_path)/diffusion_planner/v5.0/diffusion_planner_turn_indicator.onnx",
-                  "description": "Path to the turn indicator ONNX model file"
-                },
                 "dpm_solver_steps": {
                   "type": "integer",
                   "default": 10,
@@ -78,17 +57,12 @@
                   "description": "Number of DPM-Solver denoising steps. The final denoise-to-zero step is added separately."
                 }
               },
-              "required": [
-                "encoder_onnx_model_path",
-                "decoder_onnx_model_path",
-                "turn_indicator_onnx_model_path",
-                "dpm_solver_steps"
-              ]
+              "required": ["dpm_solver_steps"]
             }
           },
           "required": [
             "type",
-            "args_path",
+            "base_model_directory",
             "backend",
             "precision",
             "use_cuda_graph",

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
@@ -34,6 +34,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <filesystem>
 #include <limits>
 #include <memory>
 #include <optional>
@@ -210,6 +211,16 @@ void DiffusionPlannerCore::update_params(const DiffusionPlannerParams & params)
     centerline_guidance_->set_config(centerline_guidance_config);
     centerline_guidance_->set_enabled(centerline_guidance_enabled_);
   }
+}
+
+void DiffusionPlannerCore::resolve_model_paths()
+{
+  const std::filesystem::path base_dir(params_.base_model_directory);
+  params_.single_step_model_path = (base_dir / "diffusion_planner.onnx").string();
+  params_.encoder_model_path = (base_dir / "diffusion_planner_encoder.onnx").string();
+  params_.decoder_model_path = (base_dir / "diffusion_planner_decoder.onnx").string();
+  params_.turn_indicator_model_path = (base_dir / "diffusion_planner_turn_indicator.onnx").string();
+  params_.args_path = (base_dir / "diffusion_planner.param.json").string();
 }
 
 void DiffusionPlannerCore::set_start_guidance_enabled(const bool enabled)

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
@@ -216,11 +216,11 @@ void DiffusionPlannerCore::update_params(const DiffusionPlannerParams & params)
 void DiffusionPlannerCore::resolve_model_paths()
 {
   const std::filesystem::path base_dir(params_.base_model_directory);
-  params_.single_step_model_path = (base_dir / "diffusion_planner.onnx").string();
-  params_.encoder_model_path = (base_dir / "diffusion_planner_encoder.onnx").string();
-  params_.decoder_model_path = (base_dir / "diffusion_planner_decoder.onnx").string();
-  params_.turn_indicator_model_path = (base_dir / "diffusion_planner_turn_indicator.onnx").string();
-  params_.args_path = (base_dir / "diffusion_planner.param.json").string();
+  params_.single_step_model_path = (base_dir / params_.single_step_model_filename).string();
+  params_.encoder_model_path = (base_dir / params_.encoder_model_filename).string();
+  params_.decoder_model_path = (base_dir / params_.decoder_model_filename).string();
+  params_.turn_indicator_model_path = (base_dir / params_.turn_indicator_model_filename).string();
+  params_.args_path = (base_dir / params_.args_filename).string();
 }
 
 void DiffusionPlannerCore::set_start_guidance_enabled(const bool enabled)

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
@@ -166,15 +166,8 @@ void DiffusionPlanner::set_up_params()
 {
   // node params
   params_.model_type = this->declare_parameter<std::string>("model.type", "single_step");
-  params_.args_path = this->declare_parameter<std::string>("model.args_path", "");
-  params_.single_step_model_path =
-    this->declare_parameter<std::string>("model.single_step_model.onnx_model_path", "");
-  params_.encoder_model_path =
-    this->declare_parameter<std::string>("model.multi_step_model.encoder_onnx_model_path", "");
-  params_.decoder_model_path =
-    this->declare_parameter<std::string>("model.multi_step_model.decoder_onnx_model_path", "");
-  params_.turn_indicator_model_path = this->declare_parameter<std::string>(
-    "model.multi_step_model.turn_indicator_onnx_model_path", "");
+  params_.base_model_directory =
+    this->declare_parameter<std::string>("model.base_model_directory", "");
   params_.dpm_solver_steps =
     this->declare_parameter<int>("model.multi_step_model.dpm_solver_steps", 10);
   params_.backend = this->declare_parameter<std::string>("model.backend", "tensorrt");
@@ -233,6 +226,7 @@ void DiffusionPlanner::load_model()
 {
   diagnostics_inference_->update_level_and_message(DiagnosticStatus::WARN, "Loading model");
   diagnostics_inference_->publish(get_clock()->now());
+  core_->resolve_model_paths();
   core_->load_model();
   diagnostics_inference_->update_level_and_message(DiagnosticStatus::OK, "Model loaded");
   diagnostics_inference_->publish(get_clock()->now());
@@ -267,12 +261,7 @@ SetParametersResult DiffusionPlanner::on_parameter(
   using autoware_utils::update_param;
   {
     DiffusionPlannerParams temp_params = params_;
-    const auto previous_args_path = params_.args_path;
-    const auto previous_model_type = params_.model_type;
-    const auto previous_single_step_model_path = params_.single_step_model_path;
-    const auto previous_encoder_model_path = params_.encoder_model_path;
-    const auto previous_decoder_model_path = params_.decoder_model_path;
-    const auto previous_turn_indicator_model_path = params_.turn_indicator_model_path;
+    const auto previous_base_model_directory = params_.base_model_directory;
     const auto previous_batch_size = params_.batch_size;
     const auto previous_dpm_solver_steps = params_.dpm_solver_steps;
     const auto previous_backend = params_.backend;
@@ -280,16 +269,8 @@ SetParametersResult DiffusionPlanner::on_parameter(
     const auto previous_use_cuda_graph = params_.use_cuda_graph;
     const auto previous_line_string_max_step_m = params_.line_string_max_step_m;
     update_param<std::string>(parameters, "model.type", temp_params.model_type);
-    update_param<std::string>(parameters, "model.args_path", temp_params.args_path);
     update_param<std::string>(
-      parameters, "model.single_step_model.onnx_model_path", temp_params.single_step_model_path);
-    update_param<std::string>(
-      parameters, "model.multi_step_model.encoder_onnx_model_path", temp_params.encoder_model_path);
-    update_param<std::string>(
-      parameters, "model.multi_step_model.decoder_onnx_model_path", temp_params.decoder_model_path);
-    update_param<std::string>(
-      parameters, "model.multi_step_model.turn_indicator_onnx_model_path",
-      temp_params.turn_indicator_model_path);
+      parameters, "model.base_model_directory", temp_params.base_model_directory);
     update_param<int>(
       parameters, "model.multi_step_model.dpm_solver_steps", temp_params.dpm_solver_steps);
     update_param<std::string>(parameters, "model.backend", temp_params.backend);
@@ -347,13 +328,8 @@ SetParametersResult DiffusionPlanner::on_parameter(
 #endif
       return result;
     }
-    const bool args_path_changed = temp_params.args_path != previous_args_path;
-    const bool model_paths_changed =
-      temp_params.model_type != previous_model_type ||
-      temp_params.single_step_model_path != previous_single_step_model_path ||
-      temp_params.encoder_model_path != previous_encoder_model_path ||
-      temp_params.decoder_model_path != previous_decoder_model_path ||
-      temp_params.turn_indicator_model_path != previous_turn_indicator_model_path;
+    const bool base_model_directory_changed =
+      temp_params.base_model_directory != previous_base_model_directory;
     const bool batch_size_changed = temp_params.batch_size != previous_batch_size;
     const bool dpm_solver_steps_changed = temp_params.dpm_solver_steps != previous_dpm_solver_steps;
     const bool backend_changed = temp_params.backend != previous_backend;
@@ -365,7 +341,7 @@ SetParametersResult DiffusionPlanner::on_parameter(
     core_->update_params(params_);
 
     if (
-      args_path_changed || model_paths_changed || batch_size_changed || dpm_solver_steps_changed ||
+      base_model_directory_changed || batch_size_changed || dpm_solver_steps_changed ||
       backend_changed || trt_config_changed) {
       try {
         load_model();

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
@@ -168,6 +168,17 @@ void DiffusionPlanner::set_up_params()
   params_.model_type = this->declare_parameter<std::string>("model.type", "single_step");
   params_.base_model_directory =
     this->declare_parameter<std::string>("model.base_model_directory", "");
+  params_.args_filename =
+    this->declare_parameter<std::string>("model.args_filename", "diffusion_planner.param.json");
+  params_.single_step_model_filename = this->declare_parameter<std::string>(
+    "model.single_step_model.onnx_model_filename", "diffusion_planner.onnx");
+  params_.encoder_model_filename = this->declare_parameter<std::string>(
+    "model.multi_step_model.encoder_onnx_model_filename", "diffusion_planner_encoder.onnx");
+  params_.decoder_model_filename = this->declare_parameter<std::string>(
+    "model.multi_step_model.decoder_onnx_model_filename", "diffusion_planner_decoder.onnx");
+  params_.turn_indicator_model_filename = this->declare_parameter<std::string>(
+    "model.multi_step_model.turn_indicator_onnx_model_filename",
+    "diffusion_planner_turn_indicator.onnx");
   params_.dpm_solver_steps =
     this->declare_parameter<int>("model.multi_step_model.dpm_solver_steps", 10);
   params_.backend = this->declare_parameter<std::string>("model.backend", "tensorrt");
@@ -262,6 +273,11 @@ SetParametersResult DiffusionPlanner::on_parameter(
   {
     DiffusionPlannerParams temp_params = params_;
     const auto previous_base_model_directory = params_.base_model_directory;
+    const auto previous_args_filename = params_.args_filename;
+    const auto previous_single_step_model_filename = params_.single_step_model_filename;
+    const auto previous_encoder_model_filename = params_.encoder_model_filename;
+    const auto previous_decoder_model_filename = params_.decoder_model_filename;
+    const auto previous_turn_indicator_model_filename = params_.turn_indicator_model_filename;
     const auto previous_batch_size = params_.batch_size;
     const auto previous_dpm_solver_steps = params_.dpm_solver_steps;
     const auto previous_backend = params_.backend;
@@ -271,6 +287,19 @@ SetParametersResult DiffusionPlanner::on_parameter(
     update_param<std::string>(parameters, "model.type", temp_params.model_type);
     update_param<std::string>(
       parameters, "model.base_model_directory", temp_params.base_model_directory);
+    update_param<std::string>(parameters, "model.args_filename", temp_params.args_filename);
+    update_param<std::string>(
+      parameters, "model.single_step_model.onnx_model_filename",
+      temp_params.single_step_model_filename);
+    update_param<std::string>(
+      parameters, "model.multi_step_model.encoder_onnx_model_filename",
+      temp_params.encoder_model_filename);
+    update_param<std::string>(
+      parameters, "model.multi_step_model.decoder_onnx_model_filename",
+      temp_params.decoder_model_filename);
+    update_param<std::string>(
+      parameters, "model.multi_step_model.turn_indicator_onnx_model_filename",
+      temp_params.turn_indicator_model_filename);
     update_param<int>(
       parameters, "model.multi_step_model.dpm_solver_steps", temp_params.dpm_solver_steps);
     update_param<std::string>(parameters, "model.backend", temp_params.backend);
@@ -328,8 +357,13 @@ SetParametersResult DiffusionPlanner::on_parameter(
 #endif
       return result;
     }
-    const bool base_model_directory_changed =
-      temp_params.base_model_directory != previous_base_model_directory;
+    const bool model_paths_changed =
+      temp_params.base_model_directory != previous_base_model_directory ||
+      temp_params.args_filename != previous_args_filename ||
+      temp_params.single_step_model_filename != previous_single_step_model_filename ||
+      temp_params.encoder_model_filename != previous_encoder_model_filename ||
+      temp_params.decoder_model_filename != previous_decoder_model_filename ||
+      temp_params.turn_indicator_model_filename != previous_turn_indicator_model_filename;
     const bool batch_size_changed = temp_params.batch_size != previous_batch_size;
     const bool dpm_solver_steps_changed = temp_params.dpm_solver_steps != previous_dpm_solver_steps;
     const bool backend_changed = temp_params.backend != previous_backend;
@@ -341,8 +375,8 @@ SetParametersResult DiffusionPlanner::on_parameter(
     core_->update_params(params_);
 
     if (
-      base_model_directory_changed || batch_size_changed || dpm_solver_steps_changed ||
-      backend_changed || trt_config_changed) {
+      model_paths_changed || batch_size_changed || dpm_solver_steps_changed || backend_changed ||
+      trt_config_changed) {
       try {
         load_model();
       } catch (const std::exception & e) {


### PR DESCRIPTION
## Summary
- Replace per-file absolute ONNX/args paths with `model.base_model_directory` plus configurable filenames.
- Add `resolve_model_paths()` to join the base directory with filenames at load time.
- Expose `args_filename` and per-model `*_filename` parameters so different products can use names like `args.json` vs `diffusion_planner.param.json`, or `model.onnx` vs `diffusion_planner.onnx`.
- Update default YAML, JSON schema, and dynamic parameter handling to reload when the base directory or any filename changes.

## Test plan
- [ ] Not run locally — rely on CI
- [ ] Verify diffusion planner loads models when `model.base_model_directory` points to a valid bundle with default filenames
- [ ] Verify per-product filename overrides work without changing full paths

## Notes for reviewers
- `base_model_directory` is intended for dynamic per-vehicle configuration; filenames are typically fixed per product but remain overridable.
- Addresses review feedback to avoid hardcoding filenames in `resolve_model_paths()`.

## Related links
- Companion launch sync: https://github.com/autowarefoundation/autoware_launch/pull/1932